### PR TITLE
Restructure bug fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,12 +8,12 @@
   "plugins": [
     {
       "name": "mc-safe-change",
-      "source": "./plugins/claude-code/safe-change",
+      "source": "../plugins/claude-code/safe-change",
       "description": "Detect and prevent breaking schema changes using MC lineage and monitoring."
     },
     {
       "name": "mc-generate-validation-notebook",
-      "source": "./plugins/claude-code/generate-validation-notebook",
+      "source": "../plugins/claude-code/generate-validation-notebook",
       "description": "Generate Monte Carlo validation notebooks."
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,20 +1,20 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "mcd-agent-toolkit",
-  "owner": {
-    "name": "Monte Carlo",
-    "email": "support@montecarlodata.com"
-  },
-  "plugins": [
-    {
-      "name": "mc-safe-change",
-      "source": "../plugins/claude-code/safe-change",
-      "description": "Detect and prevent breaking schema changes using MC lineage and monitoring."
+    "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+    "name": "mcd-agent-toolkit",
+    "owner": {
+        "name": "Monte Carlo",
+        "email": "support@montecarlodata.com"
     },
-    {
-      "name": "mc-generate-validation-notebook",
-      "source": "../plugins/claude-code/generate-validation-notebook",
-      "description": "Generate Monte Carlo validation notebooks."
-    }
-  ]
+    "plugins": [
+        {
+            "name": "mc-safe-change",
+            "source": "./plugins/claude-code/safe-change",
+            "description": "Detect and prevent breaking schema changes using MC lineage and monitoring."
+        },
+        {
+            "name": "mc-generate-validation-notebook",
+            "source": "./plugins/claude-code/generate-validation-notebook",
+            "description": "Generate Monte Carlo validation notebooks."
+        }
+    ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ mcd-agent-toolkit/
 │           ├── .claude-plugin/plugin.json
 │           └── skills/generate-validation-notebook → symlink
 │
-├── marketplace.json
+├── .claude-plugin/
+│   └── marketplace.json
 ├── README.md
 ├── LICENSE
 └── SECURITY.md
@@ -55,7 +56,7 @@ Plugins reference skills via symlinks so that skills are authored once and share
    ln -s ../../../../skills/<skill-name> <skill-name>
    ```
 4. If the plugin needs hooks, create a `hooks/` directory at the plugin root and add hook files there.
-5. Add the plugin to `marketplace.json` at the repo root.
+5. Add the plugin to `.claude-plugin/marketplace.json`.
 6. Test locally with `claude --plugin-dir ./plugins/claude-code/<skill-name>`.
 
 ## Updating an existing skill


### PR DESCRIPTION
## Main change
- Move `marketplace.json` to `./claude-plugin/marketplace.json`. This is necessary to to make the repo discoverable by claude marketplace. Essentially, this fix makes `/plugin marketplace add monte-carlo-data/mcd-agent-toolkit` work. 