### PR TITLE
fix: add missing name field to generate-validation-notebook SKILL.md

### DIFF
--- a/skills/generate-validation-notebook/SKILL.md
+++ b/skills/generate-validation-notebook/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: generate-validation-notebook
 description: Generate SQL validation notebooks for dbt changes. Pass a GitHub PR URL or local dbt repo path.
 ---
 


### PR DESCRIPTION
## Summary

- Adds the required `name` field to `skills/generate-validation-notebook/SKILL.md`, which was the only skill missing it

## Why

The [Agent Skills specification](https://agentskills.io/specification) requires a `name` field in SKILL.md frontmatter. Without it, the skill fails validation on [skills.sh](https://skills.sh) and other registries that enforce the spec. This is a prerequisite for listing mc-agent-toolkit on those registries.

## Note on name/directory mismatches in other skills

The spec also states that the `name` field must match the parent directory name. Three other skills currently use names that differ from their directory:

| Directory | `name` in SKILL.md |
|---|---|
| `prevent/` | `monte-carlo-prevent` |
| `monitor-creation/` | `monte-carlo-monitor-creation` |
| `push-ingestion/` | `push-ingestion` ✅ |

This is intentional — Claude Code uses the `name` field (not the directory name) to determine the skill's invocation name within the plugin namespace. Renaming them to match the directories would change how users invoke them (e.g. `/mc-agent-toolkit:monte-carlo-prevent` would become `/mc-agent-toolkit:prevent`), which is a breaking change for existing users.

For now, we're keeping the existing names as-is and accepting that skills.sh validation may flag them. If this becomes a blocker for registry listing, we can revisit — but the tradeoff favors not breaking existing Claude Code plugin users.

## Test plan

- [x] Verify `generate-validation-notebook` skill still works in Claude Code (`/mc-agent-toolkit:generate-validation-notebook`)
- [x] Run `npx skills add monte-carlo-data/mc-agent-toolkit --list` to confirm skills.sh picks up the skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)