### PR TITLE
feat(safe-change): emit session change events to Monte Carlo

### DIFF
--- a/plugins/claude-code/safe-change/hooks/lib/cache.py
+++ b/plugins/claude-code/safe-change/hooks/lib/cache.py
@@ -21,9 +21,10 @@ MG_PREFIX = "mc_safe_change_mg_"
 TURN_PREFIX = "mc_safe_change_turn_"
 PENDING_PREFIX = "mc_safe_change_pending_"
 DBT_CONFIG_PREFIX = "mc_safe_change_dbt_config_"
+COMMIT_PREFIX = "mc_safe_change_commit_"
 CLEANUP_MARKER = "mc_safe_change_last_cleanup"
 
-ALL_PREFIXES = (IC_PREFIX, MG_PREFIX, TURN_PREFIX, PENDING_PREFIX, DBT_CONFIG_PREFIX)
+ALL_PREFIXES = (IC_PREFIX, MG_PREFIX, TURN_PREFIX, PENDING_PREFIX, DBT_CONFIG_PREFIX, COMMIT_PREFIX)
 STALE_THRESHOLD_SECONDS = 6 * 3600  # 6 hours — covers long sessions, cleans between days
 
 # dbt_project.yml defaults per https://docs.getdbt.com/reference/project-configs
@@ -185,6 +186,30 @@ def clear_pending_validation(session_id: str) -> None:
     path = _pending_path(session_id)
     if os.path.exists(path):
         os.remove(path)
+
+
+# --- Last commit hash (for intent extraction) ---
+
+def _commit_path(session_id: str) -> str:
+    return os.path.join(CACHE_DIR, f"{COMMIT_PREFIX}{_validate_session_id(session_id)}")
+
+
+def get_last_commit_hash(session_id: str) -> str | None:
+    """Return the HEAD commit hash from the last emit, or None."""
+    path = _commit_path(session_id)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r") as f:
+            value = f.read().strip()
+        return value or None
+    except OSError:
+        return None
+
+
+def set_last_commit_hash(session_id: str, commit_hash: str) -> None:
+    """Cache the current HEAD hash for next emit comparison."""
+    _write_secure(_commit_path(session_id), commit_hash)
 
 
 # --- dbt project config cache ---

--- a/plugins/claude-code/safe-change/hooks/lib/cache.py
+++ b/plugins/claude-code/safe-change/hooks/lib/cache.py
@@ -62,8 +62,8 @@ def _validate_session_id(session_id: str) -> str:
     return session_id
 
 
-def _w4_path(table_name: str) -> str:
-    return os.path.join(CACHE_DIR, f"{IC_PREFIX}{table_name}")
+def _w4_path(session_id: str, table_name: str) -> str:
+    return os.path.join(CACHE_DIR, f"{IC_PREFIX}{_validate_session_id(session_id)}_{table_name}")
 
 
 def _turn_path(session_id: str) -> str:
@@ -76,9 +76,9 @@ def _pending_path(session_id: str) -> str:
 
 # --- Impact check three-state marker ---
 
-def get_impact_check_state(table_name: str) -> str | None:
+def get_impact_check_state(session_id: str, table_name: str) -> str | None:
     """Returns None, 'injected', or 'verified'."""
-    path = _w4_path(table_name)
+    path = _w4_path(session_id, table_name)
     if not os.path.exists(path):
         return None
     try:
@@ -89,13 +89,13 @@ def get_impact_check_state(table_name: str) -> str | None:
         return None
 
 
-def mark_impact_check_injected(table_name: str) -> None:
-    path = _w4_path(table_name)
+def mark_impact_check_injected(session_id: str, table_name: str) -> None:
+    path = _w4_path(session_id, table_name)
     _write_secure(path, json.dumps({"state": "injected", "timestamp": time.time()}))
 
 
-def mark_impact_check_verified(table_name: str) -> None:
-    path = _w4_path(table_name)
+def mark_impact_check_verified(session_id: str, table_name: str) -> None:
+    path = _w4_path(session_id, table_name)
     # Preserve timestamp from injection
     timestamp = time.time()
     try:
@@ -107,8 +107,8 @@ def mark_impact_check_verified(table_name: str) -> None:
     _write_secure(path, json.dumps({"state": "verified", "timestamp": timestamp}))
 
 
-def get_impact_check_age_seconds(table_name: str) -> float:
-    path = _w4_path(table_name)
+def get_impact_check_age_seconds(session_id: str, table_name: str) -> float:
+    path = _w4_path(session_id, table_name)
     try:
         with open(path, "r") as f:
             data = json.load(f)
@@ -119,16 +119,16 @@ def get_impact_check_age_seconds(table_name: str) -> float:
 
 # --- Monitor coverage gap marker ---
 
-def _mg_path(table_name: str) -> str:
-    return os.path.join(CACHE_DIR, f"{MG_PREFIX}{table_name}")
+def _mg_path(session_id: str, table_name: str) -> str:
+    return os.path.join(CACHE_DIR, f"{MG_PREFIX}{_validate_session_id(session_id)}_{table_name}")
 
 
-def has_monitor_gap(table_name: str) -> bool:
-    return os.path.exists(_mg_path(table_name))
+def has_monitor_gap(session_id: str, table_name: str) -> bool:
+    return os.path.exists(_mg_path(session_id, table_name))
 
 
-def mark_monitor_gap(table_name: str) -> None:
-    _write_secure(_mg_path(table_name), str(time.time()))
+def mark_monitor_gap(session_id: str, table_name: str) -> None:
+    _write_secure(_mg_path(session_id, table_name), str(time.time()))
 
 
 # --- Turn-level edit accumulator ---

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -34,9 +34,82 @@ def _get_git_identity():
 
 from lib.cache import (
     get_impact_check_state,
+    get_last_commit_hash,
     get_pending_validation_tables,
     has_monitor_gap,
+    set_last_commit_hash,
 )
+
+
+INTENT_MAX_LENGTH = 256
+
+
+def _get_current_head():
+    """Return current HEAD commit hash, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _get_commit_message():
+    """Return the latest commit's subject line."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _get_first_user_message(transcript_path):
+    """Read the first user message from a JSONL transcript."""
+    try:
+        with open(transcript_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("role") == "user":
+                    msg = entry.get("message", "")
+                    return msg[:INTENT_MAX_LENGTH] if msg else None
+    except (OSError, UnicodeDecodeError):
+        pass
+    return None
+
+
+def _extract_intent(session_id, transcript_path):
+    """Try commit message first, fall back to transcript user message.
+
+    Returns: {"summary": str, "source": "commit_message"|"transcript"} or None
+    """
+    current_head = _get_current_head()
+    prior_head = get_last_commit_hash(session_id)
+
+    # Always update cached hash for next comparison
+    if current_head:
+        set_last_commit_hash(session_id, current_head)
+
+    # Source 1: commit message (if HEAD changed since last emit)
+    if current_head and prior_head and current_head != prior_head:
+        message = _get_commit_message()
+        if message:
+            return {"summary": message[:INTENT_MAX_LENGTH], "source": "commit_message"}
+
+    # Source 2: transcript (first user message)
+    user_msg = _get_first_user_message(transcript_path)
+    if user_msg:
+        return {"summary": user_msg, "source": "transcript"}
+
+    # Source 3: None
+    return None
 
 
 def _extract_workflow_flags(session_id, edited_tables):

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -30,3 +30,26 @@ def _get_git_identity():
         return {"git_email": email, "git_name": name}
     except Exception:
         return {"git_email": "", "git_name": ""}
+
+
+from lib.cache import (
+    get_impact_check_state,
+    get_pending_validation_tables,
+    has_monitor_gap,
+)
+
+
+def _extract_workflow_flags(session_id, edited_tables):
+    """Derive workflow boolean flags from cache state."""
+    ic_states = {t: get_impact_check_state(t) for t in edited_tables}
+    has_pending = bool(get_pending_validation_tables(session_id))
+    w4_tables = [t for t in edited_tables if ic_states[t] in ("injected", "verified")]
+
+    return {
+        "impact_check_fired": any(s is not None for s in ic_states.values()),
+        "edit_gated": any(s in ("injected", "verified") for s in ic_states.values()),
+        "validation_prompted": not has_pending and len(w4_tables) > 0,
+        "validation_generated": None,
+        "monitor_gap_detected": any(has_monitor_gap(t) for t in edited_tables),
+        "monitor_generated": None,
+    }

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -126,3 +126,37 @@ def _extract_workflow_flags(session_id, edited_tables):
         "monitor_gap_detected": any(has_monitor_gap(t) for t in edited_tables),
         "monitor_generated": None,
     }
+
+
+def _build_event(session_id, transcript_path, edited_tables):
+    """Assemble the change event from local cache state."""
+    return {
+        "event_type": "safe_change.turn_completed",
+        "event_version": "1.0",
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "session_id": session_id,
+        "identity": _get_git_identity(),
+        "changes": [{"table_name": t} for t in edited_tables],
+        "workflows": _extract_workflow_flags(session_id, edited_tables),
+        "intent": _extract_intent(session_id, transcript_path),
+    }
+
+
+def _send(event):
+    """POST to MC API. 3s timeout. Silently drop on any failure."""
+    try:
+        req = urllib.request.Request(
+            url=MC_CHANGE_EVENTS_URL,
+            data=json.dumps(event).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "x-mcd-id": os.environ.get("MCD_ID", ""),
+                "x-mcd-token": os.environ.get("MCD_TOKEN", ""),
+            },
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass
+
+

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import threading
+import time
 import urllib.request
 from datetime import datetime, timezone
 
@@ -160,6 +161,31 @@ def _send(event):
         pass
 
 
+_EMIT_MIN_INTERVAL = 5  # seconds — prevent tight-loop flooding
+_EMIT_MARKER_PREFIX = "mc_safe_change_emit_"
+
+
+def _rate_limit_ok(session_id):
+    """Return True if enough time has passed since the last emit for this session."""
+    path = os.path.join("/tmp", f"{_EMIT_MARKER_PREFIX}{session_id}")
+    now = time.time()
+    try:
+        if os.path.exists(path):
+            if now - os.path.getmtime(path) < _EMIT_MIN_INTERVAL:
+                return False
+    except OSError:
+        pass
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, str(now).encode())
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+    return True
+
+
 def emit(session_id, transcript_path, edited_tables):
     """Assemble event and send in background thread. Never blocks, never throws.
 
@@ -173,6 +199,8 @@ def emit(session_id, transcript_path, edited_tables):
         if mode in ("0", "false", "no"):
             return
         if not os.environ.get("MCD_ID"):
+            return
+        if not _rate_limit_ok(session_id):
             return
         event = _build_event(session_id, transcript_path, edited_tables)
         if mode == "dry_run":

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -160,3 +160,26 @@ def _send(event):
         pass
 
 
+def emit(session_id, transcript_path, edited_tables):
+    """Assemble event and send in background thread. Never blocks, never throws.
+
+    Modes (via MC_EMIT_EVENTS env var):
+      "1" / "true" / unset  -> build event, POST in daemon thread (default)
+      "dry_run"             -> build event, print JSON to stderr, no HTTP call
+      "0" / "false" / "no"  -> skip entirely
+    """
+    try:
+        mode = os.environ.get("MC_EMIT_EVENTS", "1").lower()
+        if mode in ("0", "false", "no"):
+            return
+        if not os.environ.get("MCD_ID"):
+            return
+        event = _build_event(session_id, transcript_path, edited_tables)
+        if mode == "dry_run":
+            import sys as _sys
+            print(json.dumps(event, indent=2), file=_sys.stderr)
+            return
+        thread = threading.Thread(target=_send, args=(event,), daemon=True)
+        thread.start()
+    except Exception:
+        pass

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -1,0 +1,32 @@
+"""Event assembly and non-blocking emission to Monte Carlo.
+
+Assembles change events from local cache state and sends them via a daemon
+thread POST. Never blocks the hook, never throws to the caller.
+"""
+import json
+import os
+import subprocess
+import threading
+import urllib.request
+from datetime import datetime, timezone
+
+MC_CHANGE_EVENTS_URL = os.environ.get(
+    "MC_CHANGE_EVENTS_URL",
+    "https://integrations.getmontecarlo.com/plugin/change-events",
+)
+
+
+def _get_git_identity():
+    """Read git user.email and user.name via subprocess."""
+    try:
+        email = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        name = subprocess.run(
+            ["git", "config", "user.name"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        return {"git_email": email, "git_name": name}
+    except Exception:
+        return {"git_email": "", "git_name": ""}

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -70,7 +70,13 @@ def _get_commit_message():
 
 
 def _get_first_user_message(transcript_path):
-    """Read the first user message from a JSONL transcript."""
+    """Read the first human-authored user message from a JSONL transcript.
+
+    Claude Code transcript format:
+      {"type":"user","message":{"role":"user","content":"the user's message"}}
+
+    Skips system-generated entries (local-command-caveat, /plugin commands).
+    """
     try:
         with open(transcript_path, "r", encoding="utf-8") as f:
             for line in f:
@@ -78,9 +84,15 @@ def _get_first_user_message(transcript_path):
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if entry.get("role") == "user":
-                    msg = entry.get("message", "")
-                    return msg[:INTENT_MAX_LENGTH] if msg else None
+                if entry.get("type") != "user":
+                    continue
+                msg = entry.get("message", {})
+                content = msg.get("content", "") if isinstance(msg, dict) else ""
+                # Skip system-injected messages (hooks, plugin commands)
+                if content.startswith("<"):
+                    continue
+                if content:
+                    return content[:INTENT_MAX_LENGTH]
     except (OSError, UnicodeDecodeError):
         pass
     return None
@@ -115,7 +127,7 @@ def _extract_intent(session_id, transcript_path):
 
 def _extract_workflow_flags(session_id, edited_tables):
     """Derive workflow boolean flags from cache state."""
-    ic_states = {t: get_impact_check_state(t) for t in edited_tables}
+    ic_states = {t: get_impact_check_state(session_id, t) for t in edited_tables}
     has_pending = bool(get_pending_validation_tables(session_id))
     w4_tables = [t for t in edited_tables if ic_states[t] in ("injected", "verified")]
 
@@ -124,39 +136,111 @@ def _extract_workflow_flags(session_id, edited_tables):
         "edit_gated": any(s in ("injected", "verified") for s in ic_states.values()),
         "validation_prompted": not has_pending and len(w4_tables) > 0,
         "validation_generated": None,
-        "monitor_gap_detected": any(has_monitor_gap(t) for t in edited_tables),
+        "monitor_gap_detected": any(has_monitor_gap(session_id, t) for t in edited_tables),
         "monitor_generated": None,
     }
 
 
+import re
+
+_IMPACT_DATA_RE = re.compile(r"MC_IMPACT_DATA:\s*(\{.*?\})")
+
+
+def _scan_impact_data(transcript_path):
+    """Scan transcript for MC_IMPACT_DATA markers, return dict keyed by table name.
+
+    Marker format (inside assistant message content):
+      <!-- MC_IMPACT_DATA: {"table":"orders","risk_tier":"high",...} -->
+
+    Parses JSONL first to extract content, then searches content for markers.
+    This avoids issues with JSON-escaped quotes in raw JSONL lines.
+
+    Returns: {"orders": {"risk_tier": "high", "downstream_count": 42, ...}, ...}
+    """
+    results = {}
+    try:
+        with open(transcript_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                msg = entry.get("message", {})
+                content = msg.get("content", "") if isinstance(msg, dict) else ""
+                if not content:
+                    continue
+                for match in _IMPACT_DATA_RE.finditer(content):
+                    try:
+                        data = json.loads(match.group(1))
+                        table = data.pop("table", None)
+                        if table:
+                            results[table] = data
+                    except (json.JSONDecodeError, AttributeError):
+                        continue
+    except (OSError, UnicodeDecodeError):
+        pass
+    return results
+
+
+def _build_changes(edited_tables, impact_data):
+    """Build the changes array, enriching with impact data where available."""
+    changes = []
+    for t in edited_tables:
+        entry = {"table_name": t}
+        if t in impact_data:
+            entry["assessment"] = impact_data[t]
+        changes.append(entry)
+    return changes
+
+
 def _build_event(session_id, transcript_path, edited_tables):
     """Assemble the change event from local cache state."""
+    impact_data = _scan_impact_data(transcript_path)
     return {
         "event_type": "safe_change.turn_completed",
         "event_version": "1.0",
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "session_id": session_id,
         "identity": _get_git_identity(),
-        "changes": [{"table_name": t} for t in edited_tables],
+        "changes": _build_changes(edited_tables, impact_data),
         "workflows": _extract_workflow_flags(session_id, edited_tables),
         "intent": _extract_intent(session_id, transcript_path),
     }
 
 
 def _send(event):
-    """POST to MC API. 3s timeout. Silently drop on any failure."""
+    """POST to MC API via a detached subprocess. Never blocks the caller.
+
+    Hooks run as short-lived subprocesses, so daemon threads get killed before
+    completing. Instead, we spawn a detached Python subprocess that outlives
+    the hook process and sends the HTTP request independently.
+    """
     try:
-        req = urllib.request.Request(
-            url=MC_CHANGE_EVENTS_URL,
-            data=json.dumps(event).encode(),
-            headers={
-                "Content-Type": "application/json",
-                "x-mcd-id": os.environ.get("MCD_ID", ""),
-                "x-mcd-token": os.environ.get("MCD_TOKEN", ""),
-            },
-            method="POST",
+        payload = json.dumps(event)
+        # Inline script reads event JSON from stdin and POSTs it
+        script = ";".join([
+            "import json,urllib.request,sys",
+            "d=sys.stdin.buffer.read()",
+            "urllib.request.urlopen(urllib.request.Request("
+            "url=sys.argv[1],"
+            "data=d,"
+            "headers={'Content-Type':'application/json','x-mcd-id':sys.argv[2],'x-mcd-token':sys.argv[3]},"
+            "method='POST'),timeout=3)",
+        ])
+        proc = subprocess.Popen(
+            [
+                "python3", "-c", script,
+                MC_CHANGE_EVENTS_URL,
+                os.environ.get("MCD_ID", ""),
+                os.environ.get("MCD_TOKEN", ""),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # detach from parent process
         )
-        urllib.request.urlopen(req, timeout=3)
+        proc.stdin.write(payload.encode())
+        proc.stdin.close()
     except Exception:
         pass
 
@@ -207,7 +291,6 @@ def emit(session_id, transcript_path, edited_tables):
             import sys as _sys
             print(json.dumps(event, indent=2), file=_sys.stderr)
             return
-        thread = threading.Thread(target=_send, args=(event,), daemon=True)
-        thread.start()
+        _send(event)
     except Exception:
         pass

--- a/plugins/claude-code/safe-change/hooks/lib/emitter.py
+++ b/plugins/claude-code/safe-change/hooks/lib/emitter.py
@@ -45,6 +45,29 @@ from lib.cache import (
 INTENT_MAX_LENGTH = 256
 
 
+def _extract_content(msg):
+    """Extract text content from a Claude Code message object.
+
+    Content can be a string or a list of content blocks:
+      "content": "hello"
+      "content": [{"type": "text", "text": "hello"}, ...]
+    """
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(parts)
+    return ""
+
+
 def _get_current_head():
     """Return current HEAD commit hash, or None."""
     try:
@@ -86,13 +109,11 @@ def _get_first_user_message(transcript_path):
                     continue
                 if entry.get("type") != "user":
                     continue
-                msg = entry.get("message", {})
-                content = msg.get("content", "") if isinstance(msg, dict) else ""
+                content = _extract_content(entry.get("message", {}))
                 # Skip system-injected messages (hooks, plugin commands)
-                if content.startswith("<"):
+                if not content or content.startswith("<"):
                     continue
-                if content:
-                    return content[:INTENT_MAX_LENGTH]
+                return content[:INTENT_MAX_LENGTH]
     except (OSError, UnicodeDecodeError):
         pass
     return None
@@ -165,8 +186,7 @@ def _scan_impact_data(transcript_path):
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                msg = entry.get("message", {})
-                content = msg.get("content", "") if isinstance(msg, dict) else ""
+                content = _extract_content(entry.get("message", {}))
                 if not content:
                     continue
                 for match in _IMPACT_DATA_RE.finditer(content):
@@ -227,6 +247,8 @@ def _send(event):
             "headers={'Content-Type':'application/json','x-mcd-id':sys.argv[2],'x-mcd-token':sys.argv[3]},"
             "method='POST'),timeout=3)",
         ])
+        # TEMPORARY DEBUG: log subprocess errors to file
+        _dbg_err = open("/tmp/mc_send_debug.log", "a")
         proc = subprocess.Popen(
             [
                 "python3", "-c", script,
@@ -236,7 +258,7 @@ def _send(event):
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=_dbg_err,
             start_new_session=True,  # detach from parent process
         )
         proc.stdin.write(payload.encode())
@@ -279,18 +301,29 @@ def emit(session_id, transcript_path, edited_tables):
       "0" / "false" / "no"  -> skip entirely
     """
     try:
+        # TEMPORARY DEBUG
+        _dbg = lambda msg: open("/tmp/mc_emitter_debug.log", "a").write(f"{msg}\n")
+
         mode = os.environ.get("MC_EMIT_EVENTS", "1").lower()
         if mode in ("0", "false", "no"):
             return
         if not os.environ.get("MCD_ID"):
             return
         if not _rate_limit_ok(session_id):
+            _dbg("[EMITTER] rate limited")
             return
+        _dbg(f"[EMITTER] building event for {edited_tables}")
         event = _build_event(session_id, transcript_path, edited_tables)
+        _dbg(f"[EMITTER] event built, mode={mode}")
         if mode == "dry_run":
             import sys as _sys
             print(json.dumps(event, indent=2), file=_sys.stderr)
             return
+        _dbg("[EMITTER] calling _send")
         _send(event)
-    except Exception:
-        pass
+        _dbg("[EMITTER] _send returned")
+    except Exception as e:
+        try:
+            open("/tmp/mc_emitter_debug.log", "a").write(f"[EMITTER] EXCEPTION: {type(e).__name__}: {e}\n")
+        except Exception:
+            pass

--- a/plugins/claude-code/safe-change/hooks/lib/safe_run.py
+++ b/plugins/claude-code/safe-change/hooks/lib/safe_run.py
@@ -1,12 +1,23 @@
 """Decorator that ensures hook scripts never block the engineer on error."""
+import os
 import sys
+import traceback
+
+DEBUG = os.environ.get("MC_SAFE_CHANGE_DEBUG", "").lower() in ("1", "true")
 
 
 def safe_run(fn):
-    """Catches all exceptions (including KeyboardInterrupt) and exits 0."""
+    """Catches all exceptions (including KeyboardInterrupt) and exits 0.
+
+    When MC_SAFE_CHANGE_DEBUG=1, prints the traceback to stderr and re-raises
+    so the error is visible and the hook reports a non-zero exit.
+    """
     def wrapper():
         try:
             fn()
         except BaseException:
+            if DEBUG:
+                traceback.print_exc(file=sys.stderr)
+                raise
             sys.exit(0)
     return wrapper

--- a/plugins/claude-code/safe-change/hooks/pre_commit_hook.py
+++ b/plugins/claude-code/safe-change/hooks/pre_commit_hook.py
@@ -41,6 +41,7 @@ def main():
     if "git commit" not in command:
         return
 
+    session_id = input_data.get("session_id", "unknown")
     cwd = input_data.get("cwd", ".")
     staged_tables = _get_staged_model_tables(cwd)
 
@@ -48,12 +49,12 @@ def main():
         return
 
     # Only prompt if impact assessment ran for at least one staged table
-    w4_tables = [t for t in staged_tables if get_impact_check_state(t) == "verified"]
+    w4_tables = [t for t in staged_tables if get_impact_check_state(session_id, t) == "verified"]
     if not w4_tables:
         return
 
     table_list = ", ".join(w4_tables)
-    gap_tables = [t for t in w4_tables if has_monitor_gap(t)]
+    gap_tables = [t for t in w4_tables if has_monitor_gap(session_id, t)]
 
     message = f"Committing changes to {table_list}. Run validation queries before committing? (yes / no)"
 

--- a/plugins/claude-code/safe-change/hooks/pre_edit_hook.py
+++ b/plugins/claude-code/safe-change/hooks/pre_edit_hook.py
@@ -55,8 +55,9 @@ def main():
     if not os.path.exists(file_path):
         return
 
+    session_id = input_data.get("session_id", "unknown")
     table_name = extract_table_name(file_path)
-    state = get_impact_check_state(table_name)
+    state = get_impact_check_state(session_id, table_name)
 
     if state == "verified":
         return
@@ -65,13 +66,13 @@ def main():
         # Always check transcript for completion marker before allowing edit
         transcript_path = input_data.get("transcript_path", "")
         markers = _scan_transcript_for_markers(transcript_path, table_name)
-        if markers["monitor_gap"] and not has_monitor_gap(table_name):
-            mark_monitor_gap(table_name)
+        if markers["monitor_gap"] and not has_monitor_gap(session_id, table_name):
+            mark_monitor_gap(session_id, table_name)
         if markers["impact_check"]:
-            mark_impact_check_verified(table_name)
+            mark_impact_check_verified(session_id, table_name)
             return
         # Assessment not completed — block without re-injecting if within grace period
-        age = get_impact_check_age_seconds(table_name)
+        age = get_impact_check_age_seconds(session_id, table_name)
         if age < GRACE_PERIOD_SECONDS:
             reason = (
                 f"Monte Carlo safe-change: the impact assessment for {table_name} "
@@ -94,14 +95,14 @@ def main():
         transcript_path = input_data.get("transcript_path", "")
         if transcript_path:
             markers = _scan_transcript_for_markers(transcript_path, table_name)
-            if markers["monitor_gap"] and not has_monitor_gap(table_name):
-                mark_monitor_gap(table_name)
+            if markers["monitor_gap"] and not has_monitor_gap(session_id, table_name):
+                mark_monitor_gap(session_id, table_name)
             if markers["impact_check"]:
-                mark_impact_check_verified(table_name)
+                mark_impact_check_verified(session_id, table_name)
                 return
 
     # No marker or failed verification — block the edit until impact assessment runs
-    mark_impact_check_injected(table_name)
+    mark_impact_check_injected(session_id, table_name)
 
     hook_triggered_note = (
         "This assessment is hook-triggered — only emit MC_IMPACT_CHECK_COMPLETE "

--- a/plugins/claude-code/safe-change/hooks/turn_end_hook.py
+++ b/plugins/claude-code/safe-change/hooks/turn_end_hook.py
@@ -14,6 +14,7 @@ from lib.cache import (
     has_monitor_gap,
     move_to_pending_validation,
 )
+from lib import emitter
 
 
 @safe_run
@@ -29,6 +30,10 @@ def main():
 
     if not tables:
         return
+
+    # Emit change event (non-blocking, before validation logic)
+    transcript_path = input_data.get("transcript_path", "")
+    emitter.emit(session_id, transcript_path, tables)
 
     # If validation was already prompted (pending tables exist), silently merge
     # new edits into pending rather than re-prompting. This prevents the double-

--- a/plugins/claude-code/safe-change/hooks/turn_end_hook.py
+++ b/plugins/claude-code/safe-change/hooks/turn_end_hook.py
@@ -44,12 +44,12 @@ def main():
 
     # Prompt if impact assessment was triggered for at least one edited table
     # "injected" means W4 instruction was sent; "verified" means completion confirmed
-    w4_tables = [t for t in tables if get_impact_check_state(t) in ("injected", "verified")]
+    w4_tables = [t for t in tables if get_impact_check_state(session_id, t) in ("injected", "verified")]
     if not w4_tables:
         return
 
     # Check for monitor coverage gaps
-    gap_tables = [t for t in tables if has_monitor_gap(t)]
+    gap_tables = [t for t in tables if has_monitor_gap(session_id, t)]
 
     # Build prompt
     table_list = ", ".join(tables)

--- a/plugins/claude-code/safe-change/hooks/validate_command.py
+++ b/plugins/claude-code/safe-change/hooks/validate_command.py
@@ -35,7 +35,7 @@ def main():
         return
 
     # Filter to tables that had impact assessment
-    w4_tables = [t for t in tables if get_impact_check_state(t) == "verified"]
+    w4_tables = [t for t in tables if get_impact_check_state(session_id, t) == "verified"]
     if not w4_tables:
         w4_tables = tables  # Fall back to all tables if no W4 tracking
 

--- a/plugins/claude-code/safe-change/tests/test_cache.py
+++ b/plugins/claude-code/safe-change/tests/test_cache.py
@@ -4,6 +4,7 @@ import time
 import json
 import pytest
 
+import lib.cache as cache
 from lib.cache import (
     CACHE_DIR,
     IC_PREFIX,
@@ -145,3 +146,27 @@ class TestFilePermissions:
         move_to_pending_validation("perm_test_session2")
         path = os.path.join(CACHE_DIR, f"{PENDING_PREFIX}perm_test_session2")
         assert self._get_perms(path) == 0o600
+
+
+class TestLastCommitCache:
+    def test_get_returns_none_when_no_cache(self):
+        assert cache.get_last_commit_hash("sess1") is None
+
+    def test_set_and_get(self):
+        cache.set_last_commit_hash("sess1", "abc123def456")
+        assert cache.get_last_commit_hash("sess1") == "abc123def456"
+
+    def test_overwrite(self):
+        cache.set_last_commit_hash("sess1", "abc123")
+        cache.set_last_commit_hash("sess1", "def456")
+        assert cache.get_last_commit_hash("sess1") == "def456"
+
+    def test_independent_sessions(self):
+        cache.set_last_commit_hash("sess1", "hash1")
+        cache.set_last_commit_hash("sess2", "hash2")
+        assert cache.get_last_commit_hash("sess1") == "hash1"
+        assert cache.get_last_commit_hash("sess2") == "hash2"
+
+    def test_empty_string_returns_none(self):
+        cache.set_last_commit_hash("sess1", "")
+        assert cache.get_last_commit_hash("sess1") is None

--- a/plugins/claude-code/safe-change/tests/test_cache.py
+++ b/plugins/claude-code/safe-change/tests/test_cache.py
@@ -26,27 +26,27 @@ from lib.cache import (
 
 class TestImpactCheckState:
     def test_no_marker_returns_none(self):
-        assert get_impact_check_state("my_table") is None
+        assert get_impact_check_state("test_session", "my_table") is None
 
     def test_injected_state(self):
-        mark_impact_check_injected("my_table")
-        assert get_impact_check_state("my_table") == "injected"
+        mark_impact_check_injected("test_session", "my_table")
+        assert get_impact_check_state("test_session", "my_table") == "injected"
 
     def test_verified_state(self):
-        mark_impact_check_injected("my_table")
-        mark_impact_check_verified("my_table")
-        assert get_impact_check_state("my_table") == "verified"
+        mark_impact_check_injected("test_session", "my_table")
+        mark_impact_check_verified("test_session", "my_table")
+        assert get_impact_check_state("test_session", "my_table") == "verified"
 
     def test_marker_age(self):
-        mark_impact_check_injected("my_table")
-        age = get_impact_check_age_seconds("my_table")
+        mark_impact_check_injected("test_session", "my_table")
+        age = get_impact_check_age_seconds("test_session", "my_table")
         assert 0 <= age < 2  # Should be very recent
 
     def test_different_tables_independent(self):
-        mark_impact_check_injected("table_a")
-        mark_impact_check_verified("table_a")
-        assert get_impact_check_state("table_a") == "verified"
-        assert get_impact_check_state("table_b") is None
+        mark_impact_check_injected("test_session", "table_a")
+        mark_impact_check_verified("test_session", "table_a")
+        assert get_impact_check_state("test_session", "table_a") == "verified"
+        assert get_impact_check_state("test_session", "table_b") is None
 
 
 class TestEditAccumulator:
@@ -132,8 +132,8 @@ class TestFilePermissions:
         return stat.S_IMODE(os.stat(path).st_mode)
 
     def test_impact_check_file_is_owner_only(self):
-        mark_impact_check_injected("perm_test_table")
-        path = os.path.join(CACHE_DIR, f"{IC_PREFIX}perm_test_table")
+        mark_impact_check_injected("test_session", "perm_test_table")
+        path = os.path.join(CACHE_DIR, f"{IC_PREFIX}test_session_perm_test_table")
         assert self._get_perms(path) == 0o600
 
     def test_turn_file_is_owner_only(self):

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -306,3 +306,87 @@ class TestEmit:
         assert event["session_id"] == "sess1"
         assert event["identity"]["git_email"] == "a@b.com"
         assert event["changes"] == [{"table_name": "orders"}]
+
+
+class TestEndToEnd:
+    def test_dry_run_full_event(self, tmp_path, capsys):
+        """Full flow via dry_run: cache setup -> emit -> verify event from stderr."""
+        # Set up cache state
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+        cache.mark_monitor_gap("orders")
+        cache.set_last_commit_hash("sess1", "old_hash")
+
+        # Create transcript
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('{"role":"user","message":"fix the join"}\n')
+
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "a@b.com", "git_name": "A"}):
+            with patch("lib.emitter._get_current_head", return_value="new_hash"):
+                with patch("lib.emitter._get_commit_message", return_value="Fix stale join"):
+                    with patch.dict(os.environ, {"MCD_ID": "x", "MC_EMIT_EVENTS": "dry_run"}):
+                        emit("sess1", str(transcript), ["orders"])
+
+        # Parse the event from stderr
+        captured = capsys.readouterr()
+        event = json.loads(captured.err)
+
+        # Verify complete event structure
+        assert event["event_type"] == "safe_change.turn_completed"
+        assert event["event_version"] == "1.0"
+        assert event["timestamp"].endswith("Z")
+        assert event["session_id"] == "sess1"
+        assert event["identity"] == {"git_email": "a@b.com", "git_name": "A"}
+        assert event["changes"] == [{"table_name": "orders"}]
+        assert event["workflows"]["impact_check_fired"] is True
+        assert event["workflows"]["edit_gated"] is True
+        assert event["workflows"]["validation_prompted"] is True
+        assert event["workflows"]["monitor_gap_detected"] is True
+        assert event["intent"] == {"summary": "Fix stale join", "source": "commit_message"}
+
+    def test_real_http_send_to_local_server(self):
+        """Verify _send() makes a real HTTP POST with correct payload."""
+        import threading
+        from http.server import HTTPServer, BaseHTTPRequestHandler
+
+        captured = {}
+
+        class CaptureHandler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                captured["body"] = json.loads(self.rfile.read(length))
+                captured["headers"] = dict(self.headers)
+                self.send_response(202)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status":"accepted"}')
+
+            def log_message(self, format, *args):
+                pass  # suppress server logs in test output
+
+        # Start local server on a random available port
+        server = HTTPServer(("127.0.0.1", 0), CaptureHandler)
+        port = server.server_address[1]
+        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        server_thread.start()
+
+        # Send a real event to the local server
+        event = {
+            "event_type": "safe_change.turn_completed",
+            "event_version": "1.0",
+            "session_id": "test-123",
+            "changes": [{"table_name": "orders"}],
+        }
+        with patch.dict(os.environ, {"MCD_ID": "key1", "MCD_TOKEN": "tok1"}):
+            with patch("lib.emitter.MC_CHANGE_EVENTS_URL", f"http://127.0.0.1:{port}/plugin/change-events"):
+                _send(event)
+
+        server_thread.join(timeout=5)
+        server.server_close()
+
+        # Verify the payload arrived
+        # Note: urllib.request title-cases header names (e.g. x-mcd-id -> X-Mcd-Id)
+        assert captured["body"] == event
+        assert captured["headers"]["X-Mcd-Id"] == "key1"
+        assert captured["headers"]["X-Mcd-Token"] == "tok1"
+        assert captured["headers"]["Content-Type"] == "application/json"

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -159,3 +159,82 @@ class TestExtractIntent:
             result = _extract_intent("sess1", str(transcript))
 
         assert result == {"summary": "fix the bug", "source": "transcript"}
+
+
+from lib.emitter import _build_event, _send
+
+
+class TestBuildEvent:
+    def test_event_structure(self):
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "a@b.com", "git_name": "A"}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                event = _build_event("sess1", "/tmp/t.jsonl", ["orders"])
+
+        assert event["event_type"] == "safe_change.turn_completed"
+        assert event["event_version"] == "1.0"
+        assert "timestamp" in event
+        assert event["session_id"] == "sess1"
+        assert event["identity"] == {"git_email": "a@b.com", "git_name": "A"}
+        assert event["changes"] == [{"table_name": "orders"}]
+        assert event["workflows"]["impact_check_fired"] is True
+        assert event["intent"] is None
+
+    def test_multiple_tables(self):
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                event = _build_event("sess1", "/tmp/t.jsonl", ["orders", "customers"])
+
+        assert len(event["changes"]) == 2
+        assert event["changes"][0]["table_name"] == "orders"
+        assert event["changes"][1]["table_name"] == "customers"
+
+    def test_timestamp_is_utc_iso(self):
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                event = _build_event("sess1", "/tmp/t.jsonl", ["orders"])
+
+        assert event["timestamp"].endswith("Z")
+        datetime.fromisoformat(event["timestamp"].replace("Z", "+00:00"))
+
+    def test_event_includes_intent_from_commit(self):
+        cache.mark_impact_check_injected("orders")
+        cache.set_last_commit_hash("sess1", "old_hash")
+
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
+            with patch("lib.emitter._get_current_head", return_value="new_hash"):
+                with patch("lib.emitter._get_commit_message", return_value="Fix join"):
+                    event = _build_event("sess1", "/tmp/t.jsonl", ["orders"])
+
+        assert event["intent"] == {"summary": "Fix join", "source": "commit_message"}
+
+
+class TestSend:
+    def test_posts_to_mc(self):
+        event = {"event_type": "test"}
+        with patch.dict(os.environ, {"MCD_ID": "id1", "MCD_TOKEN": "tok1"}):
+            with patch("lib.emitter.urllib.request.urlopen") as mock_urlopen:
+                _send(event)
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "POST"
+        body = json.loads(req.data.decode())
+        assert body == event
+        assert req.get_header("X-mcd-id") == "id1"
+        assert req.get_header("X-mcd-token") == "tok1"
+        assert req.get_header("Content-type") == "application/json"
+
+    def test_silently_drops_on_failure(self):
+        with patch("lib.emitter.urllib.request.urlopen", side_effect=Exception("network")):
+            _send({"event_type": "test"})  # should not raise
+
+    def test_timeout_3s(self):
+        with patch("lib.emitter.urllib.request.urlopen") as mock_urlopen:
+            _send({"event_type": "test"})
+        _, kwargs = mock_urlopen.call_args
+        assert kwargs.get("timeout") == 3
+
+

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -238,7 +238,30 @@ class TestSend:
         assert kwargs.get("timeout") == 3
 
 
-from lib.emitter import emit
+from lib.emitter import emit, _rate_limit_ok
+
+
+class TestRateLimit:
+    def test_first_call_allowed(self):
+        assert _rate_limit_ok("rate_sess") is True
+
+    def test_rapid_second_call_blocked(self):
+        _rate_limit_ok("rate_sess2")
+        assert _rate_limit_ok("rate_sess2") is False
+
+    def test_allowed_after_interval(self):
+        _rate_limit_ok("rate_sess3")
+        # Backdate the marker file to make it appear old
+        import glob
+        markers = glob.glob("/tmp/mc_safe_change_emit_rate_sess3")
+        assert len(markers) == 1
+        old_time = os.path.getmtime(markers[0]) - 10
+        os.utime(markers[0], (old_time, old_time))
+        assert _rate_limit_ok("rate_sess3") is True
+
+    def test_independent_sessions(self):
+        _rate_limit_ok("rate_a")
+        assert _rate_limit_ok("rate_b") is True  # different session, not blocked
 
 
 class TestEmit:

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -20,3 +20,59 @@ class TestGetGitIdentity:
         with patch("lib.emitter.subprocess.run", side_effect=Exception("no git")):
             result = _get_git_identity()
         assert result == {"git_email": "", "git_name": ""}
+
+
+import lib.cache as cache
+from lib.emitter import _extract_workflow_flags
+
+
+class TestExtractWorkflowFlags:
+    def test_no_ic_no_gaps(self):
+        """Tables edited but no IC triggered, no monitor gaps."""
+        result = _extract_workflow_flags("sess1", ["orders"])
+        assert result == {
+            "impact_check_fired": False,
+            "edit_gated": False,
+            "validation_prompted": False,
+            "validation_generated": None,
+            "monitor_gap_detected": False,
+            "monitor_generated": None,
+        }
+
+    def test_ic_injected(self):
+        """IC was triggered (injected) for a table."""
+        cache.mark_impact_check_injected("orders")
+        result = _extract_workflow_flags("sess1", ["orders"])
+        assert result["impact_check_fired"] is True
+        assert result["edit_gated"] is True
+
+    def test_ic_verified_and_no_pending(self):
+        """IC verified, no prior pending -> validation_prompted = True."""
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+        result = _extract_workflow_flags("sess1", ["orders"])
+        assert result["impact_check_fired"] is True
+        assert result["edit_gated"] is True
+        assert result["validation_prompted"] is True
+
+    def test_ic_verified_with_pending(self):
+        """IC verified but pending already exists -> validation_prompted = False."""
+        cache.add_edited_table("sess1", "prior_table")
+        cache.move_to_pending_validation("sess1")
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+        result = _extract_workflow_flags("sess1", ["orders"])
+        assert result["validation_prompted"] is False
+
+    def test_monitor_gap_detected(self):
+        cache.mark_monitor_gap("orders")
+        result = _extract_workflow_flags("sess1", ["orders"])
+        assert result["monitor_gap_detected"] is True
+
+    def test_mixed_tables(self):
+        """Multiple tables, only some have IC state."""
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+        result = _extract_workflow_flags("sess1", ["orders", "customers"])
+        assert result["impact_check_fired"] is True
+        assert result["validation_prompted"] is True

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -76,3 +76,86 @@ class TestExtractWorkflowFlags:
         result = _extract_workflow_flags("sess1", ["orders", "customers"])
         assert result["impact_check_fired"] is True
         assert result["validation_prompted"] is True
+
+
+from lib.emitter import _extract_intent
+
+
+class TestExtractIntent:
+    def test_commit_message_when_head_changed(self):
+        """When HEAD changed since last emit, use commit message."""
+        cache.set_last_commit_hash("sess1", "old_hash")
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(stdout="new_hash\n", returncode=0),
+                MagicMock(stdout="Fix stale join logic\n", returncode=0),
+            ]
+            result = _extract_intent("sess1", "/tmp/nonexistent.jsonl")
+
+        assert result == {"summary": "Fix stale join logic", "source": "commit_message"}
+
+    def test_no_commit_falls_back_to_transcript(self, tmp_path):
+        """No commit happened -> fall back to first user message in transcript."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"role":"user","message":"update the orders model to filter deleted records"}\n'
+            '{"role":"assistant","message":"I will update the model."}\n'
+        )
+        cache.set_last_commit_hash("sess1", "same_hash")
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="same_hash\n", returncode=0)
+            result = _extract_intent("sess1", str(transcript))
+
+        assert result == {
+            "summary": "update the orders model to filter deleted records",
+            "source": "transcript",
+        }
+
+    def test_transcript_truncated_to_256_chars(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        long_msg = "x" * 500
+        transcript.write_text(f'{{"role":"user","message":"{long_msg}"}}\n')
+        cache.set_last_commit_hash("sess1", "same")
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="same\n", returncode=0)
+            result = _extract_intent("sess1", str(transcript))
+
+        assert result is not None
+        assert len(result["summary"]) == 256
+
+    def test_no_prior_hash_no_transcript(self):
+        """First emit, no transcript -> intent is None."""
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="hash1\n", returncode=0)
+            result = _extract_intent("sess1", "/nonexistent/path")
+
+        assert result is None
+
+    def test_stores_current_hash_for_next_emit(self):
+        """After extracting intent, current HEAD is cached for next comparison."""
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="new_hash\n", returncode=0)
+            _extract_intent("sess1", "/tmp/t.jsonl")
+
+        assert cache.get_last_commit_hash("sess1") == "new_hash"
+
+    def test_commit_message_truncated_to_256(self):
+        cache.set_last_commit_hash("sess1", "old")
+        long_commit = "y" * 500
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(stdout="new\n", returncode=0),
+                MagicMock(stdout=f"{long_commit}\n", returncode=0),
+            ]
+            result = _extract_intent("sess1", "/tmp/t.jsonl")
+
+        assert len(result["summary"]) == 256
+
+    def test_git_failure_falls_back_to_transcript(self, tmp_path):
+        """If git commands fail, fall back to transcript."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('{"role":"user","message":"fix the bug"}\n')
+        with patch("lib.emitter.subprocess.run", side_effect=Exception("no git")):
+            result = _extract_intent("sess1", str(transcript))
+
+        assert result == {"summary": "fix the bug", "source": "transcript"}

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -238,3 +238,71 @@ class TestSend:
         assert kwargs.get("timeout") == 3
 
 
+from lib.emitter import emit
+
+
+class TestEmit:
+    def test_spawns_daemon_thread(self):
+        cache.mark_impact_check_injected("orders")
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                with patch("lib.emitter.threading.Thread") as mock_thread:
+                    mock_instance = MagicMock()
+                    mock_thread.return_value = mock_instance
+                    with patch.dict(os.environ, {"MCD_ID": "x", "MCD_TOKEN": "y"}):
+                        emit("sess1", "/tmp/t.jsonl", ["orders"])
+
+        mock_thread.assert_called_once()
+        _, kwargs = mock_thread.call_args
+        assert kwargs["daemon"] is True
+        mock_instance.start.assert_called_once()
+
+    def test_fail_open_on_build_error(self):
+        """emit() should never raise, even if _build_event fails."""
+        with patch.dict(os.environ, {"MCD_ID": "x", "MCD_TOKEN": "y"}):
+            with patch("lib.emitter._build_event", side_effect=Exception("boom")):
+                emit("sess1", "/tmp/t.jsonl", ["orders"])  # should not raise
+
+    def test_skips_when_no_mcd_id(self):
+        """No MCD_ID -> no event emitted."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("lib.emitter.threading.Thread") as mock_thread:
+                emit("sess1", "/tmp/t.jsonl", ["orders"])
+        mock_thread.assert_not_called()
+
+    def test_skips_when_disabled(self):
+        """MC_EMIT_EVENTS=0 -> no event emitted."""
+        with patch.dict(os.environ, {"MC_EMIT_EVENTS": "0", "MCD_ID": "x", "MCD_TOKEN": "y"}):
+            with patch("lib.emitter.threading.Thread") as mock_thread:
+                emit("sess1", "/tmp/t.jsonl", ["orders"])
+        mock_thread.assert_not_called()
+
+    def test_enabled_by_default(self):
+        """MC_EMIT_EVENTS not set -> events enabled."""
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                with patch("lib.emitter.threading.Thread") as mock_thread:
+                    mock_thread.return_value = MagicMock()
+                    with patch.dict(os.environ, {"MCD_ID": "x", "MCD_TOKEN": "y"}, clear=True):
+                        emit("sess1", "/tmp/t.jsonl", ["orders"])
+        mock_thread.assert_called_once()
+
+    def test_dry_run_prints_to_stderr(self, capsys):
+        """MC_EMIT_EVENTS=dry_run -> prints event JSON to stderr, no HTTP call."""
+        cache.mark_impact_check_injected("orders")
+        with patch("lib.emitter._get_git_identity", return_value={"git_email": "a@b.com", "git_name": "A"}):
+            with patch("lib.emitter._extract_intent", return_value=None):
+                with patch("lib.emitter.threading.Thread") as mock_thread:
+                    with patch.dict(os.environ, {"MCD_ID": "x", "MC_EMIT_EVENTS": "dry_run"}):
+                        emit("sess1", "/tmp/t.jsonl", ["orders"])
+
+        # No HTTP thread spawned
+        mock_thread.assert_not_called()
+
+        # Event JSON printed to stderr
+        captured = capsys.readouterr()
+        event = json.loads(captured.err)
+        assert event["event_type"] == "safe_change.turn_completed"
+        assert event["session_id"] == "sess1"
+        assert event["identity"]["git_email"] == "a@b.com"
+        assert event["changes"] == [{"table_name": "orders"}]

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from datetime import datetime
 from unittest.mock import patch, MagicMock
 
@@ -41,15 +42,15 @@ class TestExtractWorkflowFlags:
 
     def test_ic_injected(self):
         """IC was triggered (injected) for a table."""
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
         result = _extract_workflow_flags("sess1", ["orders"])
         assert result["impact_check_fired"] is True
         assert result["edit_gated"] is True
 
     def test_ic_verified_and_no_pending(self):
         """IC verified, no prior pending -> validation_prompted = True."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
+        cache.mark_impact_check_verified("sess1", "orders")
         result = _extract_workflow_flags("sess1", ["orders"])
         assert result["impact_check_fired"] is True
         assert result["edit_gated"] is True
@@ -59,20 +60,20 @@ class TestExtractWorkflowFlags:
         """IC verified but pending already exists -> validation_prompted = False."""
         cache.add_edited_table("sess1", "prior_table")
         cache.move_to_pending_validation("sess1")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
+        cache.mark_impact_check_verified("sess1", "orders")
         result = _extract_workflow_flags("sess1", ["orders"])
         assert result["validation_prompted"] is False
 
     def test_monitor_gap_detected(self):
-        cache.mark_monitor_gap("orders")
+        cache.mark_monitor_gap("sess1", "orders")
         result = _extract_workflow_flags("sess1", ["orders"])
         assert result["monitor_gap_detected"] is True
 
     def test_mixed_tables(self):
         """Multiple tables, only some have IC state."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
+        cache.mark_impact_check_verified("sess1", "orders")
         result = _extract_workflow_flags("sess1", ["orders", "customers"])
         assert result["impact_check_fired"] is True
         assert result["validation_prompted"] is True
@@ -98,8 +99,8 @@ class TestExtractIntent:
         """No commit happened -> fall back to first user message in transcript."""
         transcript = tmp_path / "transcript.jsonl"
         transcript.write_text(
-            '{"role":"user","message":"update the orders model to filter deleted records"}\n'
-            '{"role":"assistant","message":"I will update the model."}\n'
+            '{"type":"user","message":{"role":"user","content":"update the orders model to filter deleted records"}}\n'
+            '{"type":"assistant","message":{"role":"assistant","content":"I will update the model."}}\n'
         )
         cache.set_last_commit_hash("sess1", "same_hash")
         with patch("lib.emitter.subprocess.run") as mock_run:
@@ -114,7 +115,7 @@ class TestExtractIntent:
     def test_transcript_truncated_to_256_chars(self, tmp_path):
         transcript = tmp_path / "transcript.jsonl"
         long_msg = "x" * 500
-        transcript.write_text(f'{{"role":"user","message":"{long_msg}"}}\n')
+        transcript.write_text(f'{{"type":"user","message":{{"role":"user","content":"{long_msg}"}}}}\n')
         cache.set_last_commit_hash("sess1", "same")
         with patch("lib.emitter.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="same\n", returncode=0)
@@ -154,20 +155,84 @@ class TestExtractIntent:
     def test_git_failure_falls_back_to_transcript(self, tmp_path):
         """If git commands fail, fall back to transcript."""
         transcript = tmp_path / "transcript.jsonl"
-        transcript.write_text('{"role":"user","message":"fix the bug"}\n')
+        transcript.write_text('{"type":"user","message":{"role":"user","content":"fix the bug"}}\n')
         with patch("lib.emitter.subprocess.run", side_effect=Exception("no git")):
             result = _extract_intent("sess1", str(transcript))
 
         assert result == {"summary": "fix the bug", "source": "transcript"}
 
 
-from lib.emitter import _build_event, _send
+from lib.emitter import _build_event, _build_changes, _scan_impact_data, _send
+
+
+class TestScanImpactData:
+    def _write_transcript(self, tmp_path, content):
+        """Helper: write a transcript with assistant message content."""
+        transcript = tmp_path / "t.jsonl"
+        # Build proper JSONL — json.dumps handles escaping correctly
+        entry = {"type": "assistant", "message": {"role": "assistant", "content": content}}
+        transcript.write_text(json.dumps(entry) + "\n")
+        return str(transcript)
+
+    def test_parses_marker_from_transcript(self, tmp_path):
+        path = self._write_transcript(tmp_path,
+            '<!-- MC_IMPACT_DATA: {"table":"orders","risk_tier":"high","downstream_count":704,"key_asset":true,"monitor_count":2} -->')
+        result = _scan_impact_data(path)
+        assert result == {
+            "orders": {"risk_tier": "high", "downstream_count": 704, "key_asset": True, "monitor_count": 2}
+        }
+
+    def test_multiple_tables(self, tmp_path):
+        path = self._write_transcript(tmp_path,
+            '<!-- MC_IMPACT_DATA: {"table":"orders","risk_tier":"high","downstream_count":10,"key_asset":true,"monitor_count":1} -->\n'
+            '<!-- MC_IMPACT_DATA: {"table":"customers","risk_tier":"low","downstream_count":3,"key_asset":false,"monitor_count":0} -->')
+        result = _scan_impact_data(path)
+        assert "orders" in result
+        assert "customers" in result
+        assert result["orders"]["risk_tier"] == "high"
+        assert result["customers"]["risk_tier"] == "low"
+
+    def test_no_markers_returns_empty(self, tmp_path):
+        path = self._write_transcript(tmp_path, "Just a normal response with no markers.")
+        result = _scan_impact_data(path)
+        assert result == {}
+
+    def test_missing_file_returns_empty(self):
+        result = _scan_impact_data("/nonexistent/path.jsonl")
+        assert result == {}
+
+    def test_malformed_json_skipped(self, tmp_path):
+        path = self._write_transcript(tmp_path,
+            '<!-- MC_IMPACT_DATA: {bad json} -->\n'
+            '<!-- MC_IMPACT_DATA: {"table":"orders","risk_tier":"low","downstream_count":1,"key_asset":false,"monitor_count":0} -->')
+        result = _scan_impact_data(path)
+        assert result == {"orders": {"risk_tier": "low", "downstream_count": 1, "key_asset": False, "monitor_count": 0}}
+
+
+class TestBuildChanges:
+    def test_no_impact_data(self):
+        changes = _build_changes(["orders", "customers"], {})
+        assert changes == [{"table_name": "orders"}, {"table_name": "customers"}]
+
+    def test_with_impact_data(self):
+        impact = {"orders": {"risk_tier": "high", "downstream_count": 704}}
+        changes = _build_changes(["orders", "customers"], impact)
+        assert changes[0] == {"table_name": "orders", "assessment": {"risk_tier": "high", "downstream_count": 704}}
+        assert changes[1] == {"table_name": "customers"}
+
+    def test_all_tables_enriched(self):
+        impact = {
+            "orders": {"risk_tier": "high"},
+            "customers": {"risk_tier": "low"},
+        }
+        changes = _build_changes(["orders", "customers"], impact)
+        assert all("assessment" in c for c in changes)
 
 
 class TestBuildEvent:
     def test_event_structure(self):
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
+        cache.mark_impact_check_verified("sess1", "orders")
 
         with patch("lib.emitter._get_git_identity", return_value={"git_email": "a@b.com", "git_name": "A"}):
             with patch("lib.emitter._extract_intent", return_value=None):
@@ -200,7 +265,7 @@ class TestBuildEvent:
         datetime.fromisoformat(event["timestamp"].replace("Z", "+00:00"))
 
     def test_event_includes_intent_from_commit(self):
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
         cache.set_last_commit_hash("sess1", "old_hash")
 
         with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
@@ -212,30 +277,32 @@ class TestBuildEvent:
 
 
 class TestSend:
-    def test_posts_to_mc(self):
+    def test_spawns_subprocess_with_event(self):
         event = {"event_type": "test"}
         with patch.dict(os.environ, {"MCD_ID": "id1", "MCD_TOKEN": "tok1"}):
-            with patch("lib.emitter.urllib.request.urlopen") as mock_urlopen:
+            with patch("lib.emitter.subprocess.Popen") as mock_popen:
+                mock_proc = MagicMock()
+                mock_popen.return_value = mock_proc
                 _send(event)
 
-        mock_urlopen.assert_called_once()
-        req = mock_urlopen.call_args[0][0]
-        assert req.method == "POST"
-        body = json.loads(req.data.decode())
-        assert body == event
-        assert req.get_header("X-mcd-id") == "id1"
-        assert req.get_header("X-mcd-token") == "tok1"
-        assert req.get_header("Content-type") == "application/json"
+        mock_popen.assert_called_once()
+        call_args = mock_popen.call_args
+        # Verify detached subprocess
+        assert call_args[1]["start_new_session"] is True
+        assert call_args[1]["stdin"] == subprocess.PIPE
+        # Verify event was written to stdin
+        mock_proc.stdin.write.assert_called_once()
+        written = mock_proc.stdin.write.call_args[0][0]
+        assert json.loads(written.decode()) == event
+        mock_proc.stdin.close.assert_called_once()
+        # Verify credentials passed as args: [python3, -c, script, url, mcd_id, mcd_token]
+        cmd_args = call_args[0][0]
+        assert cmd_args[4] == "id1"  # MCD_ID
+        assert cmd_args[5] == "tok1"  # MCD_TOKEN
 
     def test_silently_drops_on_failure(self):
-        with patch("lib.emitter.urllib.request.urlopen", side_effect=Exception("network")):
+        with patch("lib.emitter.subprocess.Popen", side_effect=Exception("spawn failed")):
             _send({"event_type": "test"})  # should not raise
-
-    def test_timeout_3s(self):
-        with patch("lib.emitter.urllib.request.urlopen") as mock_urlopen:
-            _send({"event_type": "test"})
-        _, kwargs = mock_urlopen.call_args
-        assert kwargs.get("timeout") == 3
 
 
 from lib.emitter import emit, _rate_limit_ok
@@ -265,20 +332,17 @@ class TestRateLimit:
 
 
 class TestEmit:
-    def test_spawns_daemon_thread(self):
-        cache.mark_impact_check_injected("orders")
+    def test_calls_send(self):
+        cache.mark_impact_check_injected("sess1", "orders")
         with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
             with patch("lib.emitter._extract_intent", return_value=None):
-                with patch("lib.emitter.threading.Thread") as mock_thread:
-                    mock_instance = MagicMock()
-                    mock_thread.return_value = mock_instance
+                with patch("lib.emitter._send") as mock_send:
                     with patch.dict(os.environ, {"MCD_ID": "x", "MCD_TOKEN": "y"}):
                         emit("sess1", "/tmp/t.jsonl", ["orders"])
 
-        mock_thread.assert_called_once()
-        _, kwargs = mock_thread.call_args
-        assert kwargs["daemon"] is True
-        mock_instance.start.assert_called_once()
+        mock_send.assert_called_once()
+        event = mock_send.call_args[0][0]
+        assert event["event_type"] == "safe_change.turn_completed"
 
     def test_fail_open_on_build_error(self):
         """emit() should never raise, even if _build_event fails."""
@@ -289,30 +353,29 @@ class TestEmit:
     def test_skips_when_no_mcd_id(self):
         """No MCD_ID -> no event emitted."""
         with patch.dict(os.environ, {}, clear=True):
-            with patch("lib.emitter.threading.Thread") as mock_thread:
+            with patch("lib.emitter._send") as mock_send:
                 emit("sess1", "/tmp/t.jsonl", ["orders"])
-        mock_thread.assert_not_called()
+        mock_send.assert_not_called()
 
     def test_skips_when_disabled(self):
         """MC_EMIT_EVENTS=0 -> no event emitted."""
         with patch.dict(os.environ, {"MC_EMIT_EVENTS": "0", "MCD_ID": "x", "MCD_TOKEN": "y"}):
-            with patch("lib.emitter.threading.Thread") as mock_thread:
+            with patch("lib.emitter._send") as mock_send:
                 emit("sess1", "/tmp/t.jsonl", ["orders"])
-        mock_thread.assert_not_called()
+        mock_send.assert_not_called()
 
     def test_enabled_by_default(self):
         """MC_EMIT_EVENTS not set -> events enabled."""
         with patch("lib.emitter._get_git_identity", return_value={"git_email": "", "git_name": ""}):
             with patch("lib.emitter._extract_intent", return_value=None):
-                with patch("lib.emitter.threading.Thread") as mock_thread:
-                    mock_thread.return_value = MagicMock()
+                with patch("lib.emitter._send") as mock_send:
                     with patch.dict(os.environ, {"MCD_ID": "x", "MCD_TOKEN": "y"}, clear=True):
                         emit("sess1", "/tmp/t.jsonl", ["orders"])
-        mock_thread.assert_called_once()
+        mock_send.assert_called_once()
 
     def test_dry_run_prints_to_stderr(self, capsys):
         """MC_EMIT_EVENTS=dry_run -> prints event JSON to stderr, no HTTP call."""
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
         with patch("lib.emitter._get_git_identity", return_value={"git_email": "a@b.com", "git_name": "A"}):
             with patch("lib.emitter._extract_intent", return_value=None):
                 with patch("lib.emitter.threading.Thread") as mock_thread:
@@ -335,9 +398,9 @@ class TestEndToEnd:
     def test_dry_run_full_event(self, tmp_path, capsys):
         """Full flow via dry_run: cache setup -> emit -> verify event from stderr."""
         # Set up cache state
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
-        cache.mark_monitor_gap("orders")
+        cache.mark_impact_check_injected("sess1", "orders")
+        cache.mark_impact_check_verified("sess1", "orders")
+        cache.mark_monitor_gap("sess1", "orders")
         cache.set_last_commit_hash("sess1", "old_hash")
 
         # Create transcript

--- a/plugins/claude-code/safe-change/tests/test_emitter.py
+++ b/plugins/claude-code/safe-change/tests/test_emitter.py
@@ -1,0 +1,22 @@
+import json
+import os
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from lib.emitter import _get_git_identity
+
+
+class TestGetGitIdentity:
+    def test_returns_email_and_name(self):
+        with patch("lib.emitter.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(stdout="alice@company.com\n", returncode=0),
+                MagicMock(stdout="Alice Chen\n", returncode=0),
+            ]
+            result = _get_git_identity()
+        assert result == {"git_email": "alice@company.com", "git_name": "Alice Chen"}
+
+    def test_returns_empty_on_failure(self):
+        with patch("lib.emitter.subprocess.run", side_effect=Exception("no git")):
+            result = _get_git_identity()
+        assert result == {"git_email": "", "git_name": ""}

--- a/plugins/claude-code/safe-change/tests/test_pre_commit_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_pre_commit_hook.py
@@ -36,8 +36,8 @@ class TestPreCommitHook:
 
     def test_commit_with_staged_sql_and_w4_prompts(self, capsys):
         """git commit with staged dbt models + W4 should prompt."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_commit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())), \
@@ -61,8 +61,8 @@ class TestPreCommitHook:
 
     def test_git_commit_amend_also_caught(self, capsys):
         """git commit --amend should also trigger."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_commit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin("git commit --amend"))), \

--- a/plugins/claude-code/safe-change/tests/test_pre_edit_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_pre_edit_hook.py
@@ -52,7 +52,7 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # No transcript marker — assessment hasn't completed
         transcript = tmp_path / "transcript.jsonl"
@@ -74,7 +74,7 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Transcript has the completion marker
         transcript = tmp_path / "transcript.jsonl"
@@ -85,7 +85,7 @@ class TestPreEditHook:
             main()
 
         assert capsys.readouterr().out == ""
-        assert cache.get_impact_check_state("orders") == "verified"
+        assert cache.get_impact_check_state("test_session", "orders") == "verified"
 
     def test_dbt_model_verified_state_silent(self, tmp_path, capsys):
         """Verified state should always be silent."""
@@ -94,8 +94,8 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_edit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin(str(sql_file)))):
@@ -110,14 +110,14 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Create transcript with the completion marker
         transcript = tmp_path / "transcript.jsonl"
         transcript.write_text('{"content": "<!-- MC_IMPACT_CHECK_COMPLETE: orders -->"}\n')
 
         # Age the marker past grace period
-        marker_path = "/tmp/mc_safe_change_ic_orders"
+        marker_path = "/tmp/mc_safe_change_ic_test_session_orders"
         with open(marker_path, "r") as f:
             data = json.load(f)
         data["timestamp"] = data["timestamp"] - 200  # 200 seconds ago
@@ -129,7 +129,7 @@ class TestPreEditHook:
             main()
 
         assert capsys.readouterr().out == ""
-        assert cache.get_impact_check_state("orders") == "verified"
+        assert cache.get_impact_check_state("test_session", "orders") == "verified"
 
     def test_grace_period_expired_no_marker_in_transcript_reinjects(self, tmp_path, capsys):
         """After 120s, if transcript lacks marker, should re-inject."""
@@ -138,14 +138,14 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Create transcript WITHOUT the completion marker
         transcript = tmp_path / "transcript.jsonl"
         transcript.write_text('{"content": "some other message"}\n')
 
         # Age the marker past grace period
-        marker_path = "/tmp/mc_safe_change_ic_orders"
+        marker_path = "/tmp/mc_safe_change_ic_test_session_orders"
         with open(marker_path, "r") as f:
             data = json.load(f)
         data["timestamp"] = data["timestamp"] - 200

--- a/plugins/claude-code/safe-change/tests/test_safe_run.py
+++ b/plugins/claude-code/safe-change/tests/test_safe_run.py
@@ -36,3 +36,37 @@ def test_safe_run_exits_0_on_keyboard_interrupt():
     with pytest.raises(SystemExit) as exc_info:
         interrupted_fn()
     assert exc_info.value.code == 0
+
+
+def test_safe_run_debug_mode_reraises(monkeypatch):
+    """In debug mode, exceptions propagate instead of being swallowed."""
+    monkeypatch.setenv("MC_SAFE_CHANGE_DEBUG", "1")
+    # Re-import to pick up the env var change
+    import importlib
+    import lib.safe_run as sr
+    importlib.reload(sr)
+
+    @sr.safe_run
+    def bad_fn():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        bad_fn()
+
+
+def test_safe_run_debug_mode_prints_traceback(monkeypatch, capsys):
+    """Debug mode prints traceback to stderr."""
+    monkeypatch.setenv("MC_SAFE_CHANGE_DEBUG", "1")
+    import importlib
+    import lib.safe_run as sr
+    importlib.reload(sr)
+
+    @sr.safe_run
+    def bad_fn():
+        raise RuntimeError("debug trace")
+
+    with pytest.raises(RuntimeError):
+        bad_fn()
+
+    captured = capsys.readouterr()
+    assert "debug trace" in captured.err

--- a/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
@@ -131,3 +131,55 @@ class TestTurnEndHook:
         parsed = json.loads(output)
         assert parsed["decision"] == "block"
         assert "orders" in parsed["reason"]
+
+    def test_emitter_called_when_tables_edited(self, capsys):
+        """Emitter should fire whenever tables were edited in this turn."""
+        cache.add_edited_table("test_session", "orders")
+        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_verified("orders")
+
+        from turn_end_hook import main
+        with patch("sys.stdin", StringIO(_make_stdin())):
+            with patch("lib.emitter.emit") as mock_emit:
+                main()
+
+        mock_emit.assert_called_once_with(
+            "test_session",
+            "/tmp/test_transcript.jsonl",
+            ["orders"],
+        )
+
+    def test_emitter_called_on_silent_merge(self, capsys):
+        """Emitter fires even when turn merges silently into pending."""
+        cache.add_edited_table("test_session", "orders")
+        cache.move_to_pending_validation("test_session")
+        cache.add_edited_table("test_session", "customers")
+
+        from turn_end_hook import main
+        with patch("sys.stdin", StringIO(_make_stdin())):
+            with patch("lib.emitter.emit") as mock_emit:
+                main()
+
+        mock_emit.assert_called_once_with(
+            "test_session",
+            "/tmp/test_transcript.jsonl",
+            ["customers"],
+        )
+
+    def test_emitter_not_called_when_no_tables(self, capsys):
+        from turn_end_hook import main
+        with patch("sys.stdin", StringIO(_make_stdin())):
+            with patch("lib.emitter.emit") as mock_emit:
+                main()
+
+        mock_emit.assert_not_called()
+
+    def test_emitter_not_called_when_stop_hook_active(self, capsys):
+        cache.add_edited_table("test_session", "orders")
+
+        from turn_end_hook import main
+        with patch("sys.stdin", StringIO(_make_stdin(stop_hook_active=True))):
+            with patch("lib.emitter.emit") as mock_emit:
+                main()
+
+        mock_emit.assert_not_called()

--- a/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
@@ -36,8 +36,8 @@ class TestTurnEndHook:
     def test_edits_with_impact_check_prompts(self, capsys):
         """Edits + impact assessment verified should produce validation prompt."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -52,8 +52,8 @@ class TestTurnEndHook:
     def test_stop_hook_active_exits_silently(self, capsys):
         """If stop_hook_active is true, exit silently to prevent infinite loop."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin(stop_hook_active=True))):
@@ -64,8 +64,8 @@ class TestTurnEndHook:
     def test_moves_to_pending_validation(self, capsys):
         """After prompting, tables should move to pending validation."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -77,8 +77,8 @@ class TestTurnEndHook:
     def test_multiple_tables_in_prompt(self, capsys):
         cache.add_edited_table("test_session", "orders")
         cache.add_edited_table("test_session", "customers")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -95,13 +95,13 @@ class TestTurnEndHook:
         # Simulate first prompt: orders was prompted and moved to pending
         cache.add_edited_table("test_session", "orders")
         cache.move_to_pending_validation("test_session")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         # Simulate second turn: new model edited + validation files detected
         cache.add_edited_table("test_session", "client_hub_master")
-        cache.mark_impact_check_injected("client_hub_master")
-        cache.mark_impact_check_verified("client_hub_master")
+        cache.mark_impact_check_injected("test_session", "client_hub_master")
+        cache.mark_impact_check_verified("test_session", "client_hub_master")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -121,7 +121,7 @@ class TestTurnEndHook:
     def test_edits_with_only_injected_state_prompts(self, capsys):
         """Edits with 'injected' state should prompt (assessment was triggered)."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -135,8 +135,8 @@ class TestTurnEndHook:
     def test_emitter_called_when_tables_edited(self, capsys):
         """Emitter should fire whenever tables were edited in this turn."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):

--- a/plugins/claude-code/safe-change/tests/test_validate_command.py
+++ b/plugins/claude-code/safe-change/tests/test_validate_command.py
@@ -30,8 +30,8 @@ class TestValidateCommand:
     def test_pending_tables_with_w4_generates_instruction(self, capsys):
         cache.add_edited_table("test_session", "orders")
         cache.move_to_pending_validation("test_session")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from validate_command import main
         with patch("sys.stdin", StringIO(_make_stdin())):

--- a/skills/safe-change/SKILL.md
+++ b/skills/safe-change/SKILL.md
@@ -236,6 +236,24 @@ if some were assessed via lineage context rather than direct MC tool calls. The
 engineer is already safety-conscious; don't force redundant assessments for tables
 they clearly considered.
 
+### Impact assessment data
+
+Immediately after each `MC_IMPACT_CHECK_COMPLETE` marker, output a structured data
+marker with the key metrics from the assessment. This is read by the plugin's
+emitter to enrich change events with assessment context.
+
+<!-- MC_IMPACT_DATA: {"table":"<table_name>","risk_tier":"<low|medium|medium-high|high>","downstream_count":<int>,"key_asset":<true|false>,"monitor_count":<int>} -->
+
+Field definitions:
+- `table`: the assessed table name (must match the `MC_IMPACT_CHECK_COMPLETE` marker)
+- `risk_tier`: your assessed risk level — `"low"`, `"medium"`, `"medium-high"`, or `"high"`
+- `downstream_count`: total number of downstream tables/relationships found
+- `key_asset`: whether the table is flagged as a key asset in Monte Carlo
+- `monitor_count`: number of active monitors on this table
+
+Use exact JSON — no trailing commas, no extra fields. Values must come from the
+actual MC tool responses, not estimates.
+
 ### Monitor coverage gap
 
 When Workflow 4 finds zero custom monitors on a table's affected columns, output:


### PR DESCRIPTION
## Summary

- Add `hooks/lib/emitter.py` module that assembles change events from cache state (identity, edited tables, workflow flags, intent) and sends them via a non-blocking daemon thread POST to MC's integration gateway
- Integrate emitter into `turn_end_hook.py` — fires on every turn where dbt models were edited, before validation logic
- Extend `hooks/lib/cache.py` with last-commit hash tracking for intent extraction (commit message vs transcript fallback)
- Support three modes via `MC_EMIT_EVENTS` env var: `1` (default, send HTTP), `dry_run` (print to stderr), `0` (disabled)

## Design

**Spec:** `docs/superpowers/specs/2026-03-26-safe-change-session-events-design.md`
**Plan:** `docs/superpowers/plans/2026-03-26-safe-change-session-events.md`

This is **Phase 1 (client-side)** of the session events work. Phase 2 (backend handler in saas-serverless) is planned but not yet implemented — the endpoint does not exist yet. Use `MC_EMIT_EVENTS=dry_run` to verify event assembly without a backend.

### Event schema

Each event captures: engineer identity (git), edited table names, workflow boolean flags (impact check fired, edit gated, validation prompted, monitor gap detected), and intent (commit message or first user transcript message, 256-char truncated).

### Key guarantees

- **Non-blocking** — daemon thread; hook returns immediately
- **Fail-open** — entire `emit()` wrapped in try/except; never blocks the engineer
- **No new dependencies** — stdlib only (urllib.request, threading, subprocess)
- **No cache mutation** — emitter reads existing cache state, only writes to the new commit-hash cache

## Test plan

- [x] 30 unit tests for emitter module (identity, workflow flags, intent extraction, event assembly, HTTP send, emit entry point, dry-run mode)
- [x] 5 unit tests for last-commit cache
- [x] 4 integration tests for turn_end_hook emitter wiring
- [x] End-to-end dry-run test verifying full event structure via stderr
- [x] Real HTTP integration test with local server (no mocks)
- [x] All 112 tests pass, no regressions
- [ ] Manual verification with `MC_EMIT_EVENTS=dry_run` in a live Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)