### PR TITLE
fix: correct marketplace add command to use repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The toolkit bundles the following capabilities as a single **mc-agent-toolkit** 
 
 1. Add the marketplace:
    ```
-   /plugin marketplace add monte-carlo-data/mc-marketplace
+   /plugin marketplace add monte-carlo-data/mc-agent-toolkit
    ```
 2. Install the plugin:
    ```

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -8,7 +8,7 @@ Claude Code plugin that brings Monte Carlo data observability into your editor. 
 
 1. Add the marketplace:
    ```
-   /plugin marketplace add monte-carlo-data/mc-marketplace
+   /plugin marketplace add monte-carlo-data/mc-agent-toolkit
    ```
 2. Install the plugin:
    ```


### PR DESCRIPTION
## Summary

- Fix `/plugin marketplace add` command in README and Claude Code README
- Changed from `monte-carlo-data/mc-marketplace` (non-existent repo) to `monte-carlo-data/mc-agent-toolkit` (actual repo)

The command takes a GitHub repo path, not the marketplace logical name. The install command (`/plugin install mc-agent-toolkit@mc-marketplace`) is correct and unchanged — `mc-marketplace` there refers to the marketplace name defined in `marketplace.json`.

## Test plan

- [ ] Run `/plugin marketplace add monte-carlo-data/mc-agent-toolkit` — should succeed
- [ ] Run `/plugin install mc-agent-toolkit@mc-marketplace` — should install the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)