### PR TITLE
feat: add prevent trigger evals and shared eval runner

### DIFF
--- a/plugins/claude-code/evals/prevent/trigger-evals.json
+++ b/plugins/claude-code/evals/prevent/trigger-evals.json
@@ -1,0 +1,156 @@
+{
+  "skill": "monte-carlo-prevent",
+  "description": "Trigger accuracy evals for the monte-carlo-prevent skill. Each case specifies whether the skill SHOULD or SHOULD NOT be triggered by the given prompt.",
+  "cases": [
+    {
+      "id": "should-01",
+      "prompt": "I need to add a new column to the orders model in models/marts/orders.sql. Can you help?",
+      "expected": "trigger",
+      "rationale": "Direct request to modify a dbt model — requires impact assessment before editing"
+    },
+    {
+      "id": "should-02",
+      "prompt": "What's the health status of the dim_customers table? Are there any active alerts?",
+      "expected": "trigger",
+      "rationale": "Asking about table health and alerts — core Workflow 1 use case"
+    },
+    {
+      "id": "should-03",
+      "prompt": "I'm refactoring the join logic in our stg_payments model to use a left join instead of inner join.",
+      "expected": "trigger",
+      "rationale": "Planned change to a dbt model — must run impact assessment before editing"
+    },
+    {
+      "id": "should-04",
+      "prompt": "We got a freshness alert on the raw_events table. What's going on and what's downstream?",
+      "expected": "trigger",
+      "rationale": "Alert triage with downstream impact — Workflow 3"
+    },
+    {
+      "id": "should-05",
+      "prompt": "Can you open models/staging/stg_orders.sql? I want to review it before making changes.",
+      "expected": "trigger",
+      "rationale": "Opening a .sql file in models/ — auto-activate Workflow 1"
+    },
+    {
+      "id": "should-06",
+      "prompt": "What's the blast radius if I change the date_spine macro? Which models use it?",
+      "expected": "trigger",
+      "rationale": "Macro change affecting downstream models — must gate and run impact assessment"
+    },
+    {
+      "id": "should-07",
+      "prompt": "I want to add a filter on status = 'active' to the fct_subscriptions model.",
+      "expected": "trigger",
+      "rationale": "Adding a filter to a dbt model — requires impact assessment"
+    },
+    {
+      "id": "should-08",
+      "prompt": "The row counts on analytics.prod.user_events have been dropping for the past week. Can you check Monte Carlo?",
+      "expected": "trigger",
+      "rationale": "Asking about data quality anomalies on a specific table"
+    },
+    {
+      "id": "should-09",
+      "prompt": "I'm updating the snapshot strategy in snapshots/scd_accounts.sql to use a different unique key.",
+      "expected": "trigger",
+      "rationale": "Snapshot modification — sensitive change that can affect historical tracking"
+    },
+    {
+      "id": "should-10",
+      "prompt": "This model uses {{ ref('stg_customers') }} and {{ source('stripe', 'payments') }}. What do we know about those tables?",
+      "expected": "trigger",
+      "rationale": "References ref() and source() — clear dbt model context"
+    },
+    {
+      "id": "should-11",
+      "prompt": "I need to add a new metric column to dim_products and want to make sure nothing breaks downstream.",
+      "expected": "trigger",
+      "rationale": "Adding a column to a model with downstream concern — impact assessment + monitor offer"
+    },
+    {
+      "id": "should-12",
+      "prompt": "Can you check if there are any monitors on the fct_orders table? I want to know what's covered.",
+      "expected": "trigger",
+      "rationale": "Asking about monitor coverage on a specific table"
+    },
+    {
+      "id": "should-13",
+      "prompt": "We're seeing NULL values in the revenue column of our daily_metrics model. Is this a known issue in Monte Carlo?",
+      "expected": "trigger",
+      "rationale": "Data quality issue on a specific model — alert triage and investigation"
+    },
+    {
+      "id": "should-14",
+      "prompt": "I want to rename the customer_id column to cust_id in the stg_customers model. What will this affect?",
+      "expected": "trigger",
+      "rationale": "Schema change on a dbt model — requires blast radius analysis"
+    },
+    {
+      "id": "should-15",
+      "prompt": "Let me look at the lineage for the revenue_summary table before I make any changes.",
+      "expected": "trigger",
+      "rationale": "Requesting lineage context before changes — Workflow 1"
+    },
+    {
+      "id": "should-not-01",
+      "prompt": "Can you help me update the dbt_project.yml to change the project name?",
+      "expected": "no-trigger",
+      "rationale": "Configuration file edit — not a model, no Monte Carlo context needed"
+    },
+    {
+      "id": "should-not-02",
+      "prompt": "I need to add a new row to seeds/country_codes.csv with the entry for Antarctica.",
+      "expected": "no-trigger",
+      "rationale": "Seed file edit — explicitly excluded from activation"
+    },
+    {
+      "id": "should-not-03",
+      "prompt": "Can you write a quick SQL query to count duplicates in a CSV I just uploaded? It's not part of our dbt project.",
+      "expected": "no-trigger",
+      "rationale": "Ad-hoc SQL unrelated to a dbt project"
+    },
+    {
+      "id": "should-not-04",
+      "prompt": "Help me set up a new Monte Carlo integration for our Snowflake warehouse.",
+      "expected": "no-trigger",
+      "rationale": "Pull-based integration setup — not prevent/observability context"
+    },
+    {
+      "id": "should-not-05",
+      "prompt": "I need to update our profiles.yml to point to the new development database.",
+      "expected": "no-trigger",
+      "rationale": "dbt config file — explicitly excluded"
+    },
+    {
+      "id": "should-not-06",
+      "prompt": "Can you help me write a Python script to parse our Airflow DAG logs?",
+      "expected": "no-trigger",
+      "rationale": "General Python scripting — no dbt/SQL/table context"
+    },
+    {
+      "id": "should-not-07",
+      "prompt": "How do I fix this git merge conflict in my PR?",
+      "expected": "no-trigger",
+      "rationale": "General git question — unrelated to data observability"
+    },
+    {
+      "id": "should-not-08",
+      "prompt": "Can you update the analyses/quarterly_report.sql file with the new fiscal year logic?",
+      "expected": "no-trigger",
+      "rationale": "Analysis file — explicitly excluded from activation"
+    },
+    {
+      "id": "should-not-09",
+      "prompt": "I need to add a new schema test to our schema.yml file for the email column.",
+      "expected": "no-trigger",
+      "rationale": "Test YAML file edit — not asking about data quality, just adding test config"
+    },
+    {
+      "id": "should-not-10",
+      "prompt": "Can you help me configure Slack notifications for Monte Carlo incidents?",
+      "expected": "no-trigger",
+      "rationale": "Monte Carlo notification setup — not model/table observability context"
+    }
+  ]
+}

--- a/plugins/claude-code/evals/run_evals.py
+++ b/plugins/claude-code/evals/run_evals.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # ruff: noqa
 """
-Trigger accuracy eval for the montecarlo-push-ingestion skill.
+Trigger accuracy eval runner for mc-agent-toolkit skills.
 
 Loads the skill description from SKILL.md and runs each case from trigger-evals.json
 through the Claude API to check whether the skill would be triggered.
@@ -9,7 +9,8 @@ through the Claude API to check whether the skill would be triggered.
 Usage:
     pip install anthropic
     export ANTHROPIC_API_KEY=sk-ant-...
-    python run_evals.py [--model claude-sonnet-4-6] [--threshold 0.85]
+    python run_evals.py --skill prevent
+    python run_evals.py --skill push-ingestion [--model claude-sonnet-4-6] [--threshold 0.85]
 
 Exit codes:
     0 — pass rate meets threshold
@@ -25,7 +26,8 @@ from pathlib import Path
 import anthropic
 
 EVALS_DIR = Path(__file__).parent
-SKILL_DIR = EVALS_DIR.parent / "skills" / "push-ingestion"
+PLUGIN_DIR = EVALS_DIR.parent
+SKILLS_DIR = PLUGIN_DIR / "skills"
 
 JUDGE_SYSTEM_PROMPT = """You are evaluating whether a Claude skill should be triggered for a given user message.
 
@@ -37,8 +39,7 @@ Respond with exactly one word: TRIGGER if the skill should activate for this mes
 
 Rules:
 - Trigger if the message clearly falls within the skill's stated scope
-- Do NOT trigger for general Monte Carlo questions unrelated to the push ingestion model
-- Do NOT trigger for pull-based integrations, monitor configuration, or alerting
+- Do NOT trigger for messages outside the skill's domain
 - When in doubt, lean toward NO_TRIGGER
 """
 
@@ -61,8 +62,8 @@ def load_skill_description(skill_dir: Path) -> tuple[str, str]:
 
     fm = frontmatter.group(1)
     name_match = re.search(r"^name:\s*(.+)$", fm, re.MULTILINE)
-    # description may be multi-line (YAML block scalar with >)
-    desc_match = re.search(r"^description:\s*>\n((?:  .+\n?)+)", fm, re.MULTILINE)
+    # description may be multi-line (YAML block scalar with > or |)
+    desc_match = re.search(r"^description:\s*[>|]\n((?:  .+\n?)+)", fm, re.MULTILINE)
     if not desc_match:
         desc_match = re.search(r"^description:\s*(.+)$", fm, re.MULTILINE)
 
@@ -93,20 +94,40 @@ def judge(client: anthropic.Anthropic, model: str, skill_name: str, skill_descri
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Run trigger accuracy evals for the push-ingestion skill")
+    parser = argparse.ArgumentParser(description="Run trigger accuracy evals for an mc-agent-toolkit skill")
+    parser.add_argument("--skill", required=True, help="Skill directory name (e.g. 'prevent', 'push-ingestion')")
     parser.add_argument("--model", default="claude-sonnet-4-6", help="Claude model to use as judge")
     parser.add_argument("--threshold", type=float, default=0.85, help="Minimum pass rate to exit 0 (default: 0.85)")
-    parser.add_argument("--evals", default=str(EVALS_DIR / "trigger-evals.json"), help="Path to eval cases JSON")
+    parser.add_argument("--evals", default=None, help="Path to eval cases JSON (default: <skill>/trigger-evals.json)")
+    parser.add_argument("--dry-run", action="store_true", help="Load and validate cases without calling the API")
     args = parser.parse_args()
 
-    cases = json.loads(Path(args.evals).read_text())["cases"]
-    skill_name, skill_description = load_skill_description(SKILL_DIR)
+    skill_dir = SKILLS_DIR / args.skill
+    if not skill_dir.exists():
+        print(f"Error: Skill directory not found: {skill_dir}")
+        sys.exit(1)
+
+    evals_path = Path(args.evals) if args.evals else EVALS_DIR / args.skill / "trigger-evals.json"
+    if not evals_path.exists():
+        print(f"Error: Eval cases not found: {evals_path}")
+        sys.exit(1)
+
+    cases = json.loads(evals_path.read_text())["cases"]
+    skill_name, skill_description = load_skill_description(skill_dir)
 
     print(f"Skill:     {skill_name}")
     print(f"Model:     {args.model}")
     print(f"Cases:     {len(cases)}")
-    print(f"Threshold: {args.threshold:.0%}\n")
+    print(f"Threshold: {args.threshold:.0%}")
 
+    if args.dry_run:
+        print(f"\n[dry-run] Loaded {len(cases)} cases for {skill_name}")
+        print(f"[dry-run] Skill description: {skill_description[:120]}...")
+        for case in cases:
+            print(f"  [{case['id']}] ({case['expected']}) {case['prompt'][:75]}{'…' if len(case['prompt']) > 75 else ''}")
+        sys.exit(0)
+
+    print()
     client = anthropic.Anthropic()
 
     results = []


### PR DESCRIPTION
## Summary

- Add 25 trigger accuracy test cases for the `monte-carlo-prevent` skill (15 should-trigger, 10 should-not-trigger)
- Refactor `run_evals.py` into a shared runner at `plugins/claude-code/evals/run_evals.py` that works for any skill via `--skill` flag
- Remove the push-ingestion-specific `run_evals.py` (replaced by shared runner)

## Usage

```bash
# Dry-run (no API key needed)
python3 plugins/claude-code/evals/run_evals.py --skill prevent --dry-run

# Full run
export ANTHROPIC_API_KEY=sk-ant-...
python3 plugins/claude-code/evals/run_evals.py --skill prevent
python3 plugins/claude-code/evals/run_evals.py --skill push-ingestion
```

## Test plan

- [x] `--dry-run` loads and validates all 25 prevent cases
- [x] `--dry-run` still works for push-ingestion with shared runner
- [ ] Full run against API (requires `ANTHROPIC_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)