### PR TITLE
Bump to 1.0.11: fix skill script paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "monte-carlo",
       "source": "./plugins/monte-carlo",
       "description": "Claude Code skills by Monte Carlo Data",
-      "version": "1.0.10"
+      "version": "1.0.11"
     }
   ]
 }

--- a/plugins/monte-carlo/.claude-plugin/plugin.json
+++ b/plugins/monte-carlo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "monte-carlo",
   "description": "Claude Code skills by Monte Carlo Data",
-  "version": "1.0.10"
+  "version": "1.0.11"
 }


### PR DESCRIPTION
## Summary
- Update skills submodule to pick up script path fix (monte-carlo-data/mcd-skills#11)
- Bump version to 1.0.11 so users get the update via `/plugin update`