### PR TITLE
fix(safe-change): use cache and markers per session

### DIFF
--- a/plugins/claude-code/safe-change/.claude-plugin/plugin.json
+++ b/plugins/claude-code/safe-change/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-safe-change",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Monte Carlo Safe Change — data observability context and safe change enforcement in your editor",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/safe-change/CHANGELOG.md
+++ b/plugins/claude-code/safe-change/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Safe Change plugin will be documented in 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-30
+
+### Fixed
+
+- Session cache is now keyed per Claude Code session ID, preventing state from leaking across sessions
+
 ## [1.1.0] - 2026-03-26
 
 ### Added

--- a/plugins/claude-code/safe-change/hooks/lib/cache.py
+++ b/plugins/claude-code/safe-change/hooks/lib/cache.py
@@ -61,8 +61,8 @@ def _validate_session_id(session_id: str) -> str:
     return session_id
 
 
-def _w4_path(table_name: str) -> str:
-    return os.path.join(CACHE_DIR, f"{IC_PREFIX}{table_name}")
+def _w4_path(session_id: str, table_name: str) -> str:
+    return os.path.join(CACHE_DIR, f"{IC_PREFIX}{_validate_session_id(session_id)}_{table_name}")
 
 
 def _turn_path(session_id: str) -> str:
@@ -75,9 +75,9 @@ def _pending_path(session_id: str) -> str:
 
 # --- Impact check three-state marker ---
 
-def get_impact_check_state(table_name: str) -> str | None:
+def get_impact_check_state(session_id: str, table_name: str) -> str | None:
     """Returns None, 'injected', or 'verified'."""
-    path = _w4_path(table_name)
+    path = _w4_path(session_id, table_name)
     if not os.path.exists(path):
         return None
     try:
@@ -88,13 +88,13 @@ def get_impact_check_state(table_name: str) -> str | None:
         return None
 
 
-def mark_impact_check_injected(table_name: str) -> None:
-    path = _w4_path(table_name)
+def mark_impact_check_injected(session_id: str, table_name: str) -> None:
+    path = _w4_path(session_id, table_name)
     _write_secure(path, json.dumps({"state": "injected", "timestamp": time.time()}))
 
 
-def mark_impact_check_verified(table_name: str) -> None:
-    path = _w4_path(table_name)
+def mark_impact_check_verified(session_id: str, table_name: str) -> None:
+    path = _w4_path(session_id, table_name)
     # Preserve timestamp from injection
     timestamp = time.time()
     try:
@@ -106,8 +106,8 @@ def mark_impact_check_verified(table_name: str) -> None:
     _write_secure(path, json.dumps({"state": "verified", "timestamp": timestamp}))
 
 
-def get_impact_check_age_seconds(table_name: str) -> float:
-    path = _w4_path(table_name)
+def get_impact_check_age_seconds(session_id: str, table_name: str) -> float:
+    path = _w4_path(session_id, table_name)
     try:
         with open(path, "r") as f:
             data = json.load(f)
@@ -118,16 +118,16 @@ def get_impact_check_age_seconds(table_name: str) -> float:
 
 # --- Monitor coverage gap marker ---
 
-def _mg_path(table_name: str) -> str:
-    return os.path.join(CACHE_DIR, f"{MG_PREFIX}{table_name}")
+def _mg_path(session_id: str, table_name: str) -> str:
+    return os.path.join(CACHE_DIR, f"{MG_PREFIX}{_validate_session_id(session_id)}_{table_name}")
 
 
-def has_monitor_gap(table_name: str) -> bool:
-    return os.path.exists(_mg_path(table_name))
+def has_monitor_gap(session_id: str, table_name: str) -> bool:
+    return os.path.exists(_mg_path(session_id, table_name))
 
 
-def mark_monitor_gap(table_name: str) -> None:
-    _write_secure(_mg_path(table_name), str(time.time()))
+def mark_monitor_gap(session_id: str, table_name: str) -> None:
+    _write_secure(_mg_path(session_id, table_name), str(time.time()))
 
 
 # --- Turn-level edit accumulator ---

--- a/plugins/claude-code/safe-change/hooks/pre_commit_hook.py
+++ b/plugins/claude-code/safe-change/hooks/pre_commit_hook.py
@@ -41,6 +41,7 @@ def main():
     if "git commit" not in command:
         return
 
+    session_id = input_data.get("session_id", "unknown")
     cwd = input_data.get("cwd", ".")
     staged_tables = _get_staged_model_tables(cwd)
 
@@ -48,12 +49,12 @@ def main():
         return
 
     # Only prompt if impact assessment ran for at least one staged table
-    w4_tables = [t for t in staged_tables if get_impact_check_state(t) == "verified"]
+    w4_tables = [t for t in staged_tables if get_impact_check_state(session_id, t) == "verified"]
     if not w4_tables:
         return
 
     table_list = ", ".join(w4_tables)
-    gap_tables = [t for t in w4_tables if has_monitor_gap(t)]
+    gap_tables = [t for t in w4_tables if has_monitor_gap(session_id, t)]
 
     message = f"Committing changes to {table_list}. Run validation queries before committing? (yes / no)"
 

--- a/plugins/claude-code/safe-change/hooks/pre_edit_hook.py
+++ b/plugins/claude-code/safe-change/hooks/pre_edit_hook.py
@@ -55,8 +55,9 @@ def main():
     if not os.path.exists(file_path):
         return
 
+    session_id = input_data.get("session_id", "unknown")
     table_name = extract_table_name(file_path)
-    state = get_impact_check_state(table_name)
+    state = get_impact_check_state(session_id, table_name)
 
     if state == "verified":
         return
@@ -65,13 +66,13 @@ def main():
         # Always check transcript for completion marker before allowing edit
         transcript_path = input_data.get("transcript_path", "")
         markers = _scan_transcript_for_markers(transcript_path, table_name)
-        if markers["monitor_gap"] and not has_monitor_gap(table_name):
-            mark_monitor_gap(table_name)
+        if markers["monitor_gap"] and not has_monitor_gap(session_id, table_name):
+            mark_monitor_gap(session_id, table_name)
         if markers["impact_check"]:
-            mark_impact_check_verified(table_name)
+            mark_impact_check_verified(session_id, table_name)
             return
         # Assessment not completed — block without re-injecting if within grace period
-        age = get_impact_check_age_seconds(table_name)
+        age = get_impact_check_age_seconds(session_id, table_name)
         if age < GRACE_PERIOD_SECONDS:
             reason = (
                 f"Monte Carlo safe-change: the impact assessment for {table_name} "
@@ -94,14 +95,14 @@ def main():
         transcript_path = input_data.get("transcript_path", "")
         if transcript_path:
             markers = _scan_transcript_for_markers(transcript_path, table_name)
-            if markers["monitor_gap"] and not has_monitor_gap(table_name):
-                mark_monitor_gap(table_name)
+            if markers["monitor_gap"] and not has_monitor_gap(session_id, table_name):
+                mark_monitor_gap(session_id, table_name)
             if markers["impact_check"]:
-                mark_impact_check_verified(table_name)
+                mark_impact_check_verified(session_id, table_name)
                 return
 
     # No marker or failed verification — block the edit until impact assessment runs
-    mark_impact_check_injected(table_name)
+    mark_impact_check_injected(session_id, table_name)
 
     hook_triggered_note = (
         "This assessment is hook-triggered — only emit MC_IMPACT_CHECK_COMPLETE "

--- a/plugins/claude-code/safe-change/hooks/turn_end_hook.py
+++ b/plugins/claude-code/safe-change/hooks/turn_end_hook.py
@@ -39,12 +39,12 @@ def main():
 
     # Prompt if impact assessment was triggered for at least one edited table
     # "injected" means W4 instruction was sent; "verified" means completion confirmed
-    w4_tables = [t for t in tables if get_impact_check_state(t) in ("injected", "verified")]
+    w4_tables = [t for t in tables if get_impact_check_state(session_id, t) in ("injected", "verified")]
     if not w4_tables:
         return
 
     # Check for monitor coverage gaps
-    gap_tables = [t for t in tables if has_monitor_gap(t)]
+    gap_tables = [t for t in tables if has_monitor_gap(session_id, t)]
 
     # Build prompt
     table_list = ", ".join(tables)

--- a/plugins/claude-code/safe-change/hooks/validate_command.py
+++ b/plugins/claude-code/safe-change/hooks/validate_command.py
@@ -35,7 +35,7 @@ def main():
         return
 
     # Filter to tables that had impact assessment
-    w4_tables = [t for t in tables if get_impact_check_state(t) == "verified"]
+    w4_tables = [t for t in tables if get_impact_check_state(session_id, t) == "verified"]
     if not w4_tables:
         w4_tables = tables  # Fall back to all tables if no W4 tracking
 

--- a/plugins/claude-code/safe-change/tests/test_cache.py
+++ b/plugins/claude-code/safe-change/tests/test_cache.py
@@ -25,27 +25,27 @@ from lib.cache import (
 
 class TestImpactCheckState:
     def test_no_marker_returns_none(self):
-        assert get_impact_check_state("my_table") is None
+        assert get_impact_check_state("test_session", "my_table") is None
 
     def test_injected_state(self):
-        mark_impact_check_injected("my_table")
-        assert get_impact_check_state("my_table") == "injected"
+        mark_impact_check_injected("test_session", "my_table")
+        assert get_impact_check_state("test_session", "my_table") == "injected"
 
     def test_verified_state(self):
-        mark_impact_check_injected("my_table")
-        mark_impact_check_verified("my_table")
-        assert get_impact_check_state("my_table") == "verified"
+        mark_impact_check_injected("test_session", "my_table")
+        mark_impact_check_verified("test_session", "my_table")
+        assert get_impact_check_state("test_session", "my_table") == "verified"
 
     def test_marker_age(self):
-        mark_impact_check_injected("my_table")
-        age = get_impact_check_age_seconds("my_table")
+        mark_impact_check_injected("test_session", "my_table")
+        age = get_impact_check_age_seconds("test_session", "my_table")
         assert 0 <= age < 2  # Should be very recent
 
     def test_different_tables_independent(self):
-        mark_impact_check_injected("table_a")
-        mark_impact_check_verified("table_a")
-        assert get_impact_check_state("table_a") == "verified"
-        assert get_impact_check_state("table_b") is None
+        mark_impact_check_injected("test_session", "table_a")
+        mark_impact_check_verified("test_session", "table_a")
+        assert get_impact_check_state("test_session", "table_a") == "verified"
+        assert get_impact_check_state("test_session", "table_b") is None
 
 
 class TestEditAccumulator:
@@ -131,8 +131,8 @@ class TestFilePermissions:
         return stat.S_IMODE(os.stat(path).st_mode)
 
     def test_impact_check_file_is_owner_only(self):
-        mark_impact_check_injected("perm_test_table")
-        path = os.path.join(CACHE_DIR, f"{IC_PREFIX}perm_test_table")
+        mark_impact_check_injected("test_session", "perm_test_table")
+        path = os.path.join(CACHE_DIR, f"{IC_PREFIX}test_session_perm_test_table")
         assert self._get_perms(path) == 0o600
 
     def test_turn_file_is_owner_only(self):

--- a/plugins/claude-code/safe-change/tests/test_pre_commit_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_pre_commit_hook.py
@@ -36,8 +36,8 @@ class TestPreCommitHook:
 
     def test_commit_with_staged_sql_and_w4_prompts(self, capsys):
         """git commit with staged dbt models + W4 should prompt."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_commit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())), \
@@ -61,8 +61,8 @@ class TestPreCommitHook:
 
     def test_git_commit_amend_also_caught(self, capsys):
         """git commit --amend should also trigger."""
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_commit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin("git commit --amend"))), \

--- a/plugins/claude-code/safe-change/tests/test_pre_edit_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_pre_edit_hook.py
@@ -52,7 +52,7 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # No transcript marker — assessment hasn't completed
         transcript = tmp_path / "transcript.jsonl"
@@ -74,7 +74,7 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Transcript has the completion marker
         transcript = tmp_path / "transcript.jsonl"
@@ -85,7 +85,7 @@ class TestPreEditHook:
             main()
 
         assert capsys.readouterr().out == ""
-        assert cache.get_impact_check_state("orders") == "verified"
+        assert cache.get_impact_check_state("test_session", "orders") == "verified"
 
     def test_dbt_model_verified_state_silent(self, tmp_path, capsys):
         """Verified state should always be silent."""
@@ -94,8 +94,8 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from pre_edit_hook import main
         with patch("sys.stdin", StringIO(_make_stdin(str(sql_file)))):
@@ -110,14 +110,14 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Create transcript with the completion marker
         transcript = tmp_path / "transcript.jsonl"
         transcript.write_text('{"content": "<!-- MC_IMPACT_CHECK_COMPLETE: orders -->"}\n')
 
         # Age the marker past grace period
-        marker_path = "/tmp/mc_safe_change_ic_orders"
+        marker_path = "/tmp/mc_safe_change_ic_test_session_orders"
         with open(marker_path, "r") as f:
             data = json.load(f)
         data["timestamp"] = data["timestamp"] - 200  # 200 seconds ago
@@ -129,7 +129,7 @@ class TestPreEditHook:
             main()
 
         assert capsys.readouterr().out == ""
-        assert cache.get_impact_check_state("orders") == "verified"
+        assert cache.get_impact_check_state("test_session", "orders") == "verified"
 
     def test_grace_period_expired_no_marker_in_transcript_reinjects(self, tmp_path, capsys):
         """After 120s, if transcript lacks marker, should re-inject."""
@@ -138,14 +138,14 @@ class TestPreEditHook:
         sql_file = model_dir / "orders.sql"
         sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
 
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         # Create transcript WITHOUT the completion marker
         transcript = tmp_path / "transcript.jsonl"
         transcript.write_text('{"content": "some other message"}\n')
 
         # Age the marker past grace period
-        marker_path = "/tmp/mc_safe_change_ic_orders"
+        marker_path = "/tmp/mc_safe_change_ic_test_session_orders"
         with open(marker_path, "r") as f:
             data = json.load(f)
         data["timestamp"] = data["timestamp"] - 200

--- a/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
+++ b/plugins/claude-code/safe-change/tests/test_turn_end_hook.py
@@ -36,8 +36,8 @@ class TestTurnEndHook:
     def test_edits_with_impact_check_prompts(self, capsys):
         """Edits + impact assessment verified should produce validation prompt."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -52,8 +52,8 @@ class TestTurnEndHook:
     def test_stop_hook_active_exits_silently(self, capsys):
         """If stop_hook_active is true, exit silently to prevent infinite loop."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin(stop_hook_active=True))):
@@ -64,8 +64,8 @@ class TestTurnEndHook:
     def test_moves_to_pending_validation(self, capsys):
         """After prompting, tables should move to pending validation."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -77,8 +77,8 @@ class TestTurnEndHook:
     def test_multiple_tables_in_prompt(self, capsys):
         cache.add_edited_table("test_session", "orders")
         cache.add_edited_table("test_session", "customers")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -95,13 +95,13 @@ class TestTurnEndHook:
         # Simulate first prompt: orders was prompted and moved to pending
         cache.add_edited_table("test_session", "orders")
         cache.move_to_pending_validation("test_session")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         # Simulate second turn: new model edited + validation files detected
         cache.add_edited_table("test_session", "client_hub_master")
-        cache.mark_impact_check_injected("client_hub_master")
-        cache.mark_impact_check_verified("client_hub_master")
+        cache.mark_impact_check_injected("test_session", "client_hub_master")
+        cache.mark_impact_check_verified("test_session", "client_hub_master")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):
@@ -121,7 +121,7 @@ class TestTurnEndHook:
     def test_edits_with_only_injected_state_prompts(self, capsys):
         """Edits with 'injected' state should prompt (assessment was triggered)."""
         cache.add_edited_table("test_session", "orders")
-        cache.mark_impact_check_injected("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
 
         from turn_end_hook import main
         with patch("sys.stdin", StringIO(_make_stdin())):

--- a/plugins/claude-code/safe-change/tests/test_validate_command.py
+++ b/plugins/claude-code/safe-change/tests/test_validate_command.py
@@ -30,8 +30,8 @@ class TestValidateCommand:
     def test_pending_tables_with_w4_generates_instruction(self, capsys):
         cache.add_edited_table("test_session", "orders")
         cache.move_to_pending_validation("test_session")
-        cache.mark_impact_check_injected("orders")
-        cache.mark_impact_check_verified("orders")
+        cache.mark_impact_check_injected("test_session", "orders")
+        cache.mark_impact_check_verified("test_session", "orders")
 
         from validate_command import main
         with patch("sys.stdin", StringIO(_make_stdin())):


### PR DESCRIPTION
Changes:

- cache.py: Updated cache implementation to be per-session based
- Multiple hook files updated: pre_commit_hook, pre_edit_hook, turn_end_hook, validate_command — all now use session-based cache
- Test files updated: All corresponding tests updated to reflect the per-session caching