### PR TITLE
feat: add release automation

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,18 @@
+name: Create Release on Tag
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,28 @@ Plugins reference skills via symlinks so that skills are authored once and share
 - **Minor** (`1.0.0` → `1.1.0`): new features, new scripts, or significant skill content changes.
 - **Major** (`1.0.0` → `2.0.0`): breaking changes to skill behavior or hook interfaces.
 
+## Releasing
+
+Use `scripts/release.sh` to cut a release. It bumps the version in all 5 plugin config files, opens your editor for a changelog entry, commits, and tags.
+
+```bash
+# Bump patch version (1.0.0 → 1.0.1), commit + tag locally
+./scripts/release.sh patch
+
+# Bump minor version and push (triggers GitHub Release via Actions)
+./scripts/release.sh minor --push
+
+# Set an explicit version
+./scripts/release.sh 2.0.0
+
+# Preview what would happen without making changes
+./scripts/release.sh patch --dry-run
+```
+
+The script requires a clean working tree and warns if you're not on `main`. Without `--push`, it commits and tags locally so you can inspect before pushing.
+
+When a `v*` tag is pushed, a GitHub Actions workflow automatically creates a GitHub Release with auto-generated release notes.
+
 ## Architecture
 
 For the reasoning behind the plugin structure, the unified toolkit model, and guidelines on how skills and plugins interact across editors, see the [Plugin Architecture Guide](docs/plugin-architecture-guide.md).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# release.sh — Bump versions, update changelogs, commit, and tag a release.
+#
+# Usage:
+#   ./scripts/release.sh <patch|minor|major|X.Y.Z> [--push] [--dry-run]
+#
+# Examples:
+#   ./scripts/release.sh patch              # 1.0.0 → 1.0.1, commit + tag locally
+#   ./scripts/release.sh minor --push       # 1.0.0 → 1.1.0, commit + tag + push
+#   ./scripts/release.sh 2.0.0 --dry-run    # Preview what would happen
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ── Plugin config files (version source of truth) ──────────────────────────
+VERSION_FILES=(
+  "plugins/claude-code/.claude-plugin/plugin.json"
+  "plugins/cursor/.cursor-plugin/plugin.json"
+  "plugins/copilot/plugin.json"
+  "plugins/codex/.codex-plugin/plugin.json"
+  "plugins/opencode/package.json"
+)
+
+CHANGELOG_FILES=(
+  "plugins/claude-code/CHANGELOG.md"
+  "plugins/cursor/CHANGELOG.md"
+  "plugins/copilot/CHANGELOG.md"
+  "plugins/codex/CHANGELOG.md"
+  "plugins/opencode/CHANGELOG.md"
+)
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+PUSH=false
+DRY_RUN=false
+BUMP_TYPE=""
+
+# ── Parse arguments ─────────────────────────────────────────────────────────
+usage() {
+  echo "Usage: $0 <patch|minor|major|X.Y.Z> [--push] [--dry-run]"
+  exit 1
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --push)    PUSH=true ;;
+    --dry-run) DRY_RUN=true ;;
+    patch|minor|major) BUMP_TYPE="$arg" ;;
+    [0-9]*.[0-9]*.[0-9]*)  BUMP_TYPE="explicit"; EXPLICIT_VERSION="$arg" ;;
+    -h|--help) usage ;;
+    *) echo "Unknown argument: $arg"; usage ;;
+  esac
+done
+
+[[ -z "$BUMP_TYPE" ]] && usage
+
+# ── Read current version ────────────────────────────────────────────────────
+SOURCE_FILE="$REPO_ROOT/${VERSION_FILES[0]}"
+CURRENT_VERSION=$(grep -o '"version": *"[^"]*"' "$SOURCE_FILE" | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+  echo "Error: Could not read current version from $SOURCE_FILE"
+  exit 1
+fi
+
+# ── Compute next version ────────────────────────────────────────────────────
+if [[ "$BUMP_TYPE" == "explicit" ]]; then
+  NEW_VERSION="$EXPLICIT_VERSION"
+else
+  IFS='.' read -r V_MAJOR V_MINOR V_PATCH <<< "$CURRENT_VERSION"
+  case "$BUMP_TYPE" in
+    patch) V_PATCH=$((V_PATCH + 1)) ;;
+    minor) V_MINOR=$((V_MINOR + 1)); V_PATCH=0 ;;
+    major) V_MAJOR=$((V_MAJOR + 1)); V_MINOR=0; V_PATCH=0 ;;
+  esac
+  NEW_VERSION="$V_MAJOR.$V_MINOR.$V_PATCH"
+fi
+
+echo "Current version: $CURRENT_VERSION"
+echo "Next version:    $NEW_VERSION"
+echo ""
+
+# ── Preflight checks ───────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == false ]]; then
+  if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+    echo "Error: Working tree is not clean. Commit or stash changes first."
+    exit 1
+  fi
+
+  CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+  if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    echo "Warning: You are on branch '$CURRENT_BRANCH', not 'main'."
+    read -rp "Continue anyway? [y/N] " confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+  fi
+
+  if git -C "$REPO_ROOT" rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
+    echo "Error: Tag v$NEW_VERSION already exists."
+    exit 1
+  fi
+fi
+
+# ── Changelog entry ─────────────────────────────────────────────────────────
+RELEASE_DATE=$(date +%Y-%m-%d)
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/release-changelog.XXXXXX")
+
+# Pre-fill with commits since last tag
+LAST_TAG=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "")
+{
+  echo "## [$NEW_VERSION] - $RELEASE_DATE"
+  echo ""
+  echo "### Changed"
+  echo ""
+  if [[ -n "$LAST_TAG" ]]; then
+    git -C "$REPO_ROOT" log --oneline "$LAST_TAG..HEAD" | sed 's/^/- /'
+  else
+    git -C "$REPO_ROOT" log --oneline -20 | sed 's/^/- /'
+  fi
+  echo ""
+  echo "<!-- Edit the changelog entry above. Lines starting with <!-- are removed. -->"
+} > "$TMPFILE"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] Would open editor for changelog entry. Template:"
+  echo "---"
+  cat "$TMPFILE"
+  echo "---"
+else
+  # Open editor for the user to refine
+  "${EDITOR:-vi}" "$TMPFILE"
+
+  # Strip HTML comments
+  CHANGELOG_ENTRY=$(sed '/^<!--/d' "$TMPFILE")
+
+  if [[ -z "$(echo "$CHANGELOG_ENTRY" | tr -d '[:space:]')" ]]; then
+    echo "Error: Changelog entry is empty. Aborting."
+    rm -f "$TMPFILE"
+    exit 1
+  fi
+fi
+
+rm -f "$TMPFILE"
+
+# ── Update version files ───────────────────────────────────────────────────
+echo ""
+for file in "${VERSION_FILES[@]}"; do
+  filepath="$REPO_ROOT/$file"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] Would update version in $file"
+  else
+    sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" "$filepath"
+    echo "Updated version in $file"
+  fi
+done
+
+# ── Update changelogs ──────────────────────────────────────────────────────
+echo ""
+for file in "${CHANGELOG_FILES[@]}"; do
+  filepath="$REPO_ROOT/$file"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] Would prepend changelog entry to $file"
+  else
+    # Insert the new entry after the first blank line following the header
+    # (after the "Format follows..." preamble lines)
+    awk -v entry="$CHANGELOG_ENTRY" '
+      /^## \[/ && !inserted {
+        print entry
+        print ""
+        inserted = 1
+      }
+      { print }
+    ' "$filepath" > "${filepath}.tmp" && mv "${filepath}.tmp" "$filepath"
+    echo "Updated changelog in $file"
+  fi
+done
+
+# ── Git commit and tag ─────────────────────────────────────────────────────
+echo ""
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] Would commit: release: v$NEW_VERSION"
+  echo "[dry-run] Would tag: v$NEW_VERSION"
+else
+  cd "$REPO_ROOT"
+  git add "${VERSION_FILES[@]}" "${CHANGELOG_FILES[@]}"
+  git commit -m "release: v$NEW_VERSION"
+  git tag "v$NEW_VERSION"
+  echo "Committed: release: v$NEW_VERSION"
+  echo "Tagged: v$NEW_VERSION"
+fi
+
+# ── Push ────────────────────────────────────────────────────────────────────
+echo ""
+if [[ "$PUSH" == true ]]; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] Would push to origin with tags"
+  else
+    git -C "$REPO_ROOT" push origin HEAD --tags
+    echo "Pushed to origin with tags"
+  fi
+else
+  if [[ "$DRY_RUN" == false ]]; then
+    echo "Done! To publish the release, run:"
+    echo "  git push origin main --tags"
+  fi
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/release.sh` — bumps version across all 5 plugin configs, opens `$EDITOR` for changelog entry, commits, and tags
- Add `.github/workflows/release-on-tag.yml` — auto-creates a GitHub Release when a `v*` tag is pushed
- Document the release process in `CONTRIBUTING.md`

## Details

**Release script** (`scripts/release.sh`):
- Accepts `patch | minor | major | X.Y.Z`
- Reads current version from claude-code plugin.json (source of truth)
- Validates clean working tree, warns if not on `main`
- Opens editor with changelog template pre-filled with commits since last tag
- Updates all 5 plugin JSON files + all 5 CHANGELOGs
- `--push` flag to push after tagging, `--dry-run` to preview

**GitHub Actions workflow**: ~10-line workflow triggered on `v*` tag push, creates a Release with auto-generated notes.

## After merge

Tag current HEAD as `v1.0.0` to establish the baseline for future releases:
```bash
git tag v1.0.0
git push origin v1.0.0
```

## Test plan

- [x] `./scripts/release.sh patch --dry-run` — correct version computation and file targets
- [x] `./scripts/release.sh minor --dry-run` — minor bump works
- [x] `./scripts/release.sh major --dry-run` — major bump works
- [x] `./scripts/release.sh 2.5.0 --dry-run` — explicit version works
- [ ] After merge: tag `v1.0.0`, push tag, verify GitHub Release is created
- [ ] Run `./scripts/release.sh patch` end-to-end on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)