### PR TITLE
chore: add session id validation and cache file permissions

### DIFF
--- a/plugins/claude-code/safe-change/.claude-plugin/plugin.json
+++ b/plugins/claude-code/safe-change/.claude-plugin/plugin.json
@@ -1,34 +1,34 @@
 {
-    "name": "mc-safe-change",
-    "version": "1.0.0",
-    "description": "Monte Carlo Safe Change — data observability context and safe change enforcement in your editor",
-    "author": {
-        "name": "Monte Carlo",
-        "url": "https://www.montecarlodata.com"
-    },
-    "repository": "https://github.com/monte-carlo-data/mcd-agent-toolkit",
-    "license": "Apache-2.0",
-    "keywords": [
-        "monte-carlo",
-        "data-observability",
-        "safe-change",
-        "dbt",
-        "schema"
-    ],
-    "skills": "./skills/",
-    "mcpServers": {
-        "monte-carlo": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "mcp-remote",
-                "https://integrations.getmontecarlo.com/mcp/",
-                "--header",
-                "x-mcd-id: ${MCD_ID}",
-                "--header",
-                "x-mcd-token: ${MCD_TOKEN}"
-            ]
-        }
-    },
-    "commands": ["./commands/mc-validate.md"]
+  "name": "mc-safe-change",
+  "version": "1.1.0",
+  "description": "Monte Carlo Safe Change — data observability context and safe change enforcement in your editor",
+  "author": {
+    "name": "Monte Carlo",
+    "url": "https://www.montecarlodata.com"
+  },
+  "repository": "https://github.com/monte-carlo-data/mcd-agent-toolkit",
+  "license": "Apache-2.0",
+  "keywords": [
+    "monte-carlo",
+    "data-observability",
+    "safe-change",
+    "dbt",
+    "schema"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "monte-carlo": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://integrations.getmontecarlo.com/mcp/",
+        "--header",
+        "x-mcd-id: ${MCD_ID}",
+        "--header",
+        "x-mcd-token: ${MCD_TOKEN}"
+      ]
+    }
+  },
+  "commands": ["./commands/mc-validate.md"]
 }

--- a/plugins/claude-code/safe-change/CHANGELOG.md
+++ b/plugins/claude-code/safe-change/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the Monte Carlo Safe Change plugin will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-03-26
+
+### Added
+
+- Hook-based enforcement for dbt model edits (pre-edit gate, post-edit accumulator, turn-end validation prompt, commit gate)
+- `/mc-validate` slash command for explicit validation
+- Shared lib: dbt model detection, session cache, fail-open decorator
+- Monte Carlo MCP server wiring
+
+## [1.0.0] - 2026-03-22
+
+- Initial plugin shell with skill file and manifest

--- a/plugins/claude-code/safe-change/hooks/lib/cache.py
+++ b/plugins/claude-code/safe-change/hooks/lib/cache.py
@@ -10,9 +10,12 @@ Impact check gate uses three states:
 import hashlib
 import json
 import os
+import re
 import time
 
 CACHE_DIR = "/tmp"
+_FILE_PERMISSIONS = 0o600  # Owner read/write only
+_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 IC_PREFIX = "mc_safe_change_ic_"
 MG_PREFIX = "mc_safe_change_mg_"
 TURN_PREFIX = "mc_safe_change_turn_"
@@ -33,16 +36,41 @@ DBT_DEFAULT_PATHS = {
 }
 
 
+def _write_secure(path: str, content: str) -> None:
+    """Write content to path and restrict permissions to owner-only."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _FILE_PERMISSIONS)
+    try:
+        os.write(fd, content.encode())
+    finally:
+        os.close(fd)
+
+
+def _append_secure(path: str, content: str) -> None:
+    """Append content to path, creating with restricted permissions if needed."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_PERMISSIONS)
+    try:
+        os.write(fd, content.encode())
+    finally:
+        os.close(fd)
+
+
+def _validate_session_id(session_id: str) -> str:
+    """Validate session_id is alphanumeric with dashes/underscores only."""
+    if not _SESSION_ID_RE.match(session_id):
+        raise ValueError(f"Invalid session_id: {session_id!r}")
+    return session_id
+
+
 def _w4_path(table_name: str) -> str:
     return os.path.join(CACHE_DIR, f"{IC_PREFIX}{table_name}")
 
 
 def _turn_path(session_id: str) -> str:
-    return os.path.join(CACHE_DIR, f"{TURN_PREFIX}{session_id}")
+    return os.path.join(CACHE_DIR, f"{TURN_PREFIX}{_validate_session_id(session_id)}")
 
 
 def _pending_path(session_id: str) -> str:
-    return os.path.join(CACHE_DIR, f"{PENDING_PREFIX}{session_id}")
+    return os.path.join(CACHE_DIR, f"{PENDING_PREFIX}{_validate_session_id(session_id)}")
 
 
 # --- Impact check three-state marker ---
@@ -62,8 +90,7 @@ def get_impact_check_state(table_name: str) -> str | None:
 
 def mark_impact_check_injected(table_name: str) -> None:
     path = _w4_path(table_name)
-    with open(path, "w") as f:
-        json.dump({"state": "injected", "timestamp": time.time()}, f)
+    _write_secure(path, json.dumps({"state": "injected", "timestamp": time.time()}))
 
 
 def mark_impact_check_verified(table_name: str) -> None:
@@ -76,8 +103,7 @@ def mark_impact_check_verified(table_name: str) -> None:
             timestamp = data.get("timestamp", timestamp)
     except (json.JSONDecodeError, OSError):
         pass
-    with open(path, "w") as f:
-        json.dump({"state": "verified", "timestamp": timestamp}, f)
+    _write_secure(path, json.dumps({"state": "verified", "timestamp": timestamp}))
 
 
 def get_impact_check_age_seconds(table_name: str) -> float:
@@ -101,8 +127,7 @@ def has_monitor_gap(table_name: str) -> bool:
 
 
 def mark_monitor_gap(table_name: str) -> None:
-    with open(_mg_path(table_name), "w") as f:
-        f.write(str(time.time()))
+    _write_secure(_mg_path(table_name), str(time.time()))
 
 
 # --- Turn-level edit accumulator ---
@@ -124,8 +149,7 @@ def add_edited_table(session_id: str, table_name: str) -> None:
     if table_name in existing:
         return
     path = _turn_path(session_id)
-    with open(path, "a") as f:
-        f.write(table_name + "\n")
+    _append_secure(path, table_name + "\n")
 
 
 def clear_edited_tables(session_id: str) -> None:
@@ -142,9 +166,7 @@ def move_to_pending_validation(session_id: str) -> None:
         existing = get_pending_validation_tables(session_id)
         merged = list(dict.fromkeys(existing + tables))  # deduplicate, preserve order
         path = _pending_path(session_id)
-        with open(path, "w") as f:
-            for t in merged:
-                f.write(t + "\n")
+        _write_secure(path, "".join(t + "\n" for t in merged))
     clear_edited_tables(session_id)
 
 
@@ -271,8 +293,7 @@ def get_dbt_paths(file_path: str) -> dict:
     paths.update(parsed)
 
     try:
-        with open(cache_path, "w") as f:
-            json.dump({"mtime": mtime, "paths": paths}, f)
+        _write_secure(cache_path, json.dumps({"mtime": mtime, "paths": paths}))
     except OSError:
         pass
 
@@ -301,8 +322,7 @@ def cleanup_stale_cache() -> None:
 
     # Touch marker first to prevent concurrent cleanup
     try:
-        with open(marker_path, "w") as f:
-            f.write(str(now))
+        _write_secure(marker_path, str(now))
     except OSError:
         return
 

--- a/plugins/claude-code/safe-change/scripts/install.sh
+++ b/plugins/claude-code/safe-change/scripts/install.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -e
 
-echo "Installing Monte Carlo Safe Change plugin..."
+echo "Running post-install cleanup for Monte Carlo Safe Change plugin..."
 
-# Remove standalone safe-change skill if present
+# Remove standalone safe-change skill if present (superseded by plugin)
 SKILL_PATH="$HOME/.claude/skills/safe-change"
 if [ -d "$SKILL_PATH" ]; then
-  echo "Backing up and removing standalone safe-change skill..."
+  echo "Backing up and removing standalone safe-change skill (now bundled in plugin)..."
   cp -r "$SKILL_PATH" "$SKILL_PATH.backup"
   rm -rf "$SKILL_PATH"
   echo "Backup saved to $SKILL_PATH.backup"
 fi
 
-echo "✓ Monte Carlo Safe Change plugin installed."
+echo "✓ Post-install cleanup complete."
 echo "  Ensure MCD_ID and MCD_TOKEN are set in your shell profile."
 echo "  Restart Claude Code to activate."

--- a/plugins/claude-code/safe-change/scripts/uninstall.sh
+++ b/plugins/claude-code/safe-change/scripts/uninstall.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 set -e
 
+echo "Running post-uninstall cleanup for Monte Carlo Safe Change plugin..."
+
 SKILL_PATH="$HOME/.claude/skills/safe-change"
 BACKUP_PATH="$SKILL_PATH.backup"
 if [ -d "$BACKUP_PATH" ]; then
-  echo "Restoring standalone safe-change skill..."
+  echo "Restoring standalone safe-change skill from backup..."
   mv "$BACKUP_PATH" "$SKILL_PATH"
   echo "✓ Standalone skill restored."
 else
   echo "No backup found. Install standalone skill from mcd-agent-toolkit/skills/ if needed."
 fi
 
-echo "✓ Plugin uninstalled."
-echo "  Remove MCD_ID and MCD_TOKEN from your shell profile manually."
+echo "✓ Post-uninstall cleanup complete."
+echo "  Remove MCD_ID and MCD_TOKEN from your shell profile if no longer needed."

--- a/plugins/claude-code/safe-change/tests/test_cache.py
+++ b/plugins/claude-code/safe-change/tests/test_cache.py
@@ -1,9 +1,15 @@
 import os
+import stat
 import time
 import json
 import pytest
 
 from lib.cache import (
+    CACHE_DIR,
+    IC_PREFIX,
+    TURN_PREFIX,
+    PENDING_PREFIX,
+    _validate_session_id,
     get_impact_check_state,
     mark_impact_check_injected,
     mark_impact_check_verified,
@@ -93,3 +99,49 @@ class TestPendingValidation:
 
     def test_no_pending_returns_empty(self):
         assert get_pending_validation_tables("session_1") == []
+
+
+class TestSessionIdValidation:
+    def test_valid_alphanumeric(self):
+        assert _validate_session_id("abc123") == "abc123"
+
+    def test_valid_with_dashes_underscores(self):
+        assert _validate_session_id("session-1_test") == "session-1_test"
+
+    def test_rejects_path_traversal(self):
+        with pytest.raises(ValueError):
+            _validate_session_id("../../etc/passwd")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError):
+            _validate_session_id("session 1")
+
+    def test_rejects_shell_metacharacters(self):
+        for bad in ["$(cmd)", "a;b", "a&b", "a|b", "a\nb"]:
+            with pytest.raises(ValueError):
+                _validate_session_id(bad)
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            _validate_session_id("")
+
+
+class TestFilePermissions:
+    def _get_perms(self, path):
+        return stat.S_IMODE(os.stat(path).st_mode)
+
+    def test_impact_check_file_is_owner_only(self):
+        mark_impact_check_injected("perm_test_table")
+        path = os.path.join(CACHE_DIR, f"{IC_PREFIX}perm_test_table")
+        assert self._get_perms(path) == 0o600
+
+    def test_turn_file_is_owner_only(self):
+        add_edited_table("perm_test_session", "orders")
+        path = os.path.join(CACHE_DIR, f"{TURN_PREFIX}perm_test_session")
+        assert self._get_perms(path) == 0o600
+
+    def test_pending_file_is_owner_only(self):
+        add_edited_table("perm_test_session2", "orders")
+        move_to_pending_validation("perm_test_session2")
+        path = os.path.join(CACHE_DIR, f"{PENDING_PREFIX}perm_test_session2")
+        assert self._get_perms(path) == 0o600


### PR DESCRIPTION
## Summary
- Add session ID validation (`_validate_session_id`) to reject path traversal and shell metacharacters in cache file paths
- Replace all `open()` calls with `_write_secure` / `_append_secure` helpers that create files with `0o600` (owner-only) permissions
- Clean up install/uninstall script messaging to clarify post-install/post-uninstall behavior
- Add tests for session ID validation and file permission enforcement

## Test plan
- [x] Unit tests for `_validate_session_id` — valid IDs, path traversal, shell metacharacters, empty string
- [x] Unit tests for file permissions — impact check, turn, and pending files all created with `0o600`
- [ ] Verify existing cache tests still pass (`pytest plugins/claude-code/safe-change/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)