### PR TITLE
fix: parse ISO8601 strings to datetime in push_query_logs templates

### DIFF
--- a/skills/push-ingestion/scripts/templates/bigquery/push_metadata.py
+++ b/skills/push-ingestion/scripts/templates/bigquery/push_metadata.py
@@ -111,7 +111,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d assets) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_metadata(
@@ -120,8 +119,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("  Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d assets) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/bigquery/push_query_logs.py
+++ b/skills/push-ingestion/scripts/templates/bigquery/push_query_logs.py
@@ -24,6 +24,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
+from dateutil.parser import isoparse
 from pycarlo.core import Client, Session
 from pycarlo.features.ingestion import IngestionService
 from pycarlo.features.ingestion.models import QueryLogEntry
@@ -63,11 +64,14 @@ def _build_query_log_entries(queries: list[dict]) -> list[QueryLogEntry]:
         if q.get("statement_type") is not None:
             extra["statement_type"] = q["statement_type"]
 
+        start_time = q.get("start_time")
+        end_time = q.get("end_time")
+
         entry = QueryLogEntry(
             query_id=q.get("query_id"),
             query_text=query_text,
-            start_time=q.get("start_time"),
-            end_time=q.get("end_time"),
+            start_time=isoparse(start_time) if start_time else None,
+            end_time=isoparse(end_time) if end_time else None,
             user=q.get("user"),
             extra=extra or None,
         )
@@ -121,7 +125,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d entries) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_query_logs(
@@ -130,8 +133,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("  Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d entries) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/databricks/push_metadata.py
+++ b/skills/push-ingestion/scripts/templates/databricks/push_metadata.py
@@ -100,7 +100,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d assets) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_metadata(
@@ -109,8 +108,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d assets) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/databricks/push_query_logs.py
+++ b/skills/push-ingestion/scripts/templates/databricks/push_query_logs.py
@@ -24,6 +24,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Any
 
+from dateutil.parser import isoparse
 from pycarlo.core import Client, Session
 from pycarlo.features.ingestion import IngestionService
 from pycarlo.features.ingestion.models import QueryLogEntry
@@ -60,12 +61,15 @@ def _build_query_log_entries(entry_dicts: list[dict[str, Any]]) -> list[QueryLog
         if d.get("read_bytes") is not None:
             extra["read_bytes"] = d["read_bytes"]
 
+        start_time = d.get("start_time")
+        end_time = d.get("end_time")
+
         entries.append(
             QueryLogEntry(
                 query_id=d.get("query_id"),
                 query_text=query_text,
-                start_time=d.get("start_time"),
-                end_time=d.get("end_time"),
+                start_time=isoparse(start_time) if start_time else None,
+                end_time=isoparse(end_time) if end_time else None,
                 user=d.get("user"),
                 returned_rows=d.get("returned_rows"),
                 extra=extra or None,
@@ -118,7 +122,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d entries) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_query_logs(
@@ -127,8 +130,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d entries) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/hive/push_metadata.py
+++ b/skills/push-ingestion/scripts/templates/hive/push_metadata.py
@@ -137,7 +137,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        print(f"  Pushing batch {batch_num}/{total_batches} ({len(batch)} assets) ...")
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_metadata(
@@ -146,8 +145,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            print(f"    Batch {batch_num}: invocation_id={invocation_id}")
+        print(f"  Pushed batch {batch_num}/{total_batches} ({len(batch)} assets) — invocation_id={invocation_id}")
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/hive/push_query_logs.py
+++ b/skills/push-ingestion/scripts/templates/hive/push_query_logs.py
@@ -148,7 +148,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        print(f"  Pushing batch {batch_num}/{total_batches} ({len(batch)} entries) ...")
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_query_logs(
@@ -157,8 +156,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            print(f"    Batch {batch_num}: invocation_id={invocation_id}")
+        print(f"  Pushed batch {batch_num}/{total_batches} ({len(batch)} entries) — invocation_id={invocation_id}")
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/redshift/push_metadata.py
+++ b/skills/push-ingestion/scripts/templates/redshift/push_metadata.py
@@ -103,7 +103,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d assets) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_metadata(
@@ -112,8 +111,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d assets) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/redshift/push_query_logs.py
+++ b/skills/push-ingestion/scripts/templates/redshift/push_query_logs.py
@@ -24,6 +24,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Any
 
+from dateutil.parser import isoparse
 from pycarlo.core import Client, Session
 from pycarlo.features.ingestion import IngestionService
 from pycarlo.features.ingestion.models import QueryLogEntry
@@ -58,12 +59,15 @@ def _build_query_log_entries(entry_dicts: list[dict[str, Any]]) -> list[QueryLog
         if d.get("elapsed_time_us") is not None:
             extra["elapsed_time_us"] = d["elapsed_time_us"]
 
+        start_time = d.get("start_time")
+        end_time = d.get("end_time")
+
         entries.append(
             QueryLogEntry(
                 query_id=d.get("query_id"),
                 query_text=query_text,
-                start_time=d.get("start_time"),
-                end_time=d.get("end_time"),
+                start_time=isoparse(start_time) if start_time else None,
+                end_time=isoparse(end_time) if end_time else None,
                 user=d.get("user"),
                 extra=extra or None,
             )
@@ -115,7 +119,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        log.info("Pushing batch %d/%d (%d entries) ...", batch_num, total_batches, len(batch))
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_query_logs(
@@ -124,8 +127,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            log.info("Batch %d: invocation_id=%s", batch_num, invocation_id)
+        log.info("Pushed batch %d/%d (%d entries) — invocation_id=%s", batch_num, total_batches, len(batch), invocation_id)
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/snowflake/push_metadata.py
+++ b/skills/push-ingestion/scripts/templates/snowflake/push_metadata.py
@@ -118,7 +118,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        print(f"  Pushing batch {batch_num}/{total_batches} ({len(batch)} assets) ...")
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_metadata(
@@ -127,8 +126,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            print(f"    Batch {batch_num}: invocation_id={invocation_id}")
+        print(f"  Pushed batch {batch_num}/{total_batches} ({len(batch)} assets) — invocation_id={invocation_id}")
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)

--- a/skills/push-ingestion/scripts/templates/snowflake/push_query_logs.py
+++ b/skills/push-ingestion/scripts/templates/snowflake/push_query_logs.py
@@ -33,6 +33,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
+from dateutil.parser import isoparse
 from pycarlo.core import Client, Session
 from pycarlo.features.ingestion import IngestionService
 from pycarlo.features.ingestion.models import QueryLogEntry
@@ -79,8 +80,8 @@ def _build_query_log_entries(queries: list[dict]) -> list[QueryLogEntry]:
 
         entries.append(
             QueryLogEntry(
-                start_time=start_time,
-                end_time=end_time,
+                start_time=isoparse(start_time) if start_time else None,
+                end_time=isoparse(end_time) if end_time else None,
                 query_text=query_text,
                 query_id=query_id,
                 user=user_name,
@@ -137,7 +138,6 @@ def push(
 
     def _push_batch(batch: list, batch_num: int) -> str | None:
         """Push a single batch using a dedicated Session (thread-safe)."""
-        print(f"  Pushing batch {batch_num}/{total_batches} ({len(batch)} entries) ...")
         client = Client(session=Session(mcd_id=key_id, mcd_token=key_token, scope="Ingestion"))
         service = IngestionService(mc_client=client)
         result = service.send_query_logs(
@@ -146,8 +146,7 @@ def push(
             events=batch,
         )
         invocation_id = service.extract_invocation_id(result)
-        if invocation_id:
-            print(f"    Batch {batch_num}: invocation_id={invocation_id}")
+        print(f"  Pushed batch {batch_num}/{total_batches} ({len(batch)} entries) — invocation_id={invocation_id}")
         return invocation_id
 
     # Push batches in parallel (each thread gets its own pycarlo Session)


### PR DESCRIPTION
## Summary

- **Bug fix:** The `push_query_logs.py` templates for bigquery, databricks, redshift, and snowflake passed ISO8601 strings directly to `QueryLogEntry(start_time=..., end_time=...)`, but pycarlo's `QueryLogEntry` expects `datetime` objects. This caused `AttributeError: 'str' object has no attribute 'astimezone'` when the SDK tried to serialize the entries for the API call. Fixed by parsing the strings with `dateutil.parser.isoparse()` before constructing the entry. (The hive template already had this fix.)
- **Logging improvement:** Consolidated the two-line batch push logging (one before push, one after with invocation_id) into a single post-push log line that includes the invocation_id inline, across all 5 warehouse templates for both `push_query_logs.py` and `push_metadata.py`.

## Affected files

All 5 warehouse templates under `skills/push-ingestion/scripts/templates/`:
- `bigquery/push_query_logs.py` — datetime fix + logging fix
- `databricks/push_query_logs.py` — datetime fix + logging fix
- `hive/push_query_logs.py` — logging fix only (datetime parsing was already correct)
- `redshift/push_query_logs.py` — datetime fix + logging fix
- `snowflake/push_query_logs.py` — datetime fix + logging fix
- `bigquery/push_metadata.py` — logging fix
- `databricks/push_metadata.py` — logging fix
- `hive/push_metadata.py` — logging fix
- `redshift/push_metadata.py` — logging fix
- `snowflake/push_metadata.py` — logging fix

## Test plan

- [ ] Verify `push_query_logs.py` no longer raises `AttributeError` when manifest contains ISO8601 string timestamps
- [ ] Verify batch push logs show invocation_id on the same line as batch info
- [ ] Verify hive template still correctly parses timestamps (was already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)