### PR TITLE
Add monitor-creation skill and wire into all editor plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ Welcome! We appreciate contributions from both Monte Carlo engineers and the com
 ```
 mc-agent-toolkit/
 ├── skills/                              # Shared skill definitions (platform-agnostic)
+│   ├── monitor-creation/
+│   │   ├── SKILL.md
+│   │   └── references/
 │   ├── prevent/
 │   │   ├── SKILL.md
 │   │   └── references/
@@ -22,7 +25,7 @@ mc-agent-toolkit/
 │   ├── claude-code/                     # Unified mc-agent-toolkit plugin
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── hooks/prevent/              # Hook adapters (thin, call shared lib)
-│   │   ├── skills/ (prevent, generate-validation-notebook, push-ingestion → symlinks)
+│   │   ├── skills/ (monitor-creation, prevent, generate-validation-notebook, push-ingestion → symlinks)
 │   │   └── commands/ (prevent/, push-ingestion/)
 │   │
 │   ├── cursor/                          # Unified mc-agent-toolkit plugin

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The toolkit bundles the following capabilities as a single **mc-agent-toolkit** 
 
 | Feature | Description | Details |
 |---|---|---|
+| **Monitor Creation** | Guides AI agents through creating monitors correctly — validates tables, fields, and parameters before generating monitors-as-code YAML. | [README](skills/monitor-creation/README.md) |
 | **Prevent** | Surfaces lineage, alerts, and blast radius before code changes. Generates monitors-as-code and targeted validation queries to prevent data incidents. | [README](skills/prevent/README.md) |
 | **Generate Validation Notebook** | Generates SQL validation notebooks for dbt model changes, with targeted queries comparing baseline and development data. | [README](skills/generate-validation-notebook/README.md) |
 | **Push Ingestion** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. | [README](skills/push-ingestion/README.md) |

--- a/docs/plugin-architecture-guide.md
+++ b/docs/plugin-architecture-guide.md
@@ -66,6 +66,9 @@ This reflects the **current repository structure**.
 ```
 mc-agent-toolkit/
 ├── skills/                              # Shared skill definitions (platform-agnostic)
+│   ├── monitor-creation/
+│   │   ├── SKILL.md
+│   │   └── references/
 │   ├── prevent/
 │   │   ├── SKILL.md
 │   │   └── references/
@@ -94,6 +97,7 @@ mc-agent-toolkit/
 │   │   ├── hooks/
 │   │   │   └── prevent/                 # Thin adapters → plugins/shared/prevent/lib/
 │   │   ├── skills/
+│   │   │   ├── monitor-creation → symlink
 │   │   │   ├── prevent → symlink
 │   │   │   ├── generate-validation-notebook → symlink
 │   │   │   └── push-ingestion → symlink
@@ -106,6 +110,7 @@ mc-agent-toolkit/
 │   │   ├── hooks/
 │   │   │   └── prevent/                 # MC Prevent hook adapters
 │   │   ├── skills/
+│   │   │   ├── monitor-creation → symlink
 │   │   │   └── prevent → symlink
 │   │   └── mcp.json
 │   │
@@ -125,6 +130,7 @@ mc-agent-toolkit/
 │   │   │       ├── pre_edit_hook.py
 │   │   │       └── ...
 │   │   ├── skills/
+│   │   │   ├── monitor-creation → symlink
 │   │   │   └── prevent → symlink
 │   │   └── scripts/
 │   │       ├── install.sh               # Installs hooks to .github/hooks/
@@ -132,6 +138,7 @@ mc-agent-toolkit/
 │   │
 │   └── codex/                           # mc-agent-toolkit plugin for Codex
 │       └── skills/
+│           ├── monitor-creation → symlink
 │           └── prevent → symlink
 ```
 

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-04-08
+
+### Added
+
+- Monitor Creation skill — guides AI agents through creating Monte Carlo monitors correctly with validation, field-type compatibility checks, and monitors-as-code YAML generation. Covers metric, validation, custom SQL, comparison, and table monitors.
+
 ## [1.0.0] - 2026-04-07
 
 ### Changed

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -35,6 +35,7 @@ Restart Claude Code after installing.
 
 | Feature | Description | Details |
 |---|---|---|
+| **Monitor Creation** | Guides AI agents through creating monitors correctly — validates tables, fields, and parameters before generating monitors-as-code YAML. | [Skill README](../../skills/monitor-creation/README.md) |
 | **Prevent** | Gates dbt model edits with impact assessments, generates monitors-as-code, and produces targeted validation queries. Full hook enforcement. | [Skill README](../../skills/prevent/README.md) |
 | **Generate Validation Notebook** | Generates SQL validation notebooks for dbt model changes from a PR or local repo. | [Skill README](../../skills/generate-validation-notebook/README.md) |
 | **Push Ingestion** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. Includes 10 `/mc-*` slash commands. | [Skill README](../../skills/push-ingestion/README.md) |

--- a/plugins/claude-code/skills/monitor-creation
+++ b/plugins/claude-code/skills/monitor-creation
@@ -1,0 +1,1 @@
+../../../skills/monitor-creation

--- a/plugins/codex/skills/monitor-creation
+++ b/plugins/codex/skills/monitor-creation
@@ -1,0 +1,1 @@
+../../../skills/monitor-creation

--- a/plugins/copilot/skills/monitor-creation
+++ b/plugins/copilot/skills/monitor-creation
@@ -1,0 +1,1 @@
+../../../skills/monitor-creation

--- a/plugins/cursor/skills/monitor-creation
+++ b/plugins/cursor/skills/monitor-creation
@@ -1,0 +1,1 @@
+../../../skills/monitor-creation

--- a/plugins/opencode/skills/monitor-creation
+++ b/plugins/opencode/skills/monitor-creation
@@ -1,0 +1,1 @@
+../../../skills/monitor-creation

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,7 @@ Skills are platform-agnostic instruction sets that tell an AI coding agent what 
 
 | Skill | Description |
 |---|---|
+| **[Monitor Creation](monitor-creation/)** | Guides AI agents through creating monitors correctly — validates tables, fields, and parameters before generating monitors-as-code YAML. |
 | **[Prevent](prevent/)** | Surfaces Monte Carlo context (lineage, alerts, blast radius) before code changes, generates monitors-as-code, and produces targeted validation queries. |
 | **[Generate Validation Notebook](generate-validation-notebook/)** | Generates SQL validation notebooks for dbt model changes, with targeted queries comparing baseline and development data. |
 | **[Push Ingestion](push-ingestion/)** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. |

--- a/skills/monitor-creation/README.md
+++ b/skills/monitor-creation/README.md
@@ -1,0 +1,82 @@
+# Monte Carlo Monitor Creation Skill
+
+Guide AI agents through creating Monte Carlo monitors correctly — validating tables exist, checking field names and types, choosing the right monitor type, and generating monitors-as-code YAML. Eliminates common errors like invalid field types, nonexistent table references, and missing required parameters.
+
+## Editor & Stack Compatibility
+
+The skill works with any AI editor that supports MCP and the Agent Skills format — including Claude Code, Cursor, and VS Code.
+
+All warehouses supported by Monte Carlo work with monitor creation. The skill validates table and column references against your actual warehouse schema via the Monte Carlo API.
+
+## Prerequisites
+
+- Claude Code, Cursor, VS Code or any editor with MCP support
+- Monte Carlo account with Editor role or above
+- [MC CLI](https://docs.getmontecarlo.com/docs/using-the-cli) installed for monitor deployment (`pip install montecarlodata`)
+
+## Setup
+
+### Via the mc-agent-toolkit plugin (recommended)
+
+Install the plugin for your editor — it bundles the skill, hooks, MCP server, and permissions automatically. See the [main README](../../README.md#installing-the-plugin-recommended) for editor-specific instructions.
+
+### Standalone
+
+1. Configure the Monte Carlo MCP server:
+   ```
+   claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+   ```
+
+2. Install the skill:
+   ```bash
+   npx skills add monte-carlo-data/mc-agent-toolkit --skill monitor-creation
+   ```
+
+3. Authenticate: run `/mcp` in your editor, select `monte-carlo-mcp`, and complete the OAuth flow.
+
+4. Verify: ask your editor "Test my Monte Carlo connection" — it should call `testConnection` and confirm.
+
+<details>
+<summary>Legacy: header-based auth (for MCP clients without HTTP transport)</summary>
+
+If your MCP client doesn't support HTTP transport, use `.mcp.json.example` with `npx mcp-remote` and header-based authentication. See the [MCP server docs](https://docs.getmontecarlo.com/docs/mcp-server) for details.
+
+</details>
+
+## How to use it
+
+Tell your AI editor what you want to monitor — describe the table, the condition, or the data quality concern. The skill guides the agent through table resolution, schema validation, monitor type selection, parameter building, confirmation, and YAML generation. No special commands needed.
+
+### Monitor types
+
+| Type | When to use |
+|---|---|
+| **Metric** | Track a numeric aggregate over time — row counts, sums, averages, min/max on a column |
+| **Validation** | Assert a condition that should always be true — null checks, range constraints, uniqueness |
+| **Comparison** | Compare two tables or queries — staging vs. production, pre- vs. post-migration |
+| **Custom SQL** | Write arbitrary SQL for complex business logic that doesn't fit the other types |
+| **Table** | Monitor table-level health — freshness, volume, and schema changes |
+
+### Deploying generated monitors
+
+When Claude generates a monitor, it saves the YAML to `monitors/<table>.yml`. Deploy with:
+
+```bash
+montecarlo monitors apply --dry-run    # preview
+montecarlo monitors apply --auto-yes   # apply
+```
+
+Your project needs a `montecarlo.yml` config in the working directory:
+
+```yaml
+version: 1
+namespace: <your-namespace>
+default_resource: <your-warehouse-name>
+```
+
+## Example prompts
+
+- "Create a null check monitor for the orders table"
+- "Monitor freshness for all tables in the analytics schema"
+- "Set up a comparison monitor between staging and production orders"
+- "Add a custom SQL monitor to detect orphan records"

--- a/skills/monitor-creation/SKILL.md
+++ b/skills/monitor-creation/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: monte-carlo-monitor-creation
+description: |
+  Guides AI agents through creating Monte Carlo monitors via MCP tools.
+  Activates when a user asks to create, add, or set up a monitor for a table,
+  field, metric, or data quality rule. Produces monitors-as-code (MaC) YAML
+  that can be applied via the Monte Carlo CLI or CI/CD. All creation tools run
+  in dry-run mode and return YAML -- they do not directly create monitors.
+version: 1.0.0
+---
+
+# Monte Carlo Monitor Creation Skill
+
+This skill teaches you to create Monte Carlo monitors correctly via MCP. Every creation tool runs in **dry-run mode** and returns monitors-as-code (MaC) YAML. No monitors are created directly -- the user applies the YAML via the Monte Carlo CLI or CI/CD.
+
+Reference files live next to this skill file. **Use the Read tool** (not MCP resources) to access them:
+
+- Metric monitor details: `references/metric-monitor.md` (relative to this file)
+- Validation monitor details: `references/validation-monitor.md` (relative to this file)
+- Custom SQL monitor details: `references/custom-sql-monitor.md` (relative to this file)
+- Comparison monitor details: `references/comparison-monitor.md` (relative to this file)
+- Table monitor details: `references/table-monitor.md` (relative to this file)
+
+## When to activate this skill
+
+Activate when the user:
+
+- Asks to create, add, or set up a monitor (e.g. "add a monitor for...", "create a freshness check on...", "set up validation for...")
+- Mentions monitoring a specific table, field, or metric
+- Wants to check data quality rules or enforce data contracts
+- Asks about monitoring options for a table or dataset
+- Requests monitors-as-code YAML generation
+- Wants to add monitoring after new transformation logic (when the prevent skill is not active)
+
+## When NOT to activate this skill
+
+Do not activate when the user is:
+
+- Just querying data or exploring table contents
+- Triaging or responding to active alerts (use the prevent skill's Workflow 3)
+- Running impact assessments before code changes (use the prevent skill's Workflow 4)
+- Asking about existing monitor configuration (use `getMonitors` directly)
+- Editing or deleting existing monitors
+
+---
+
+## Available MCP tools
+
+All tools are available via the `monte-carlo` MCP server.
+
+| Tool                         | Purpose                                                    |
+| ---------------------------- | ---------------------------------------------------------- |
+| `testConnection`             | Verify auth and connectivity before starting               |
+| `search`                     | Find tables/assets by name; use `include_fields` for columns |
+| `getTable`                   | Schema, stats, metadata, domain membership, capabilities   |
+| `getValidationPredicates`    | List available validation rule types for a warehouse       |
+| `getDomains`                 | List MC domains (only needed if table has no domain info)  |
+| `createMetricMonitorMac`     | Generate metric monitor YAML (dry-run)                     |
+| `createValidationMonitorMac` | Generate validation monitor YAML (dry-run)                 |
+| `createComparisonMonitorMac` | Generate comparison monitor YAML (dry-run)                 |
+| `createCustomSqlMonitorMac`  | Generate custom SQL monitor YAML (dry-run)                 |
+| `createTableMonitorMac`      | Generate table monitor YAML (dry-run)                      |
+
+---
+
+## Monitor types
+
+| Type           | Tool                         | Use When                                                                                                                                |
+| -------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Metric**     | `createMetricMonitorMac`     | Track statistical metrics on fields (null rates, unique counts, numeric stats) or row count changes over time. Requires a timestamp field for aggregation. |
+| **Validation** | `createValidationMonitorMac` | Row-level data quality checks with conditions (e.g. "field X is never null", "status is in allowed set"). Alerts on INVALID data.       |
+| **Custom SQL** | `createCustomSqlMonitorMac`  | Run arbitrary SQL returning a single number and alert on thresholds. Most flexible; use when other types don't fit.                     |
+| **Comparison** | `createComparisonMonitorMac` | Compare metrics between two tables (e.g. dev vs prod, source vs target).                                                               |
+| **Table**      | `createTableMonitorMac`      | Monitor groups of tables for freshness, schema changes, and volume. Uses asset selection at database/schema level.                      |
+
+---
+
+## Procedure
+
+Follow these steps in order. Do NOT skip steps.
+
+### Validation Phase (Steps 1-3) -- MUST complete before any creation tool is called
+
+The number one error pattern is agents skipping validation and calling a creation tool with guessed or incomplete parameters. **Every field in the creation call must be grounded in data retrieved during this phase.** Do not proceed to Step 4 until Steps 1-3 are fully satisfied.
+
+#### Step 1: Understand the request
+
+Ask yourself:
+- What does the user want to monitor? (a specific table, a metric, a data quality rule, cross-table consistency, freshness/volume at schema level)
+- Which monitor type fits? Use the monitor types table above.
+- Does the user have all the details, or do they need guidance?
+
+If the user's intent is unclear, ask a focused question before proceeding.
+
+#### Step 2: Identify the table(s) and columns
+
+If you don't have the table MCON:
+1. Use `search` with the table name and `include_fields: ["field_names"]` to find the MCON and get column names.
+2. If the user provided a full table ID like `database:schema.table`, search for it.
+3. Once you have the MCON, call `getTable` with `include_fields: true` and `include_table_capabilities: true` to verify capabilities and get domain info.
+
+If you already have the MCON:
+1. Call `getTable` with the MCON, `include_fields: true`, and `include_table_capabilities: true`.
+
+**CRITICAL: You need the actual column names from `getTable` results. NEVER guess or hallucinate column names.** This is the most common source of monitor creation failures.
+
+For monitor types that require a timestamp column (metric monitors), review the column names and identify likely timestamp candidates. Present them to the user if ambiguous.
+
+#### Step 3: Handle domain assignment
+
+Monitors must be assigned to a domain that contains the table being monitored. The `getTable` response includes a `domains` list with `uuid` and `name`.
+
+1. If `domains` is empty: skip domain assignment.
+2. If `domains` has exactly one entry: default `domain_id` to that domain's UUID.
+3. If `domains` has multiple entries: present only those domains and ask the user to pick.
+
+Do NOT present all account domains as options -- only domains that contain the table are valid.
+
+**ALWAYS check the table's `domains` BEFORE calling any creation tool.**
+
+---
+
+### Creation Phase (Steps 4-8)
+
+Only enter this phase after the validation phase is complete with real data from MCP tools.
+
+#### Step 4: Load the sub-skill reference
+
+Based on the monitor type, read the detailed reference for parameter guidance:
+
+- **Metric** -- Read the detailed reference: `references/metric-monitor.md` (relative to this file)
+- **Validation** -- Read the detailed reference: `references/validation-monitor.md` (relative to this file)
+- **Custom SQL** -- Read the detailed reference: `references/custom-sql-monitor.md` (relative to this file)
+- **Comparison** -- Read the detailed reference: `references/comparison-monitor.md` (relative to this file)
+- **Table** -- Read the detailed reference: `references/table-monitor.md` (relative to this file)
+
+#### Step 5: Ask about scheduling
+
+**Skip this step for table monitors.** Table monitors do not support the `schedule` field in MaC YAML — adding it will cause a validation error on `montecarlo monitors apply`. Table monitor scheduling is managed automatically by Monte Carlo.
+
+For all other monitor types, the creation tools default to a fixed schedule running every 60 minutes. Present these options:
+
+1. **Fixed interval** -- any integer for `interval_minutes` (30, 60, 90, 120, 360, 720, 1440, etc.)
+2. **Dynamic** -- MC auto-determines when to run based on table update patterns.
+3. **Loose** -- runs once per day.
+
+Schedule format in MaC YAML:
+- Fixed: `schedule: { type: fixed, interval_minutes: <N> }`
+- Dynamic: `schedule: { type: dynamic }`
+- Loose: `schedule: { type: loose, start_time: "00:00" }`
+
+#### Step 6: Confirm with the user
+
+Before calling the creation tool, present the monitor configuration in plain language:
+- Monitor type
+- Target table (and columns if applicable)
+- What it checks / what triggers an alert
+- Domain assignment
+- Schedule
+
+Ask: "Does this look correct? I'll generate the monitor configuration."
+
+**NEVER call the creation tool without user confirmation.**
+
+#### Step 7: Create the monitor
+
+Call the appropriate creation tool with the parameters built in previous steps. Always pass an MCON when possible. If only table name is available, also pass warehouse.
+
+#### Step 8: Present results
+
+**CRITICAL: Always include the YAML in your response.** The user needs copy-pasteable YAML.
+
+1. If a non-default schedule was chosen, modify the schedule section in the YAML before presenting.
+2. Wrap the YAML in the full MaC structure (see "MaC YAML format" section below).
+3. ALWAYS present the full YAML in a ```yaml code block.
+4. Explain where to put it and how to apply it (see below).
+5. ALWAYS use ISO 8601 format for datetime values.
+6. NEVER reformat YAML values returned by creation tools.
+
+---
+
+## MaC YAML format
+
+The YAML returned by creation tools is the monitor definition. It must be wrapped in the standard MaC structure to be applied:
+
+```yaml
+montecarlo:
+  <monitor_type>:
+    - <returned yaml>
+```
+
+For example, a metric monitor would look like:
+
+```yaml
+montecarlo:
+  metric:
+    - <yaml returned by createMetricMonitorMac>
+```
+
+**Important:** `montecarlo.yml` (without a directory path) is a separate Monte Carlo project configuration file -- it is NOT the same as a monitor definition file. Monitor definitions go in their own `.yml` files, typically in a `monitors/` directory or alongside dbt model schema files.
+
+Tell the user:
+- Save the YAML to a `.yml` file (e.g. `monitors/<table_name>.yml` or in their dbt schema)
+- Apply via the Monte Carlo CLI: `montecarlo monitors apply --namespace <namespace>`
+- Or integrate into CI/CD for automatic deployment on merge
+
+---
+
+## Common mistakes to avoid
+
+- **NEVER guess column names.** Always get them from `getTable`.
+- **NEVER skip the confirmation step** (Step 6).
+- For metric monitors, `aggregate_time_field` MUST be a real timestamp column from the table.
+- For validation monitors, conditions match INVALID data, not valid data.
+- Always pass an MCON when possible. If only table name is available, also pass warehouse.
+- **ALWAYS check table's `domains` BEFORE calling any creation tool.**
+- ALWAYS use ISO 8601 format for datetime values.
+- NEVER reformat YAML values returned by creation tools.
+- Do not call creation tools before the validation phase is complete.

--- a/skills/monitor-creation/references/comparison-monitor.md
+++ b/skills/monitor-creation/references/comparison-monitor.md
@@ -1,0 +1,426 @@
+# Comparison Monitor Reference
+
+Detailed reference for building `createComparisonMonitorMac` tool calls.
+
+## When to Use
+
+Use a comparison monitor when the user wants to:
+
+- Compare data between two tables (e.g., source vs target, dev vs prod)
+- Validate data consistency after migration or replication
+- Check row count parity across environments
+- Compare field-level metrics between tables (null counts, sums, distributions)
+
+---
+
+## Pre-Step: Verify Both Tables and Fields
+
+Before constructing alert conditions, you MUST verify that both tables exist and that any referenced fields are real columns. This is the most common source of comparison monitor failures.
+
+1. **Resolve both MCONs.** Use `search` to find the source and target tables. If the user provided `database:schema.table` format, search for each to get the MCON.
+2. **Get full schemas.** Call `getTable` with `include_fields: true` on BOTH the source table and the target table. You need the column lists from both.
+3. **For field-level metrics, verify fields exist on both sides.** Confirm that `sourceField` exists in the source table's column list AND `targetField` exists in the target table's column list. Field names are case-sensitive on most warehouses.
+4. **Check field type compatibility.** The metric must be compatible with the column types on both sides. For example, `NUMERIC_MEAN` requires numeric columns in both the source and target tables. If the source column is numeric but the target is a string, the comparison will fail.
+5. If any field does not exist or types are incompatible, stop and ask the user to clarify. Do not guess.
+
+---
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Unique identifier for the monitor. Use a descriptive slug (e.g., `orders_dev_prod_compare`). |
+| `description` | string | Human-readable description of what the monitor checks. |
+| `source_table` | string | Source table MCON (preferred) or `database:schema.table` format. If not MCON, also pass `source_warehouse`. |
+| `target_table` | string | Target table MCON (preferred) or `database:schema.table` format. If not MCON, also pass `target_warehouse`. |
+| `alert_conditions` | array | List of comparison conditions (see Alert Conditions below). |
+
+## Optional Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_warehouse` | string | Warehouse name or UUID for the source table. Required if `source_table` is not an MCON. |
+| `target_warehouse` | string | Warehouse name or UUID for the target table. Required if `target_table` is not an MCON. |
+| `segment_fields` | array of string | Fields to segment the comparison by. Must exist in BOTH tables with the same name. |
+| `domain_id` | string (uuid) | Domain UUID (use `getDomains` to list). Only one domain can be assigned per monitor. |
+
+---
+
+## Cross-Warehouse Comparisons
+
+When the source and target tables live in different warehouses (e.g., comparing a Snowflake staging table against a BigQuery production table), you MUST provide both `source_warehouse` and `target_warehouse` explicitly. The tool cannot auto-resolve warehouses when tables are in different environments.
+
+Even when both tables are MCONs, if they belong to different warehouses, pass both warehouse parameters to be safe. Omitting them in cross-warehouse scenarios causes silent failures or incorrect results.
+
+Common cross-warehouse patterns:
+- **Dev vs prod:** same warehouse type, different databases or schemas
+- **Migration validation:** source in old warehouse, target in new warehouse
+- **Replication checks:** primary warehouse vs replica or downstream warehouse
+
+---
+
+## Alert Conditions
+
+Each condition compares a metric between the source and target tables.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metric` | string | Yes | The metric to compare (see Metrics Reference below). |
+| `sourceField` | string | For field-level metrics | Column in the source table. Required for ALL metrics except `ROW_COUNT`. |
+| `targetField` | string | For field-level metrics | Column in the target table. Required for ALL metrics except `ROW_COUNT`. |
+| `thresholdValue` | number | No | Threshold for acceptable difference between source and target. |
+| `isThresholdRelative` | boolean | No | `false` = absolute difference (default), `true` = percentage difference. |
+| `customMetric` | object | No | Custom SQL expressions for source and target (see Custom Metrics below). |
+
+---
+
+## ROW_COUNT and Fields: A Critical Rule
+
+> **NEVER pass `sourceField` or `targetField` when using the `ROW_COUNT` metric.**
+
+`ROW_COUNT` is a table-level metric -- it counts all rows in the table, not values in a column. Passing field names with `ROW_COUNT` causes the API call to fail or produce unexpected behavior.
+
+This is the single most common mistake with comparison monitors. Before submitting any alert condition with `ROW_COUNT`, verify that `sourceField` and `targetField` are both absent from the condition object.
+
+| Metric | Fields needed? | What happens if you pass fields? |
+|--------|---------------|----------------------------------|
+| `ROW_COUNT` | **No -- NEVER pass fields** | API error or undefined behavior |
+| All other metrics | **Yes -- always pass both fields** | Required for the comparison to work |
+
+---
+
+## Metrics Reference
+
+### Table-level metric (no fields needed)
+
+| Metric | Description |
+|--------|-------------|
+| `ROW_COUNT` | Compare total row counts between source and target. |
+
+### Field-level metrics (require `sourceField` and `targetField`)
+
+#### Uniqueness and duplicates
+
+| Metric | Description |
+|--------|-------------|
+| `UNIQUE_COUNT` | Count of distinct values. |
+| `DUPLICATE_COUNT` | Count of duplicate (non-unique) values. |
+| `APPROX_DISTINCT_COUNT` | Approximate distinct count (faster on large tables). |
+
+#### Null and empty checks
+
+| Metric | Description |
+|--------|-------------|
+| `NULL_COUNT` | Count of null values. |
+| `NON_NULL_COUNT` | Count of non-null values. |
+| `EMPTY_STRING_COUNT` | Count of empty string values. |
+| `TEXT_ALL_SPACES_COUNT` | Count of values that are all whitespace. |
+| `NAN_COUNT` | Count of NaN values. |
+| `TEXT_NULL_KEYWORD_COUNT` | Count of values containing null-like keywords (e.g., "NULL", "None"). |
+
+#### Numeric statistics
+
+| Metric | Description |
+|--------|-------------|
+| `NUMERIC_MEAN` | Mean of numeric field. |
+| `NUMERIC_MEDIAN` | Median of numeric field. |
+| `NUMERIC_MIN` | Minimum value. |
+| `NUMERIC_MAX` | Maximum value. |
+| `NUMERIC_STDDEV` | Standard deviation. |
+| `SUM` | Sum of numeric field. |
+| `ZERO_COUNT` | Count of zero values. |
+| `NEGATIVE_COUNT` | Count of negative values. |
+
+#### Percentiles
+
+| Metric | Description |
+|--------|-------------|
+| `PERCENTILE_20` | 20th percentile value. |
+| `PERCENTILE_40` | 40th percentile value. |
+| `PERCENTILE_60` | 60th percentile value. |
+| `PERCENTILE_80` | 80th percentile value. |
+
+#### Text statistics
+
+| Metric | Description |
+|--------|-------------|
+| `TEXT_MAX_LENGTH` | Maximum string length. |
+| `TEXT_MIN_LENGTH` | Minimum string length. |
+| `TEXT_MEAN_LENGTH` | Mean string length. |
+| `TEXT_STD_LENGTH` | Standard deviation of string length. |
+
+#### Text format checks
+
+| Metric | Description |
+|--------|-------------|
+| `TEXT_NOT_INT_COUNT` | Count of values not parseable as integers. |
+| `TEXT_NOT_NUMBER_COUNT` | Count of values not parseable as numbers. |
+| `TEXT_NOT_UUID_COUNT` | Count of values not matching UUID format. |
+| `TEXT_NOT_SSN_COUNT` | Count of values not matching SSN format. |
+| `TEXT_NOT_US_PHONE_COUNT` | Count of values not matching US phone format. |
+| `TEXT_NOT_US_STATE_CODE_COUNT` | Count of values not matching US state codes. |
+| `TEXT_NOT_US_ZIP_CODE_COUNT` | Count of values not matching US zip codes. |
+| `TEXT_NOT_EMAIL_ADDRESS_COUNT` | Count of values not matching email format. |
+| `TEXT_NOT_TIMESTAMP_COUNT` | Count of values not parseable as timestamps. |
+
+#### Boolean
+
+| Metric | Description |
+|--------|-------------|
+| `TRUE_COUNT` | Count of true values. |
+| `FALSE_COUNT` | Count of false values. |
+
+#### Timestamp
+
+| Metric | Description |
+|--------|-------------|
+| `FUTURE_TIMESTAMP_COUNT` | Count of timestamps in the future. |
+| `PAST_TIMESTAMP_COUNT` | Count of timestamps unreasonably far in the past. |
+| `UNIX_ZERO_COUNT` | Count of timestamps equal to Unix epoch zero (1970-01-01). |
+
+---
+
+## Choosing the Right Metric
+
+| User intent | Correct metric | Fields needed? |
+|-------------|---------------|----------------|
+| Row count parity | `ROW_COUNT` | **No** -- never pass fields |
+| Distinct values in a column | `UNIQUE_COUNT` | Yes |
+| Null values in a column | `NULL_COUNT` | Yes |
+| Sum, average, min, max | `SUM`, `NUMERIC_MEAN`, `NUMERIC_MIN`, `NUMERIC_MAX` | Yes |
+| Data completeness | `NON_NULL_COUNT` | Yes |
+| String format validation | `TEXT_NOT_EMAIL_ADDRESS_COUNT`, `TEXT_NOT_UUID_COUNT`, etc. | Yes |
+| Custom computed expressions | Use `customMetric` instead of `metric` | No (SQL handles it) |
+
+---
+
+## Custom Metrics
+
+Use custom metrics when:
+
+- **Column names differ** between source and target and you need a computed expression (not just a direct field comparison).
+- **You need a derived calculation** like `SUM(quantity * unit_price)` rather than a simple column metric.
+- **Standard metrics do not cover the comparison** (e.g., comparing a ratio, a conditional aggregate, or a windowed calculation).
+
+If the columns simply have different names but you want a standard metric (e.g., compare `SUM` of `revenue` in source vs `total_revenue` in target), you do NOT need a custom metric -- just use the standard metric with different `sourceField` and `targetField` values.
+
+Custom metric structure:
+
+```json
+{
+  "customMetric": {
+    "displayName": "Revenue Sum",
+    "sourceSqlExpression": "SUM(revenue)",
+    "targetSqlExpression": "SUM(total_revenue)"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `displayName` | string | Yes | Human-readable name for the metric in alerts and dashboards. |
+| `sourceSqlExpression` | string | Yes | SQL expression evaluated against the source table. |
+| `targetSqlExpression` | string | Yes | SQL expression evaluated against the target table. |
+
+When using `customMetric`, do NOT also pass `metric`, `sourceField`, or `targetField` in the same alert condition. The custom metric replaces all of those.
+
+---
+
+## Threshold Guidance
+
+### Absolute thresholds (`isThresholdRelative: false` or omitted)
+
+The `thresholdValue` is the maximum acceptable absolute difference between the source and target metric values.
+
+- `thresholdValue: 0` -- source and target must match exactly.
+- `thresholdValue: 100` -- up to 100 units of difference is acceptable.
+
+### Relative (percentage) thresholds (`isThresholdRelative: true`)
+
+The `thresholdValue` is the maximum acceptable percentage difference.
+
+- `thresholdValue: 5` -- up to 5% difference is acceptable.
+- `thresholdValue: 0.1` -- up to 0.1% difference is acceptable.
+
+### When to use each
+
+| Scenario | Recommended threshold type |
+|----------|---------------------------|
+| Exact replication (row counts must match) | Absolute, `thresholdValue: 0` |
+| Near-real-time sync with small lag | Absolute, small value (e.g., 10-100) |
+| Tables at different scales | Relative, percentage-based |
+| Aggregated metrics (sums, means) | Relative, to handle floating-point differences |
+
+---
+
+## Examples
+
+### Row count parity with absolute threshold
+
+Compare row counts between dev and prod, alerting if they differ by more than 100 rows.
+
+```json
+{
+  "name": "orders_dev_prod_row_count",
+  "description": "Verify dev and prod orders tables have similar row counts",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++dev_warehouse:core.orders",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++prod_warehouse:core.orders",
+  "alert_conditions": [
+    {
+      "metric": "ROW_COUNT",
+      "thresholdValue": 100,
+      "isThresholdRelative": false
+    }
+  ]
+}
+```
+
+Note: no `sourceField` or `targetField` -- `ROW_COUNT` is table-level.
+
+### Row count parity with percentage threshold
+
+Alert if row counts differ by more than 5%.
+
+```json
+{
+  "name": "orders_replication_check",
+  "description": "Verify replicated orders table is within 5% of source row count",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++primary:sales.orders",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++replica:sales.orders",
+  "alert_conditions": [
+    {
+      "metric": "ROW_COUNT",
+      "thresholdValue": 5,
+      "isThresholdRelative": true
+    }
+  ]
+}
+```
+
+### Field-level comparison (different column names)
+
+Compare the sum of `revenue` in the source table against `total_revenue` in the target table.
+
+```json
+{
+  "name": "revenue_source_target_sum",
+  "description": "Verify revenue sums match between staging and production",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++staging:finance.transactions",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++production:finance.transactions",
+  "alert_conditions": [
+    {
+      "metric": "SUM",
+      "sourceField": "revenue",
+      "targetField": "total_revenue",
+      "thresholdValue": 1,
+      "isThresholdRelative": true
+    }
+  ]
+}
+```
+
+### Segmented comparison
+
+Compare null counts on `email` between source and target, segmented by `country`. The `country` field must exist in both tables.
+
+```json
+{
+  "name": "email_nulls_by_country",
+  "description": "Compare email null counts by country between ETL source and target",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++raw:crm.contacts",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++analytics:crm.contacts",
+  "segment_fields": ["country"],
+  "alert_conditions": [
+    {
+      "metric": "NULL_COUNT",
+      "sourceField": "email",
+      "targetField": "email",
+      "thresholdValue": 0,
+      "isThresholdRelative": false
+    }
+  ]
+}
+```
+
+### Cross-warehouse comparison with explicit warehouses
+
+When source and target are in different warehouses, both warehouse parameters must be provided.
+
+```json
+{
+  "name": "migration_users_row_count",
+  "description": "Validate user row counts match after Snowflake to BigQuery migration",
+  "source_table": "snowflake_db:public.users",
+  "source_warehouse": "snowflake-prod",
+  "target_table": "bigquery_project:public.users",
+  "target_warehouse": "bigquery-prod",
+  "alert_conditions": [
+    {
+      "metric": "ROW_COUNT",
+      "thresholdValue": 0,
+      "isThresholdRelative": false
+    }
+  ]
+}
+```
+
+### Custom metric comparison
+
+Compare a computed revenue expression when the SQL differs between source and target.
+
+```json
+{
+  "name": "computed_revenue_compare",
+  "description": "Compare total revenue computation between legacy and new schema",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++warehouse:legacy.orders",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++warehouse:v2.orders",
+  "alert_conditions": [
+    {
+      "customMetric": {
+        "displayName": "Total Revenue",
+        "sourceSqlExpression": "SUM(quantity * unit_price)",
+        "targetSqlExpression": "SUM(total_amount)"
+      },
+      "thresholdValue": 0.01,
+      "isThresholdRelative": true
+    }
+  ]
+}
+```
+
+### Multiple alert conditions
+
+Compare both row counts and field-level metrics in a single monitor.
+
+```json
+{
+  "name": "orders_full_comparison",
+  "description": "Full comparison of orders between staging and production",
+  "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++staging:core.orders",
+  "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++production:core.orders",
+  "domain_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "alert_conditions": [
+    {
+      "metric": "ROW_COUNT",
+      "thresholdValue": 0,
+      "isThresholdRelative": false
+    },
+    {
+      "metric": "NULL_COUNT",
+      "sourceField": "customer_id",
+      "targetField": "customer_id",
+      "thresholdValue": 0,
+      "isThresholdRelative": false
+    },
+    {
+      "metric": "SUM",
+      "sourceField": "amount",
+      "targetField": "amount",
+      "thresholdValue": 0.1,
+      "isThresholdRelative": true
+    }
+  ]
+}
+```
+
+Note: the `ROW_COUNT` condition has no fields, while the field-level conditions each specify both `sourceField` and `targetField`.

--- a/skills/monitor-creation/references/custom-sql-monitor.md
+++ b/skills/monitor-creation/references/custom-sql-monitor.md
@@ -1,0 +1,207 @@
+# Custom SQL Monitor Reference
+
+Detailed reference for building `createCustomSqlMonitorMac` tool calls.
+
+## When to Use
+
+Use a custom SQL monitor when the user wants to:
+
+- Run a specific SQL query and alert on its result
+- Implement cross-table logic (joins, subqueries, CTEs)
+- Apply business-specific aggregations or calculations that don't map to a single metric
+- Monitor a condition that spans multiple columns or tables
+- Use a SQL query they already have in mind
+
+---
+
+## The Universal Fallback
+
+Custom SQL is the fallback monitor type. Reach for it whenever another monitor type cannot express what the user needs:
+
+- **Validation monitor won't work** because the column doesn't exist yet, or the logic requires joins across tables.
+- **Metric monitor can't express the business logic** -- for example, a ratio between two columns, a conditional aggregation, or a calculation that spans multiple tables.
+- **Cross-table joins are needed** -- metric and validation monitors operate on a single table. If the check requires data from two or more tables, custom SQL is the only option.
+- **The user already has a SQL query** -- don't force it into another monitor type. Wrap it in a custom SQL monitor.
+
+If you find yourself contorting another monitor type to fit the user's intent, stop and use custom SQL instead.
+
+---
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Unique identifier for the monitor. Use a descriptive slug (e.g., `orphan_orders_check`). |
+| `description` | string | Human-readable description of what the monitor checks. |
+| `warehouse` | string | Warehouse name or UUID where the SQL query will be executed. |
+| `sql` | string | SQL query that returns a **single numeric value** (one row, one column). |
+| `alert_conditions` | array | List of threshold conditions (see Alert Conditions below). |
+
+## Optional Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `domain_id` | string (uuid) | Domain UUID (use `getDomains` to list). Only one domain can be assigned per monitor. |
+
+---
+
+## Alert Conditions
+
+Each alert condition compares the query result against a threshold.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `operator` | string | Yes | `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NE"` |
+| `thresholdValue` | number | Yes | Numeric threshold to compare the query result against. |
+
+### No AUTO Support
+
+Custom SQL monitors do **NOT** support `AUTO` (anomaly detection). You must specify an explicit operator and threshold for every alert condition. This is a common mistake -- if the user asks for anomaly detection, steer them toward a metric monitor instead, which does support `AUTO`.
+
+If the user is unsure what threshold to set, help them reason about it: "What value would indicate a problem? If the query returns X, should that fire an alert?"
+
+---
+
+## SQL Query Requirements
+
+The SQL query MUST return exactly **one row with one numeric column**. This is non-negotiable -- the monitor compares that single value against the alert conditions.
+
+### Rules
+
+- Use aggregate functions: `COUNT(*)`, `SUM()`, `AVG()`, `MAX()`, `MIN()`, or similar.
+- Can reference any table, view, or materialized view accessible in the warehouse.
+- Can use joins, subqueries, CTEs, window functions -- any valid SQL.
+- Do **NOT** include trailing semicolons.
+- Do **NOT** include comments (`--` or `/* */`) -- some warehouses strip them inconsistently.
+
+### SQL Validation Tips
+
+These are the most common mistakes that cause custom SQL monitors to fail or produce misleading results:
+
+1. **Handle NULLs with COALESCE.** If your aggregate could return NULL (e.g., `SUM(amount)` on an empty result set), wrap it: `SELECT COALESCE(SUM(amount), 0) FROM ...`. A NULL result cannot be compared against a threshold and will not trigger alerts.
+
+2. **Ensure exactly one row, one column.** If your query could return zero rows (e.g., a filtered `SELECT` with no `GROUP BY`), wrap it in an outer aggregate: `SELECT COUNT(*) FROM (SELECT ...) sub`. If it returns multiple columns, select only the one you need.
+
+3. **Test the query mentally.** Before finalizing, ask: "If this query returns 5, will the alert condition fire correctly?" Walk through the logic with a concrete number.
+
+4. **For time-windowed checks, use appropriate date functions.** SQL syntax for date arithmetic varies by warehouse (see Warehouse-Specific SQL Notes below). Always scope time windows to avoid scanning the entire table history.
+
+5. **Avoid non-deterministic results.** Queries using `LIMIT` without `ORDER BY`, or `RANDOM()`, produce unpredictable results that make alerting unreliable.
+
+---
+
+## Warehouse-Specific SQL Notes
+
+SQL syntax for date arithmetic and functions varies across warehouses. When writing time-windowed queries, use the correct syntax for the user's warehouse:
+
+| Operation | Snowflake | BigQuery | Redshift |
+|-----------|-----------|----------|----------|
+| Subtract 1 day from now | `DATEADD(day, -1, CURRENT_TIMESTAMP())` | `DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)` | `DATEADD(day, -1, GETDATE())` |
+| Subtract 1 hour from now | `DATEADD(hour, -1, CURRENT_TIMESTAMP())` | `TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)` | `DATEADD(hour, -1, GETDATE())` |
+| Current timestamp | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` | `GETDATE()` |
+| Date truncation | `DATE_TRUNC('day', col)` | `DATE_TRUNC(col, DAY)` | `DATE_TRUNC('day', col)` |
+
+When unsure which warehouse the user is on, ask. Getting the syntax wrong causes the monitor to fail on every scheduled run.
+
+---
+
+## Examples
+
+### Orphan records (GT 0)
+
+Alert when orders reference customers that don't exist.
+
+```json
+{
+  "name": "orphan_orders_check",
+  "description": "Detect orders referencing non-existent customers",
+  "warehouse": "production_snowflake",
+  "sql": "SELECT COUNT(*) FROM analytics.core.orders o LEFT JOIN analytics.core.customers c ON o.customer_id = c.id WHERE c.id IS NULL",
+  "alert_conditions": [
+    {
+      "operator": "GT",
+      "thresholdValue": 0
+    }
+  ]
+}
+```
+
+### Daily revenue floor (LT threshold)
+
+Alert when total revenue for the past 24 hours drops below a minimum.
+
+```json
+{
+  "name": "daily_revenue_floor",
+  "description": "Alert when daily revenue falls below $10,000",
+  "warehouse": "production_snowflake",
+  "sql": "SELECT COALESCE(SUM(amount), 0) FROM analytics.billing.transactions WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP())",
+  "alert_conditions": [
+    {
+      "operator": "LT",
+      "thresholdValue": 10000
+    }
+  ]
+}
+```
+
+### Duplicate rate exceeds threshold
+
+Alert when the duplicate rate on a key field exceeds 1%.
+
+```json
+{
+  "name": "order_id_duplicate_rate",
+  "description": "Alert when order_id duplicate rate exceeds 1%",
+  "warehouse": "production_snowflake",
+  "sql": "SELECT COALESCE(1.0 - (COUNT(DISTINCT order_id) * 1.0 / NULLIF(COUNT(*), 0)), 0) FROM analytics.core.orders WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP())",
+  "alert_conditions": [
+    {
+      "operator": "GT",
+      "thresholdValue": 0.01
+    }
+  ]
+}
+```
+
+### Multiple threshold conditions (range check)
+
+Alert when a value falls outside an acceptable range. Multiple conditions act as independent checks -- each one that evaluates to true fires its own alert.
+
+```json
+{
+  "name": "avg_order_amount_range",
+  "description": "Alert when average order amount is outside the $20-$500 range",
+  "warehouse": "production_snowflake",
+  "sql": "SELECT COALESCE(AVG(amount), 0) FROM analytics.core.orders WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP()) AND status = 'completed'",
+  "alert_conditions": [
+    {
+      "operator": "LT",
+      "thresholdValue": 20
+    },
+    {
+      "operator": "GT",
+      "thresholdValue": 500
+    }
+  ]
+}
+```
+
+### Cross-table freshness check (BigQuery syntax)
+
+Alert when the latest row in a downstream table is more than 2 hours behind the source.
+
+```json
+{
+  "name": "pipeline_lag_check",
+  "description": "Alert when downstream table lags source by more than 2 hours",
+  "warehouse": "production_bigquery",
+  "sql": "SELECT COALESCE(TIMESTAMP_DIFF(s.max_ts, t.max_ts, MINUTE), 9999) FROM (SELECT MAX(event_timestamp) AS max_ts FROM project.raw.events) s CROSS JOIN (SELECT MAX(processed_at) AS max_ts FROM project.analytics.events_processed) t",
+  "alert_conditions": [
+    {
+      "operator": "GT",
+      "thresholdValue": 120
+    }
+  ]
+}
+```

--- a/skills/monitor-creation/references/metric-monitor.md
+++ b/skills/monitor-creation/references/metric-monitor.md
@@ -32,7 +32,23 @@ Use a metric monitor when the user wants to:
 | `segment_fields` | array of string | none | Fields to group/segment metrics by (e.g., `["country", "status"]`). |
 | `aggregate_by` | string | `"day"` | Time interval: `"hour"`, `"day"`, `"week"`, `"month"`. |
 | `where_condition` | string | none | SQL WHERE clause (without `WHERE` keyword) to filter rows before computing metrics. |
+| `interval_minutes` | int | auto | Schedule interval in minutes. Must be compatible with `aggregate_by` (see note below). If not specified, the tool defaults to the minimum valid interval for the chosen `aggregate_by`. |
 | `domain_id` | string (uuid) | none | Domain UUID (use `getDomains` to list). |
+
+---
+
+## Schedule and Aggregation Compatibility
+
+The schedule interval must be compatible with `aggregate_by`. Daily aggregation requires an interval that is a multiple of 1440 minutes (24 hours), weekly requires a multiple of 10080, etc. If you pass `interval_minutes`, make sure it satisfies this constraint. If you omit it, the tool picks a sensible default.
+
+| `aggregate_by` | Minimum `interval_minutes` | Default if omitted |
+|---|---|---|
+| `hour` | 60 | 60 |
+| `day` | 1440 | 1440 |
+| `week` | 10080 | 10080 |
+| `month` | 43200 | 43200 |
+
+For example, to run a daily-aggregated monitor every other day, pass `aggregate_by: "day"` and `interval_minutes: 2880`.
 
 ---
 

--- a/skills/monitor-creation/references/metric-monitor.md
+++ b/skills/monitor-creation/references/metric-monitor.md
@@ -1,0 +1,276 @@
+# Metric Monitor Reference
+
+Detailed reference for building `createMetricMonitorMac` tool calls.
+
+## When to Use
+
+Use a metric monitor when the user wants to:
+
+- Track row count changes over time
+- Monitor null rates, unique counts, or other statistical metrics on specific fields
+- Detect anomalies in numeric distributions (mean, max, min, percentiles)
+- Monitor data freshness (time since last row count change)
+- Segment metrics by dimensions (e.g., by country, status)
+
+---
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Unique identifier for the monitor. Use a descriptive slug (e.g., `orders_null_check`). |
+| `description` | string | Human-readable description of what the monitor checks. |
+| `table` | string | Table MCON (preferred) or `database:schema.table` format. If not MCON, also pass `warehouse`. |
+| `aggregate_time_field` | string | **MUST be a real timestamp/datetime column from the table.** NEVER guess this value. |
+| `alert_conditions` | array | List of alert condition objects (see Alert Conditions below). |
+
+## Optional Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `warehouse` | string | auto-resolved | Warehouse name or UUID. Required if `table` is not an MCON. |
+| `segment_fields` | array of string | none | Fields to group/segment metrics by (e.g., `["country", "status"]`). |
+| `aggregate_by` | string | `"day"` | Time interval: `"hour"`, `"day"`, `"week"`, `"month"`. |
+| `where_condition` | string | none | SQL WHERE clause (without `WHERE` keyword) to filter rows before computing metrics. |
+| `domain_id` | string (uuid) | none | Domain UUID (use `getDomains` to list). |
+
+---
+
+## Choosing the Timestamp Field
+
+The `aggregate_time_field` is the most critical parameter. It MUST be a real column from the table that contains timestamp or datetime values. This is the number one source of monitor creation failures.
+
+### How to pick it
+
+1. You should already have the column names from `getTable` with `include_fields: true` (done in Step 2 of the main skill).
+2. Look for columns whose names suggest a timestamp: `created_at`, `updated_at`, `modified_at`, `timestamp`, `event_timestamp`, or columns with `_ts`, `_dt`, `_time` suffixes, or `date`, `datetime`.
+3. If the user specified one, verify it exists in the column list.
+4. If exactly one obvious candidate exists, suggest it.
+5. If multiple candidates exist, present them and ask the user.
+6. If NO obvious timestamp columns exist, suggest a custom SQL monitor instead (which does not need a timestamp field).
+
+**NEVER** proceed without confirming the timestamp field exists in the table schema.
+
+### Common timestamp field mistakes
+
+- **Using a DATE column (not TIMESTAMP):** This may work, but aggregation granularity is limited. For example, `aggregate_by: "hour"` is meaningless on a DATE column because the time component is always midnight. Warn the user and default to `aggregate_by: "day"` or coarser.
+- **Using a field that contains many nulls:** If the timestamp column has significant null values, rows with null timestamps are excluded from aggregation windows, producing unreliable or misleading results. Check the column's null rate from `getTable` field stats if available, and warn the user if it is high.
+- **Guessing a field name that does not exist:** Always verify the column name against the `getTable` output. A typo or assumed name (e.g., `created_date` when the actual column is `created_at`) causes the monitor creation to fail silently or error.
+
+---
+
+## Field-Type-to-Metric Compatibility Matrix
+
+**Before selecting a metric, check the column's data type from `getTable` results.** Passing a metric incompatible with the column type is the most common source of creation failures after timestamp issues.
+
+| Column Type | Compatible Metrics |
+|-------------|-------------------|
+| **Numeric** (int, float, decimal, bigint) | `NUMERIC_MEAN`, `NUMERIC_MEDIAN`, `NUMERIC_MIN`, `NUMERIC_MAX`, `NUMERIC_STDDEV`, `SUM`, `ZERO_COUNT`, `ZERO_RATE`, `NEGATIVE_COUNT`, `NEGATIVE_RATE`, `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, `UNIQUE_RATE`, `DUPLICATE_COUNT` |
+| **String / Text** (varchar, char, text) | `TEXT_MAX_LENGTH`, `TEXT_MIN_LENGTH`, `TEXT_MEAN_LENGTH`, `TEXT_INT_RATE`, `TEXT_NUMBER_RATE`, `TEXT_UUID_RATE`, `TEXT_EMAIL_ADDRESS_RATE`, `EMPTY_STRING_COUNT`, `EMPTY_STRING_RATE`, `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, `UNIQUE_RATE`, `DUPLICATE_COUNT` |
+| **Boolean** | `TRUE_COUNT`, `FALSE_COUNT`, `NULL_COUNT`, `NULL_RATE` |
+| **Timestamp / Date** | `FUTURE_TIMESTAMP_COUNT`, `PAST_TIMESTAMP_COUNT`, `UNIX_ZERO_TIMESTAMP_COUNT`, `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, `UNIQUE_RATE` |
+| **Any type** | `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, `UNIQUE_RATE`, `DUPLICATE_COUNT` |
+
+### Rules
+
+- **NEVER** apply `NUMERIC_*`, `SUM`, `ZERO_*`, or `NEGATIVE_*` metrics to string, boolean, or timestamp columns.
+- **NEVER** apply `TEXT_*` or `EMPTY_STRING_*` metrics to numeric, boolean, or timestamp columns.
+- **NEVER** apply `TRUE_COUNT` or `FALSE_COUNT` to non-boolean columns.
+- **NEVER** apply `FUTURE_TIMESTAMP_COUNT`, `PAST_TIMESTAMP_COUNT`, or `UNIX_ZERO_TIMESTAMP_COUNT` to non-timestamp columns.
+- When in doubt, `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, and `UNIQUE_RATE` are safe for any column type.
+
+---
+
+## Alert Conditions
+
+Each alert condition has:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metric` | string | Yes | The metric to monitor (see Metrics Reference below). |
+| `operator` | string | Yes | `"AUTO"` (anomaly detection), `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NE"`. |
+| `threshold` | number | For explicit operators | The threshold value. Required when using `GT`, `LT`, `EQ`, `GTE`, `LTE`, or `NE`. Not used with `AUTO`. |
+| `fields` | array of string | Depends | Column names to apply the metric to. Required for field-level metrics. Not needed for table-level metrics. |
+
+---
+
+## Operator Guidance
+
+### When to use `AUTO` (anomaly detection)
+
+- Best when you do not know the expected range of values and want Monte Carlo's ML to learn normal patterns and alert on deviations.
+- Works well for organic metrics that vary day-to-day (row counts, null rates on evolving data, numeric distributions).
+- Some metrics **require** `AUTO` -- see the table below.
+
+### When to use explicit thresholds (`GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE`)
+
+- Use when there is a known business rule or data contract (e.g., "null rate on `email` should never exceed 5%", "order amount must always be greater than 0").
+- Provides deterministic alerting -- no training period needed, alerts fire immediately when the condition is met.
+- Requires a `threshold` value in the alert condition.
+
+### Operator restrictions by metric
+
+| Metric | Allowed Operators | Notes |
+|--------|-------------------|-------|
+| `ROW_COUNT_CHANGE` | `AUTO` only | Anomaly detection on row count delta. |
+| `TIME_SINCE_LAST_ROW_COUNT_CHANGE` | `AUTO` only | Anomaly detection on staleness duration. |
+| `RELATIVE_ROW_COUNT` | `AUTO` only | Anomaly detection on segment distribution. Requires `segment_fields`. |
+| All other metrics | `AUTO`, `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE` | Any operator is valid. |
+
+---
+
+## Metrics Reference
+
+### Table-level metrics (no `fields` needed)
+
+| Metric | Operator | Description |
+|--------|----------|-------------|
+| `ROW_COUNT_CHANGE` | Must use `AUTO` | Alert on anomalous changes in total row count. |
+| `TIME_SINCE_LAST_ROW_COUNT_CHANGE` | Must use `AUTO` | Alert when the table has not been updated for an unusual duration. |
+
+### Field-level metrics (must specify `fields`)
+
+| Metric | Column Types | Description |
+|--------|-------------|-------------|
+| `NULL_COUNT` | Any | Count of null values. |
+| `NULL_RATE` | Any | Rate of null values (0.0 to 1.0). |
+| `UNIQUE_COUNT` | Any | Count of distinct values. |
+| `UNIQUE_RATE` | Any | Rate of distinct values (0.0 to 1.0). |
+| `DUPLICATE_COUNT` | Any | Count of duplicate (non-unique) values. |
+| `EMPTY_STRING_COUNT` | String/Text | Count of empty string values. |
+| `EMPTY_STRING_RATE` | String/Text | Rate of empty string values. |
+| `NUMERIC_MEAN` | Numeric | Mean of numeric field. |
+| `NUMERIC_MEDIAN` | Numeric | Median of numeric field. |
+| `NUMERIC_MIN` | Numeric | Minimum value of numeric field. |
+| `NUMERIC_MAX` | Numeric | Maximum value of numeric field. |
+| `NUMERIC_STDDEV` | Numeric | Standard deviation of numeric field. |
+| `SUM` | Numeric | Sum of numeric field. |
+| `ZERO_COUNT` | Numeric | Count of zero values. |
+| `ZERO_RATE` | Numeric | Rate of zero values. |
+| `NEGATIVE_COUNT` | Numeric | Count of negative values. |
+| `NEGATIVE_RATE` | Numeric | Rate of negative values. |
+| `TRUE_COUNT` | Boolean | Count of true values. |
+| `FALSE_COUNT` | Boolean | Count of false values. |
+| `TEXT_MAX_LENGTH` | String/Text | Maximum string length. |
+| `TEXT_MIN_LENGTH` | String/Text | Minimum string length. |
+| `TEXT_MEAN_LENGTH` | String/Text | Mean string length. |
+| `TEXT_INT_RATE` | String/Text | Rate of values parseable as integers. |
+| `TEXT_NUMBER_RATE` | String/Text | Rate of values parseable as numbers. |
+| `TEXT_UUID_RATE` | String/Text | Rate of values matching UUID format. |
+| `TEXT_EMAIL_ADDRESS_RATE` | String/Text | Rate of values matching email format. |
+| `FUTURE_TIMESTAMP_COUNT` | Timestamp/Date | Count of timestamps in the future. |
+| `PAST_TIMESTAMP_COUNT` | Timestamp/Date | Count of timestamps unreasonably far in the past. |
+| `UNIX_ZERO_TIMESTAMP_COUNT` | Timestamp/Date | Count of timestamps equal to Unix epoch zero (1970-01-01). |
+
+### Segmentation metric
+
+| Metric | Operator | Description |
+|--------|----------|-------------|
+| `RELATIVE_ROW_COUNT` | Must use `AUTO` | Alert on anomalous changes in distribution across segments. MUST use `segment_fields`. |
+
+---
+
+## Examples
+
+### Row count anomaly detection
+
+```json
+{
+  "name": "orders_row_count",
+  "description": "Detect anomalous changes in daily order volume",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "aggregate_time_field": "created_at",
+  "aggregate_by": "day",
+  "alert_conditions": [
+    {
+      "metric": "ROW_COUNT_CHANGE",
+      "operator": "AUTO"
+    }
+  ]
+}
+```
+
+### Null monitoring on specific fields
+
+```json
+{
+  "name": "orders_null_check",
+  "description": "Alert when email or user_id nulls exceed 50 per day",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "aggregate_time_field": "created_at",
+  "aggregate_by": "day",
+  "alert_conditions": [
+    {
+      "metric": "NULL_COUNT",
+      "operator": "GT",
+      "threshold": 50,
+      "fields": ["email", "user_id"]
+    }
+  ]
+}
+```
+
+### Segmented monitoring
+
+```json
+{
+  "name": "orders_by_country_distribution",
+  "description": "Detect anomalous shifts in order distribution across countries",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "aggregate_time_field": "created_at",
+  "aggregate_by": "day",
+  "segment_fields": ["country"],
+  "alert_conditions": [
+    {
+      "metric": "RELATIVE_ROW_COUNT",
+      "operator": "AUTO"
+    }
+  ]
+}
+```
+
+### Numeric range monitoring with filter
+
+```json
+{
+  "name": "completed_orders_amount_check",
+  "description": "Detect anomalous max order amounts for completed orders",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "aggregate_time_field": "created_at",
+  "aggregate_by": "day",
+  "where_condition": "status = 'completed'",
+  "alert_conditions": [
+    {
+      "metric": "NUMERIC_MAX",
+      "operator": "AUTO",
+      "fields": ["amount"]
+    }
+  ]
+}
+```
+
+### Multiple alert conditions in one monitor
+
+```json
+{
+  "name": "payments_quality_check",
+  "description": "Monitor payment amount stats and null rate on transaction_id",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++warehouse:billing.payments",
+  "aggregate_time_field": "processed_at",
+  "aggregate_by": "day",
+  "domain_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "alert_conditions": [
+    {
+      "metric": "NUMERIC_MEAN",
+      "operator": "AUTO",
+      "fields": ["amount"]
+    },
+    {
+      "metric": "NULL_RATE",
+      "operator": "GT",
+      "threshold": 0.01,
+      "fields": ["transaction_id"]
+    }
+  ]
+}
+```

--- a/skills/monitor-creation/references/table-monitor.md
+++ b/skills/monitor-creation/references/table-monitor.md
@@ -1,0 +1,231 @@
+# Table Monitor Reference
+
+Detailed reference for building `createTableMonitorMac` tool calls.
+
+## When to Use
+
+Use a table monitor when the user wants to:
+
+- Monitor many tables at once across an entire database or schema
+- Track freshness (when was each table last updated?)
+- Detect schema changes (columns added, removed, or type-changed)
+- Monitor volume changes (row count anomalies) across a broad set of tables
+- Apply broad coverage with anomaly detection (no custom thresholds needed)
+
+**Do NOT use a table monitor when the user wants to:**
+
+- Track field-level metrics on a single table (use a metric monitor)
+- Apply custom thresholds or explicit operators like GT/LT (use a metric monitor)
+- Validate row-level business rules or referential integrity (use a validation monitor)
+
+---
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Unique identifier for the table monitor. Must be unique across all table monitors in the same namespace. |
+| `description` | string | Human-readable description of what the monitor checks (max 512 characters). |
+| `warehouse` | string | Warehouse name or UUID. Use `getTable` or `search` to find it. |
+| `asset_selection` | object | Asset selection config defining which tables to monitor (see Asset Selection below). |
+
+## Optional Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `alert_conditions` | array of strings | `["last_updated_on", "schema", "total_row_count", "total_row_count_last_changed_on"]` | Metric names to monitor (see Alert Conditions below). |
+| `domain_id` | string (uuid) | none | Domain UUID (use `getDomains` to list). |
+
+---
+
+## Pre-Step: Verify Warehouse
+
+Before creating a table monitor, resolve the warehouse name or UUID. The `warehouse` parameter is required and must match an existing warehouse in the Monte Carlo account.
+
+1. If the user provides a table name, call `getTable` to retrieve the table details -- the response includes the warehouse name and UUID.
+2. If the user provides a database or schema name without a specific table, call `search` with the database or schema name to find assets and identify the warehouse.
+3. Use either the warehouse name or UUID in the `warehouse` parameter.
+
+**NEVER guess the warehouse value.** If you cannot resolve it, ask the user.
+
+---
+
+## Asset Selection
+
+The `asset_selection` object defines which tables the monitor covers. It must include a `databases` list.
+
+**Use database and schema scoping to select which tables to monitor.** This is the reliable approach and covers most use cases.
+
+> **Known limitation:** The MCP tool supports `filters` and `exclusions` parameters, but the tool's schema describes the wrong format for them. Until this is fixed ([K2-269](https://linear.app/montecarlodata/issue/K2-269)), **do not pass `filters` or `exclusions`** — they will cause errors. Use database/schema scoping instead to narrow the set of monitored tables. If the user needs regex or pattern-based filtering, explain this limitation and suggest either (a) using schema-level scoping to get close, or (b) creating individual metric monitors for specific tables.
+
+### Database-Level Selection
+
+To monitor all tables in an entire database, specify only the database name with no `schemas` list:
+
+```json
+{
+  "databases": [
+    {"name": "analytics"}
+  ]
+}
+```
+
+This monitors every table in every schema within the `analytics` database.
+
+### Schema-Level Selection
+
+To monitor all tables in specific schemas, include the `schemas` list:
+
+```json
+{
+  "databases": [
+    {
+      "name": "analytics",
+      "schemas": ["core", "staging"]
+    }
+  ]
+}
+```
+
+This monitors every table in the `core` and `staging` schemas within `analytics`, but not tables in other schemas.
+
+### Multiple Databases
+
+You can monitor tables across multiple databases in a single monitor:
+
+```json
+{
+  "databases": [
+    {"name": "analytics", "schemas": ["core"]},
+    {"name": "raw_data"},
+    {"name": "reporting", "schemas": ["public", "internal"]}
+  ]
+}
+```
+
+---
+
+## Alert Conditions
+
+Alert conditions define which metrics the table monitor tracks. The operator is always AUTO (anomaly detection) -- custom thresholds are not available for table monitors.
+
+| Metric | Description |
+|--------|-------------|
+| `last_updated_on` | Freshness monitoring. Alerts when a table has not been updated within its normal cadence. |
+| `schema` | Any schema change. Alerts when columns are added, removed, or their types change. |
+| `schema_fields_added` | New columns detected. Alerts only when new columns appear in the table. |
+| `schema_fields_removed` | Columns removed. Alerts only when existing columns are dropped from the table. |
+| `schema_fields_type_change` | Column type changes. Alerts only when a column's data type changes. |
+| `total_row_count` | Row count changes. Alerts on anomalous changes in total row count. |
+| `total_row_count_last_changed_on` | Time since last volume change. Alerts when the row count has not changed for an unusual duration. |
+
+### Notes
+
+- **All operators are AUTO (anomaly detection).** Table monitors do not support custom thresholds like GT, LT, or explicit operators. If the user needs custom thresholds, use a metric monitor instead.
+- **No `schedule` field.** Table monitors do not support the `schedule` field in MaC YAML. Adding it will cause a validation error on `montecarlo monitors apply`. Table monitor scheduling is managed automatically by Monte Carlo. Do NOT add a schedule block to the generated YAML.
+- The default set (`last_updated_on`, `schema`, `total_row_count`, `total_row_count_last_changed_on`) provides broad coverage and is appropriate for most use cases. Only override the defaults when the user specifically requests a subset.
+- `schema` is a superset of `schema_fields_added`, `schema_fields_removed`, and `schema_fields_type_change`. If using `schema`, there is no need to also include the granular schema metrics.
+
+---
+
+## Examples
+
+### Monitor all tables in a database (minimal config)
+
+```json
+{
+  "name": "analytics_db_monitor",
+  "description": "Monitor all tables in the analytics database for freshness, schema changes, and volume",
+  "warehouse": "production_warehouse",
+  "asset_selection": {
+    "databases": [
+      {"name": "analytics"}
+    ]
+  }
+}
+```
+
+Uses the default alert conditions (`last_updated_on`, `schema`, `total_row_count`, `total_row_count_last_changed_on`).
+
+### Monitor specific schemas with default alerts
+
+```json
+{
+  "name": "core_schemas_monitor",
+  "description": "Monitor all tables in core and reporting schemas",
+  "warehouse": "production_warehouse",
+  "asset_selection": {
+    "databases": [
+      {
+        "name": "analytics",
+        "schemas": ["core", "reporting"]
+      }
+    ]
+  }
+}
+```
+
+Monitors every table in the `core` and `reporting` schemas, leaving other schemas unmonitored.
+
+### Monitor multiple schemas across databases
+
+```json
+{
+  "name": "prod_tables_monitor",
+  "description": "Monitor production tables across analytics and raw_data databases",
+  "warehouse": "production_warehouse",
+  "asset_selection": {
+    "databases": [
+      {
+        "name": "analytics",
+        "schemas": ["core", "reporting"]
+      },
+      {
+        "name": "raw_data",
+        "schemas": ["ingestion"]
+      }
+    ]
+  }
+}
+```
+
+Monitors tables in specific production schemas, leaving development and staging schemas unmonitored.
+
+### Schema change monitoring only
+
+```json
+{
+  "name": "warehouse_schema_watch",
+  "description": "Track schema changes across the entire data warehouse",
+  "warehouse": "production_warehouse",
+  "asset_selection": {
+    "databases": [
+      {"name": "analytics"},
+      {"name": "raw_data"}
+    ]
+  },
+  "alert_conditions": [
+    "schema_fields_added",
+    "schema_fields_removed",
+    "schema_fields_type_change"
+  ]
+}
+```
+
+Monitors only schema changes (not freshness or volume) across multiple databases. Uses the granular schema metrics instead of `schema` to allow selectively enabling/disabling each type.
+
+---
+
+## Table Monitor vs Metric Monitor
+
+| Aspect | Table Monitor | Metric Monitor |
+|--------|---------------|----------------|
+| **Scope** | Multiple tables (database/schema level) | Single table |
+| **Metrics** | Freshness, schema changes, row count | Field-level metrics (null rate, mean, sum, etc.) |
+| **Operator** | AUTO only (anomaly detection) | AUTO or explicit thresholds (GT, LT, EQ, etc.) |
+| **Asset selection** | Database/schema with filters and exclusions | Single table specified by MCON or name |
+| **Timestamp field** | Not required | Required (`aggregate_time_field`) |
+| **Segmentation** | Not available | Available via `segment_fields` |
+| **Best for** | Broad coverage, freshness, schema drift | Targeted field-level data quality checks |
+
+**Rule of thumb:** If the user wants to monitor a specific field on a specific table with specific thresholds, use a metric monitor. If the user wants broad monitoring across many tables with automatic anomaly detection, use a table monitor.

--- a/skills/monitor-creation/references/validation-monitor.md
+++ b/skills/monitor-creation/references/validation-monitor.md
@@ -1,0 +1,404 @@
+# Validation Monitor Reference
+
+Detailed reference for building `createValidationMonitorMac` tool calls.
+
+## When to Use
+
+Use a validation monitor when the user wants to:
+
+- Check that specific fields are never null
+- Validate that values are within an allowed set (e.g., status in 'active', 'pending', 'inactive')
+- Enforce referential integrity (field values exist in another table)
+- Apply row-level business rules (e.g., "amount must be positive")
+- Combine multiple conditions with AND/OR logic
+
+---
+
+## Getting the Logic Right: Conditions Match INVALID Data
+
+This is the single most confusing aspect of validation monitors and the number one source of mistakes. **Conditions describe what INVALID data looks like -- the data you want to be alerted about.** They do NOT describe what valid data looks like.
+
+Think of it this way: the monitor scans rows and fires an alert when it finds rows matching the condition. So the condition must match the BAD rows.
+
+| User wants | Condition should match | Common mistake |
+|------------|----------------------|----------------|
+| "id should never be null" | id IS NULL (alert when null found) | id IS NOT NULL (would alert on every valid row) |
+| "status must be in [active, pending]" | status NOT IN [active, pending] (alert on unexpected values) | status IN [active, pending] (would alert on valid rows) |
+| "amount must be positive" | amount IS NEGATIVE (alert on bad values) | amount > 0 (would alert on valid rows) |
+| "email must not be empty" | email IS NULL **OR** email = '' (alert on missing) | email IS NOT NULL (would alert on valid rows) |
+
+**Before building any condition, ask yourself: "If a row matches this condition, is the row INVALID?" If the answer is no, the logic is backwards.**
+
+---
+
+## Pre-Step: Verify Field Existence
+
+Before constructing the `alert_condition`, verify that every field name you plan to reference exists in the table's column list. This is the number two source of validation monitor failures -- referencing columns that do not exist or are misspelled.
+
+1. You should already have the column list from `getTable` with `include_fields: true` (done in Step 2 of the main skill).
+2. For every field name in your planned conditions, confirm it appears in the column list exactly as spelled (field names are case-sensitive on most warehouses).
+3. If a field does not exist, stop and ask the user to clarify the correct column name. Do not guess.
+
+---
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Unique identifier for the monitor. Use a descriptive slug (e.g., `orders_not_null_check`). |
+| `description` | string | Human-readable description of what the monitor checks. |
+| `table` | string | Table MCON (preferred) or `database:schema.table` format. If not MCON, also pass `warehouse`. |
+| `alert_condition` | object | Condition tree defining when to alert (see Alert Condition Structure below). |
+
+## Optional Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `warehouse` | string | Warehouse name or UUID. Required if `table` is not an MCON. |
+| `domain_id` | string (uuid) | Domain UUID (use `getDomains` to list). |
+
+---
+
+## Alert Condition Structure
+
+The top level of `alert_condition` must always be a GROUP node. This GROUP contains one or more conditions combined with AND or OR logic.
+
+```json
+{
+  "type": "GROUP",
+  "operator": "AND",
+  "conditions": [...]
+}
+```
+
+### Condition Types
+
+There are four condition types: UNARY, BINARY, SQL, and GROUP.
+
+#### UNARY (single-value checks)
+
+Used for predicates that operate on a single field with no comparison value.
+
+```json
+{
+  "type": "UNARY",
+  "predicate": {"name": "null", "negated": false},
+  "value": [{"type": "FIELD", "field": "column_name"}]
+}
+```
+
+- `predicate.name` -- the predicate to apply (see Predicates Reference below).
+- `predicate.negated` -- set to `true` to invert the predicate (e.g., `null` with `negated: true` means "is NOT null").
+- `value` -- an array with a single value descriptor (usually a FIELD reference).
+
+#### BINARY (comparison checks)
+
+Used for predicates that compare a field against a value.
+
+```json
+{
+  "type": "BINARY",
+  "predicate": {"name": "greater_than", "negated": false},
+  "left": [{"type": "FIELD", "field": "column_name"}],
+  "right": [{"type": "LITERAL", "literal": "0"}]
+}
+```
+
+- `left` -- the left-hand side of the comparison (typically a FIELD reference).
+- `right` -- the right-hand side (typically a LITERAL value, SQL expression, or FIELD reference).
+- Both `left` and `right` are arrays of value descriptors.
+
+#### SQL (custom SQL expression)
+
+Used for complex conditions that are difficult to express with UNARY/BINARY nodes. The SQL expression should evaluate to true for INVALID rows.
+
+```json
+{
+  "type": "SQL",
+  "sql": "amount > 0 AND amount < 1000000"
+}
+```
+
+#### GROUP (nested conditions)
+
+Used to combine multiple conditions with AND or OR logic. Groups can be nested.
+
+```json
+{
+  "type": "GROUP",
+  "operator": "OR",
+  "conditions": [
+    {"type": "UNARY", "...": "..."},
+    {"type": "BINARY", "...": "..."}
+  ]
+}
+```
+
+---
+
+## Value Types
+
+Value descriptors appear in the `value`, `left`, and `right` arrays of UNARY and BINARY conditions.
+
+| Type | Field | Description | Example |
+|------|-------|-------------|---------|
+| `FIELD` | `"field": "column_name"` | References a column in the table. | `{"type": "FIELD", "field": "user_id"}` |
+| `LITERAL` | `"literal": "value"` | A static value (always a string, even for numbers). | `{"type": "LITERAL", "literal": "100"}` |
+| `SQL` | `"sql": "SELECT ..."` | A SQL expression or subquery. | `{"type": "SQL", "sql": "SELECT MAX(id) FROM ref_table"}` |
+
+---
+
+## Predicates Reference
+
+Before building conditions, call `getValidationPredicates` to get the full list of supported predicates for the connected warehouse. The list below covers common predicates but may not be exhaustive.
+
+### Unary Predicates
+
+These predicates take no comparison value -- they check a property of the field itself.
+
+| Predicate | Description | Example use |
+|-----------|-------------|-------------|
+| `null` | Field value is null. | Alert on null ids. |
+| `is_negative` | Field value is negative. | Alert on negative amounts. |
+| `is_between_0_and_1` | Field value is between 0 and 1 (inclusive). | Alert on rates that should be percentages (0-100). |
+| `is_future_date` | Field value is a date/timestamp in the future. | Alert on future-dated records. |
+| `is_uuid` | Field value matches UUID format. | Alert on non-UUID values in a UUID field (use with `negated: true`). |
+
+### Binary Predicates
+
+These predicates compare a field against a value.
+
+| Predicate | Right-hand side | Description | Example use |
+|-----------|----------------|-------------|-------------|
+| `equal` | Single LITERAL | Field equals the given value. | Alert when `status` equals `'deleted'`. |
+| `greater_than` | Single LITERAL | Field is greater than the given value. | Alert when `discount_pct` exceeds 100. |
+| `less_than` | Single LITERAL | Field is less than the given value. | Alert when `quantity` is below 0. |
+| `in_set` | Multiple LITERALs | Field value is in the given set. | Alert when `status` is in an invalid set (see example below). |
+| `contains` | Single LITERAL | Field value contains the given substring. | Alert when `email` contains `'test@'`. |
+| `starts_with` | Single LITERAL | Field value starts with the given prefix. | Alert when `phone` starts with `'000'`. |
+| `between` | Two LITERALs | Field value is between the two given values (inclusive). | Alert when `score` is between 0 and 10 (if that range is invalid). |
+
+### Using `negated` to Invert Predicates
+
+Any predicate can be inverted by setting `"negated": true` in the predicate object. This is essential for "must be in set" validations:
+
+- **"status must be in [active, pending]"** becomes `in_set` with values `["active", "pending"]` and `negated: true` -- meaning "alert when status is NOT in [active, pending]".
+- **"id must not be null"** becomes `null` with `negated: false` -- meaning "alert when id IS null" (no inversion needed since the condition already matches invalid data).
+
+---
+
+## Examples
+
+### Alert when id is null
+
+Verify that `id` exists in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "orders_id_not_null",
+  "description": "Alert when order id is null",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "AND",
+    "conditions": [
+      {
+        "type": "UNARY",
+        "predicate": {"name": "null", "negated": false},
+        "value": [{"type": "FIELD", "field": "id"}]
+      }
+    ]
+  }
+}
+```
+
+The condition matches rows where `id` IS NULL -- these are the invalid rows we want to be alerted about.
+
+### Alert when status is not in allowed set
+
+Verify that `status` exists in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "orders_status_allowed_values",
+  "description": "Alert when order status is outside the allowed set",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "AND",
+    "conditions": [
+      {
+        "type": "BINARY",
+        "predicate": {"name": "in_set", "negated": true},
+        "left": [{"type": "FIELD", "field": "status"}],
+        "right": [
+          {"type": "LITERAL", "literal": "active"},
+          {"type": "LITERAL", "literal": "pending"},
+          {"type": "LITERAL", "literal": "inactive"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note `negated: true` -- the predicate is `in_set`, but we want to alert when the value is NOT in the set. This catches any unexpected status values.
+
+### Alert when amount is negative
+
+Verify that `amount` exists in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "orders_positive_amount",
+  "description": "Alert when order amount is negative",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "AND",
+    "conditions": [
+      {
+        "type": "UNARY",
+        "predicate": {"name": "is_negative", "negated": false},
+        "value": [{"type": "FIELD", "field": "amount"}]
+      }
+    ]
+  }
+}
+```
+
+The condition matches rows where `amount` is negative -- these are the invalid rows.
+
+### Combined conditions: null OR negative
+
+Verify that both `amount` and `quantity` exist in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "orders_amount_quality",
+  "description": "Alert when amount is null or quantity is negative",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "OR",
+    "conditions": [
+      {
+        "type": "UNARY",
+        "predicate": {"name": "null", "negated": false},
+        "value": [{"type": "FIELD", "field": "amount"}]
+      },
+      {
+        "type": "UNARY",
+        "predicate": {"name": "is_negative", "negated": false},
+        "value": [{"type": "FIELD", "field": "quantity"}]
+      }
+    ]
+  }
+}
+```
+
+The OR operator means an alert fires if either condition matches -- the row has a null amount OR a negative quantity.
+
+### Between check with nested AND/OR
+
+Verify that `score` and `status` exist in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "records_score_validation",
+  "description": "Alert when score is outside 0-100 range for active records",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++warehouse:metrics.records",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "AND",
+    "conditions": [
+      {
+        "type": "BINARY",
+        "predicate": {"name": "equal", "negated": false},
+        "left": [{"type": "FIELD", "field": "status"}],
+        "right": [{"type": "LITERAL", "literal": "active"}]
+      },
+      {
+        "type": "BINARY",
+        "predicate": {"name": "between", "negated": true},
+        "left": [{"type": "FIELD", "field": "score"}],
+        "right": [
+          {"type": "LITERAL", "literal": "0"},
+          {"type": "LITERAL", "literal": "100"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+This uses `between` with `negated: true` to alert when score is outside the 0-100 range, but only for active records (the AND operator requires both conditions to match).
+
+### Referential integrity with SQL subquery
+
+Verify that `customer_id` exists in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "orders_valid_customer",
+  "description": "Alert when customer_id does not exist in customers table",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++analytics:core.orders",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "AND",
+    "conditions": [
+      {
+        "type": "SQL",
+        "sql": "customer_id IS NOT NULL AND customer_id NOT IN (SELECT id FROM analytics.core.customers)"
+      }
+    ]
+  }
+}
+```
+
+The SQL condition type is useful for referential integrity checks that require subqueries. The `customer_id IS NOT NULL` guard avoids alerting on null values (which should be caught by a separate null check if needed).
+
+### Contains and starts_with checks
+
+Verify that `email` and `phone` exist in the table schema from `getTable` before proceeding.
+
+```json
+{
+  "name": "contacts_format_validation",
+  "description": "Alert when email contains test data or phone has invalid prefix",
+  "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++warehouse:crm.contacts",
+  "alert_condition": {
+    "type": "GROUP",
+    "operator": "OR",
+    "conditions": [
+      {
+        "type": "BINARY",
+        "predicate": {"name": "contains", "negated": false},
+        "left": [{"type": "FIELD", "field": "email"}],
+        "right": [{"type": "LITERAL", "literal": "@test.example.com"}]
+      },
+      {
+        "type": "BINARY",
+        "predicate": {"name": "starts_with", "negated": false},
+        "left": [{"type": "FIELD", "field": "phone"}],
+        "right": [{"type": "LITERAL", "literal": "000"}]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Fallback: Custom SQL Monitor
+
+If `createValidationMonitorMac` fails -- for example because a referenced column does not exist yet in the live table, or the warehouse does not support a particular predicate -- fall back to `createCustomSqlMonitorMac` with an explicit SQL query instead.
+
+A custom SQL monitor lets you express any validation logic as a SQL query that returns rows or a count. This is always available as a backup when the structured validation condition tree cannot express what you need or encounters an API error.
+
+When falling back:
+
+1. Translate the intended validation logic into a SQL query.
+2. The SQL should select rows that violate the rule (matching the same "conditions match INVALID data" principle).
+3. Use `createCustomSqlMonitorMac` with the translated query.
+4. Inform the user that you used a custom SQL monitor as a fallback and explain why.

--- a/skills/prevent/references/workflows.md
+++ b/skills/prevent/references/workflows.md
@@ -69,6 +69,8 @@ Skip Workflow 4 for new models — there is no existing blast radius to assess.
 
 ## Workflow 2: Add a monitor — when new transformation logic is added
 
+> **For detailed monitor creation guidance** — including parameter validation, field-type compatibility checks, and common error prevention — see the `monitor-creation` skill (`skills/monitor-creation/SKILL.md`). The workflow below is a quick-path for the common "just added a column, offer a monitor" case within a prevent session.
+
 When the user adds a new column, filter, or business rule, suggest adding a monitor. First, choose the monitor type based on what the new logic does:
 
 ```


### PR DESCRIPTION
## Summary

- New **monitor-creation** skill that guides AI agents through a validate-before-create workflow for Monte Carlo monitors, eliminating common errors like invalid field types, nonexistent table references, and missing required parameters
- Wired into all 5 editor plugins (Claude Code, Cursor, Copilot, Codex, OpenCode) via symlinks
- Cross-reference from prevent's Workflow 2 to the new skill for detailed monitor creation guidance

## Context

Addresses [K2-260](https://linear.app/montecarlodata/issue/K2-260): agents calling monitor creation MCP tools with invalid parameters — wrong field types, nonexistent tables, missing required fields.

## Key Decisions

- **Adapted from ai-agent skill docs + PR #21** rather than writing from scratch — the existing ai-agent skill docs had comprehensive monitor creation guidance for LangGraph agents. PR #21 had already adapted these for the SKILL.md format. Reused that content, updated for the current repo structure.
- **No separate plugin** — the repo restructured to a unified `mc-agent-toolkit` plugin per editor since PR #21. The skill is added via symlinks in each plugin's `skills/` directory, matching the pattern used by prevent, push-ingestion, and generate-validation-notebook.
- **No hooks** — skill content alone is sufficient to guide agents correctly. The validate-before-create procedure in SKILL.md enforces the workflow via instructions, not code gates.
- **Documented schedule/aggregation compatibility** — discovered during testing that `aggregate_by: "day"` fails with the MCP tool's default 60-minute schedule. Added a compatibility note to the metric-monitor reference so agents pass valid `interval_minutes`. A fix for the MCP tool itself is ready in the ai-agent repo (separate PR).
- **table-deep-dive and critical-tables skills out of scope** — both depend on internal LangGraph tools (`run_custom_sql`, `getUseCases`) not available on the public MCP server.

## Test plan

- [x] Install locally: `claude --plugin-dir ./plugins/claude-code`
- [x] Verify skill activates on monitor creation prompts (e.g. "create a null check monitor for the orders table")
- [x] Verify validate-before-create flow: table resolution via `search`, schema check via `getTable`, domain handling
- [x] Verify reference docs load correctly via Read tool
- [x] Verify symlinks resolve in all five plugin directories
- [x] Verify generated metric monitor YAML applies via `montecarlo monitors apply --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)