### PR TITLE
docs: polish README, releasing guide, and architecture doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,17 @@ Plugins reference skills via symlinks so that skills are authored once and share
 
 Use `scripts/release.sh` to cut a release. It bumps the version in all 5 plugin config files, opens your editor for a changelog entry, commits, and tags.
 
+### Prerequisites
+
+- A baseline tag must exist (e.g., `v1.0.0`). If this is the first release, create one manually:
+  ```bash
+  git tag v1.0.0
+  git push origin v1.0.0
+  ```
+- You must be on `main` with a clean working tree.
+
+### Usage
+
 ```bash
 # Bump patch version (1.0.0 → 1.0.1), commit + tag locally
 ./scripts/release.sh patch
@@ -110,9 +121,24 @@ Use `scripts/release.sh` to cut a release. It bumps the version in all 5 plugin 
 ./scripts/release.sh patch --dry-run
 ```
 
-The script requires a clean working tree and warns if you're not on `main`. Without `--push`, it commits and tags locally so you can inspect before pushing.
+### What the script does
 
-When a `v*` tag is pushed, a GitHub Actions workflow automatically creates a GitHub Release with auto-generated release notes.
+1. Reads the current version from `plugins/claude-code/.claude-plugin/plugin.json`
+2. Computes the next version based on the bump type
+3. Opens `$EDITOR` with a changelog template pre-filled with commits since the last tag
+4. Updates `"version"` in all 5 plugin config files
+5. Prepends the changelog entry to all 5 `CHANGELOG.md` files
+6. Creates a commit (`release: vX.Y.Z`) and a git tag (`vX.Y.Z`)
+
+Without `--push`, the commit and tag stay local so you can inspect before pushing. To publish:
+
+```bash
+git push origin main --tags
+```
+
+### GitHub Release
+
+When a `v*` tag is pushed, a GitHub Actions workflow (`.github/workflows/release-on-tag.yml`) automatically creates a GitHub Release with auto-generated release notes from PR titles since the previous tag.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mc-agent-toolkit
+# MC Agent Toolkit
 
-Monte Carlo's official toolkit for AI coding agents. Integrates Monte Carlo's data observability platform — lineage, monitoring, validation, and alerting — directly into your development workflow.
+Monte Carlo's official toolkit for AI coding agents. Brings data observability — lineage, monitoring, validation, alerting, and metadata ingestion — directly into your development workflow. The toolkit bundles multiple skills into a single plugin that works across supported editors.
 
 ## Features
 
@@ -70,7 +70,7 @@ See the [skills directory](skills/) for the full list and individual READMEs.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding skills, creating plugins, and submitting pull requests.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding skills, creating plugins, and submitting pull requests. It also covers [plugin architecture](docs/plugin-architecture-guide.md) and [releasing new versions](CONTRIBUTING.md#releasing).
 
 ## License
 

--- a/docs/plugin-architecture-guide.md
+++ b/docs/plugin-architecture-guide.md
@@ -24,12 +24,12 @@ As more skills are added, a per-skill-per-editor plugin model creates `skills ×
 **Option A — Toolkit as invisible plumbing.** A single plugin per editor handles distribution (MCP, auth, updates), but the plugin identity is hidden from users. All user-facing surfaces show individual skill names only (e.g., "MC Prevent").
 
 - *Pro:* Individual skills get standalone brand recognition.
-- *Con:* Users see a plugin name (`mc-agent-toolkit`) in their editor's plugin list that doesn't match what they interact with. No natural place for enable/disable configuration. Hard to make truly invisible across all editors.
+- *Con:* Users see a plugin name (`mc-agent-toolkit`) in their editor's plugin list that doesn't match what they interact with. No natural place for enable/disable configuration. Difficult to make truly invisible across all editors.
 
 **Option B — Unified toolkit with namespaced features (chosen).** One plugin per editor named `mc-agent-toolkit`. Each skill is a named feature within it. Users understand they installed "Monte Carlo's toolkit" and interact with features like "MC Prevent" inside it.
 
 - *Pro:* Consistent identity across all editors. Natural enable/disable model. New skills appear as new features in a product users already know. MCP and auth configured once. Single install, single update path.
-- *Con:* Users get all features, not just the ones they want (mitigated by enable/disable config). A bug in one feature's hooks could theoretically affect the plugin — mitigated by feature isolation (see below).
+- *Con:* Users get all features, not just the ones they want (mitigated by enable/disable config). A bug in one feature's hooks could theoretically affect the plugin, mitigated by feature isolation (see below).
 
 **Option C — Separate plugins per skill.** Each skill that needs a plugin gets its own. Distribution is handled by install scripts, not by bundling.
 


### PR DESCRIPTION
## Summary

- Rename README title to "MC Agent Toolkit" and broaden intro paragraph
- Expand the Releasing section in CONTRIBUTING.md with prerequisites and step-by-step details
- Minor proofreading in plugin architecture guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)