### PR TITLE
Add remediation skill for investigating and fixing data quality alerts

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -1,0 +1,52 @@
+---
+description: Rules for authoring agent skills in mc-agent-toolkit
+paths:
+  - "skills/**"
+---
+
+# Skill Authoring Rules
+
+## SKILL.md description must be ≤250 characters
+
+The `description` field in a skill's SKILL.md frontmatter must be a single line of 250 characters or fewer. This field is used as a skill selector in editor UIs and MCP registries — long descriptions get truncated or rejected.
+
+**Good:**
+```yaml
+description: Investigate and remediate data quality alerts using Monte Carlo MCP tools. Runs root cause analysis, assesses blast radius, discovers available tools, proposes and executes fixes.
+```
+
+**Bad (multi-line or >250 chars):**
+```yaml
+description: |
+  Activates when a user asks to remediate, fix, or respond to a data quality alert
+  or incident. Investigates the alert using Monte Carlo MCP tools...
+```
+
+Always count characters before committing. A quick check: `echo -n "your description" | wc -c`.
+
+## MCP tool names in skill docs must use snake_case
+
+When referencing Monte Carlo MCP tools in skill files (SKILL.md, references/*.md, patterns), always use snake_case matching the actual tool names — not camelCase.
+
+**Correct:**
+```
+get_alerts(...)
+run_troubleshooting_agent(...)
+get_asset_lineage(...)
+get_table(...)
+get_monitors(...)
+get_queries_for_table(...)
+get_troubleshooting_agent_results(...)
+create_or_update_alert_comment(...)
+update_alert(...)
+set_alert_owner(...)
+```
+
+**Wrong:**
+```
+getAlerts(...)
+runTroubleshootingAgent(...)
+getAssetLineage(...)
+```
+
+The actual MCP tool names follow the `mcp__<server>__<tool_name>` convention where `tool_name` is always snake_case. Using camelCase causes the agent to hallucinate tool names that don't exist.

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ bun.lock
 .DS_Store
 .venv/
 target/
-.claude/
+.claude/settings.local.json
 temp/
 __pycache__/
 *.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ mc-agent-toolkit/
 │   │   ├── SKILL.md
 │   │   └── references/
 │   ├── generate-validation-notebook/
-│   └── push-ingestion/
+│   ├── monitoring-advisor/
+│   ├── push-ingestion/
+│   └── remediation/
 │
 ├── plugins/
 │   ├── shared/                          # Platform-agnostic hook logic
@@ -25,7 +27,7 @@ mc-agent-toolkit/
 │   ├── claude-code/                     # Unified mc-agent-toolkit plugin
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── hooks/prevent/              # Hook adapters (thin, call shared lib)
-│   │   ├── skills/ (monitor-creation, monitoring-advisor, prevent, generate-validation-notebook, push-ingestion → symlinks)
+│   │   ├── skills/ (monitor-creation, monitoring-advisor, prevent, generate-validation-notebook, push-ingestion, remediation → symlinks)
 │   │   └── commands/ (prevent/, push-ingestion/, monitoring-advisor/)
 │   │
 │   ├── cursor/                          # Unified mc-agent-toolkit plugin

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,6 +13,7 @@ Skills are platform-agnostic instruction sets that tell an AI coding agent what 
 | **[Push Ingestion](push-ingestion/)** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. |
 | **[Storage Cost Analysis](storage-cost-analysis/)** | Identifies storage waste patterns (unread, zombie, dead-end tables) and recommends safe cleanup with cost estimates. |
 | **[Performance Diagnosis](performance-diagnosis/)** | Diagnoses slow pipelines and expensive queries across Airflow, dbt, and Databricks with tiered investigation. |
+| **[Remediation](remediation/)** | Investigates and remediates data quality alerts — runs TSA root cause analysis, discovers available tools, executes fixes (or escalates), and documents the resolution. |
 
 ## Standalone Installation
 

--- a/skills/remediation/README.md
+++ b/skills/remediation/README.md
@@ -1,0 +1,111 @@
+# Monte Carlo Remediation Skill
+
+Investigate and fix data quality issues detected by Monte Carlo — automatically, with safety rails.
+
+## What this does
+
+When you have a data quality alert (freshness, volume, schema change, etc.), this skill guides an AI coding agent through the full remediation lifecycle:
+
+1. **Investigate** — fetches alert details, runs TSA root cause analysis, maps blast radius via lineage, checks table state and monitoring coverage
+2. **Discover capabilities** — scans connected MCP servers to determine what remediation actions are possible (pipeline restarts, dbt reruns, code fixes, notifications)
+3. **Remediate** — proposes a fix with clear reasoning, confirms with the user, executes via available tools, and verifies the result
+4. **Close out** — updates alert status, documents what was done, and suggests prevention measures
+
+The skill works with whatever tools you have connected. If an Airflow MCP is available, it can restart pipelines. If only Slack is connected, it escalates with full context. If no external MCPs are connected, it produces a detailed remediation plan you can execute manually.
+
+## Design: single document, not playbooks
+
+This skill uses a single `SKILL.md` with reference examples — not separate playbooks for each alert type. Here's why:
+
+**Opus-class models generalize better from examples + principles than from rigid playbook branching.** A single document that teaches the reasoning pattern (investigate → discover capabilities → select action → execute safely) handles edge cases and combined root causes naturally. Real incidents rarely fit neatly into a single category — a freshness alert might be caused by a schema change upstream that broke a dbt model. Rigid playbooks force the agent down a single path; principles let it compose the right response.
+
+**Maintenance scales linearly with playbooks, but not with principles.** Adding a new alert type or remediation pattern means adding an example to `references/patterns.md` — not creating and maintaining a new playbook file with its own workflow, tool table, and edge case handling.
+
+**The reference examples are illustrative, not prescriptive.** They show the agent what good remediation looks like for common patterns. The agent uses these as a starting point and adapts based on the specific TSA findings and available tools.
+
+## Editor & stack compatibility
+
+The skill works with any AI editor that supports MCP and the Agent Skills format — including Claude Code, Cursor, and VS Code.
+
+| Stack | Support | Notes |
+|---|---|---|
+| Any MC-supported warehouse | ✅ Full | Investigation works for all warehouse types |
+| Airflow / Dagster / Prefect | ✅ Full (with MCP) | Can restart pipelines automatically |
+| dbt Cloud | ✅ Full (with MCP) | Can rerun dbt jobs automatically |
+| GitHub / GitLab | ✅ Full (with MCP) | Can create PRs for code fixes |
+| Slack / PagerDuty | ✅ Full (with MCP) | Can escalate and notify |
+| No external MCPs | 🟡 Investigation only | Produces remediation plan for manual execution |
+
+## Prerequisites
+
+- Claude Code, Cursor, VS Code, or any editor with MCP support
+- Monte Carlo account with Editor role or above
+- Monte Carlo MCP server configured and authenticated
+
+**Optional but recommended** (for automated execution):
+- One or more external MCP servers for your pipeline orchestrator, code platform, or notification system
+
+## Setup
+
+### Via the mc-agent-toolkit plugin (recommended)
+
+Install the plugin for your editor — it bundles the skill, MCP server, and permissions automatically. See the [main README](../../README.md#installing-the-plugin-recommended) for editor-specific instructions.
+
+### Standalone
+
+1. Configure the Monte Carlo MCP server:
+   ```
+   claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+   ```
+
+2. Install the skill:
+   ```bash
+   npx skills add monte-carlo-data/mc-agent-toolkit --skill remediation
+   ```
+
+3. Authenticate: run `/mcp` in your editor, select `monte-carlo-mcp`, and complete the OAuth flow.
+
+4. Verify: ask your editor "Test my Monte Carlo connection" — it should call `testConnection` and confirm.
+
+### Adding external MCPs for execution
+
+The remediation skill can use any MCP server you have configured. Here are common ones for data teams:
+
+| MCP Server | What it enables | Setup |
+|---|---|---|
+| **Airflow** | Restart DAGs, retry failed tasks | [Airflow MCP](https://github.com/apache/airflow-mcp) |
+| **dbt Cloud** | Rerun dbt jobs | [dbt Cloud MCP](https://github.com/dbt-labs/dbt-cloud-mcp) |
+| **GitHub** | Create PRs for code fixes | [GitHub MCP](https://github.com/github/github-mcp-server) |
+| **Slack** | Notify teams, escalate issues | [Slack MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/slack) |
+| **PagerDuty** | Page on-call for critical incidents | [PagerDuty MCP](https://github.com/PagerDuty/mcp-server-pagerduty) |
+
+## How to use it
+
+Open your editor and prompt with the alert or issue you want to fix. Examples:
+
+```
+"Remediate alert ABC-123"
+
+"Fix the freshness issue on the orders table"
+
+"We have a schema change alert on raw_events — can you investigate and fix it?"
+
+"Triage and remediate all open alerts on the analytics schema"
+
+"The daily pipeline hasn't run — diagnose and fix it"
+```
+
+The skill handles the full workflow: investigation → capability discovery → remediation → verification → documentation. It will ask for confirmation before taking any destructive action.
+
+## Safety
+
+The skill has built-in safety rails:
+
+- **Always explains** what it's about to do and why before executing
+- **Always confirms** destructive operations (pipeline triggers, data modifications, code changes)
+- **Escalates** when uncertain rather than guessing at a fix
+- **Documents** all findings and actions on the alert
+- **Never chains** multiple actions without verifying each one
+- **Never modifies data** without explicit confirmation and a rollback plan
+
+See `references/safety.md` for the complete safety protocol.

--- a/skills/remediation/README.md
+++ b/skills/remediation/README.md
@@ -11,7 +11,7 @@ When you have a data quality alert (freshness, volume, schema change, etc.), thi
 3. **Remediate** — proposes a fix with clear reasoning, confirms with the user, executes via available tools, and verifies the result
 4. **Close out** — updates alert status, documents what was done, and suggests prevention measures
 
-The skill works with whatever tools you have connected. If an Airflow MCP is available, it can restart pipelines. If only Slack is connected, it escalates with full context. If no external MCPs are connected, it produces a detailed remediation plan you can execute manually.
+The skill works with whatever tools you have connected. If an Airflow MCP is available, it can restart pipelines. If no external MCPs are connected, it produces a detailed remediation plan with manual commands and asks you how to proceed.
 
 ## Design: single document, not playbooks
 
@@ -33,8 +33,7 @@ The skill works with any AI editor that supports MCP and the Agent Skills format
 | Airflow / Dagster / Prefect | ✅ Full (with MCP) | Can restart pipelines automatically |
 | dbt Cloud | ✅ Full (with MCP) | Can rerun dbt jobs automatically |
 | GitHub / GitLab | ✅ Full (with MCP) | Can create PRs for code fixes |
-| Slack / PagerDuty | ✅ Full (with MCP) | Can escalate and notify |
-| No external MCPs | 🟡 Investigation only | Produces remediation plan for manual execution |
+| No external MCPs | 🟡 Investigation only | Produces remediation plan with manual commands, asks user for next steps |
 
 ## Prerequisites
 
@@ -76,8 +75,6 @@ The remediation skill can use any MCP server you have configured. Here are commo
 | **Airflow** | Restart DAGs, retry failed tasks | [Airflow MCP](https://github.com/apache/airflow-mcp) |
 | **dbt Cloud** | Rerun dbt jobs | [dbt Cloud MCP](https://github.com/dbt-labs/dbt-cloud-mcp) |
 | **GitHub** | Create PRs for code fixes | [GitHub MCP](https://github.com/github/github-mcp-server) |
-| **Slack** | Notify teams, escalate issues | [Slack MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/slack) |
-| **PagerDuty** | Page on-call for critical incidents | [PagerDuty MCP](https://github.com/PagerDuty/mcp-server-pagerduty) |
 
 ## How to use it
 
@@ -103,7 +100,7 @@ The skill has built-in safety rails:
 
 - **Always explains** what it's about to do and why before executing
 - **Always confirms** destructive operations (pipeline triggers, data modifications, code changes)
-- **Escalates** when uncertain rather than guessing at a fix
+- **Asks the user** when uncertain rather than guessing at a fix
 - **Documents** all findings and actions on the alert
 - **Never chains** multiple actions without verifying each one
 - **Never modifies data** without explicit confirmation and a rollback plan

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -104,6 +104,8 @@ This returns `triage_confidence` (HIGH/MEDIUM/LOW), `alert_impact` (HIGH/MEDIUM/
 
 #### Step 3: Root cause analysis (TSA)
 
+**Always use async mode.** TSA analysis takes 4–8 minutes — sync mode will time out.
+
 ```
 runTroubleshootingAgent(
   incident_id="<alert_uuid>",
@@ -111,7 +113,8 @@ runTroubleshootingAgent(
 )
 ```
 
-Then poll for results (wait 30s initially, then 60s intervals):
+**While TSA runs, proceed with Steps 4–6 in parallel** — gather lineage, table context, and query data while waiting. Then poll for TSA results:
+
 ```
 getTroubleshootingAgentResults(
   incident_id="<alert_uuid>"
@@ -120,11 +123,11 @@ getTroubleshootingAgentResults(
 
 Status values:
 - `not_found` → TSA hasn't been triggered yet
-- `running` → still analyzing (keep polling)
-- `success` → read the `tldr` for the root cause summary, `full_response` for details
+- `running` → still analyzing (wait 30s initially, then 60s intervals)
+- `success` → results available
 - `failed` → check `full_response` for error; proceed with manual investigation
 
-**The TSA `tldr` is your primary input for choosing a remediation action.** Read it carefully.
+**When TSA succeeds, read both the `tldr` and the verifications section.** The `tldr` summarizes the root cause — this is your primary input for choosing a remediation action. The `full_response` includes a "verifications to confirm the root cause" section with specific checks (queries to run, things to compare, upstream systems to inspect). These verifications are often actionable remediation steps themselves — use them to guide what to do next or present them to the user as concrete next steps.
 
 #### Step 4: Assess blast radius
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -264,21 +264,15 @@ Based on the TSA root cause and available tools, determine the action:
 > **Risk:** [what could go wrong, blast radius]
 > **Rollback:** [how to undo if the fix causes new problems]"
 
-Read `references/safety.md` for detailed safety protocols.
-
 #### Step 3: Execute (with safety rails)
 
-**Safety rules — these are non-negotiable:**
+Before executing, read `references/safety.md` for the full safety protocol. The essentials:
 
-1. **Always explain before executing.** Never run a remediation action without first telling the user what you're about to do and why.
-
-2. **Confirm destructive operations.** Any action that modifies data, restarts a pipeline, triggers a job, or changes configuration requires explicit user confirmation. Ask and wait for "yes", "go ahead", "proceed", or similar.
-
-3. **Ask the user when uncertain.** If you're not confident the action will fix the issue without side effects, say so. Present what you know, what you're unsure about, and ask the user how they'd like to proceed.
-
-4. **One action at a time.** Don't chain multiple remediation actions. Execute one, verify the result, then decide on the next step.
-
-5. **Log everything.** After each action, document what you did on the alert using `createOrUpdateAlertComment`.
+- **Explain before executing** — never take action without telling the user what and why
+- **Confirm destructive operations** — wait for explicit user approval
+- **Ask the user when uncertain** — don't guess at a fix
+- **One action at a time** — execute, verify, then decide next step
+- **Log everything** — document each action on the alert via `createOrUpdateAlertComment`
 
 #### Step 4: Verify the fix
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -171,6 +171,15 @@ getTable(mcon="<downstream_mcon>")
 getMonitors(mcons=["<affected_table_mcon>"])
 ```
 
+For **Custom SQL** or **Validation** alerts, also fetch the monitor configuration to understand the exact rule that breached:
+```
+getMonitors(
+  monitor_ids=["<monitor_id_from_alert>"],
+  include_fields=["config"]
+)
+```
+The config contains the SQL query or validation conditions — this tells you exactly what the monitor checks, which is essential for understanding what went wrong and what the fix should be.
+
 ```
 getQueriesForTable(
   mcon="<affected_table_mcon>",
@@ -183,13 +192,16 @@ Use `query_type="destination"` to find queries that write to this table (pipelin
 
 #### Investigation summary
 
-After completing Steps 1–6, synthesize your findings into a clear summary:
+**Wait for TSA to complete before presenting findings.** Do not present partial results — the TSA root cause analysis and its verifications section are critical for choosing the right remediation action. If TSA is still running, keep polling; gather Steps 4–6 in the meantime.
+
+After all steps are complete, synthesize your findings into a clear summary:
 
 1. **What happened:** alert type, when it fired, severity
 2. **Root cause:** TSA findings (or your best assessment if TSA failed)
-3. **Blast radius:** N downstream consumers, any key assets affected
-4. **Pipeline context:** which queries/jobs write to this table, when they last ran
-5. **Monitoring:** what monitors exist, any gaps
+3. **TSA verifications:** specific checks from the TSA `full_response` that can confirm the root cause or serve as remediation steps
+4. **Blast radius:** N downstream consumers, any key assets affected
+5. **Pipeline context:** which queries/jobs write to this table, when they last ran
+6. **Monitoring:** what monitors exist, any gaps. Note recurring patterns (e.g., "16 incidents in 30 days" signals a chronic issue, not a one-off)
 
 Present this summary to the user before proceeding to remediation.
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -68,14 +68,15 @@ All tools are available via the `monte-carlo` MCP server.
 
 ### External tools (remediation execution)
 
-These are **not** Monte Carlo tools. They come from external MCP servers the user may have configured. Their availability varies — see Workflow 2 (Capability Discovery) for how to detect them at runtime.
+These are **not** Monte Carlo tools. They may be available as MCP servers, CLI tools, or APIs. Their availability varies — see Workflow 2 (Capability Discovery) for how to detect them at runtime.
 
-| Capability | Example MCP Servers | Example Tools |
-| ---------- | ------------------- | ------------- |
-| Pipeline orchestration | Airflow, Dagster, Prefect | `trigger_dag_run`, `get_task_status`, `retry_task` |
-| dbt operations | dbt Cloud | `trigger_run`, `get_run`, `list_jobs` |
-| Code changes | GitHub, GitLab | `create_pull_request`, `create_issue`, `create_branch` |
-| Data warehouse | Snowflake, BigQuery, Databricks | `execute_query`, `get_table_info` |
+| Capability | MCP Servers | CLI Tools | What they enable |
+| ---------- | ----------- | --------- | ---------------- |
+| Pipeline orchestration | Airflow, Dagster, Prefect | `airflow`, `dagster`, `prefect` | Trigger runs, retry tasks, check status |
+| dbt operations | dbt Cloud | `dbt` | Trigger job runs, rebuild models, run tests |
+| Code changes | GitHub, GitLab | `gh`, `git` | Create PRs, branches, issues |
+| Data warehouse | Snowflake, BigQuery, Databricks | `snowsql`, `bq`, `databricks` | Execute queries, inspect tables |
+| Any HTTP API | — | `curl` | Call any service REST API directly |
 
 ---
 
@@ -219,47 +220,34 @@ Present this summary to the user before proceeding to remediation.
 
 **Goal:** Determine what remediation actions are possible given the tools you have available.
 
-Before attempting any remediation action, you must know what tools you can use. You cannot assume any external MCP server is connected.
+Before attempting any remediation action, you must know what tools you can use. You have three categories to check:
 
-#### How tool discovery works
+1. **MCP servers** — scan your tool list for `mcp__*__*` patterns (e.g., `mcp__airflow__trigger_dag_run`)
+2. **CLI tools** — you have shell access; check for tools like `gh`, `dbt`, `airflow`, `curl` via `which <tool>`
+3. **APIs** — any service with a REST API is reachable via `curl` if you have the right credentials
 
-Your available tools are listed in your system prompt or tool inventory. External MCP tools follow the naming convention `mcp__<server_name>__<tool_name>`.
+Don't assume any particular tool is available. But also don't assume MCP is the only option — a `gh pr create` via the CLI works just as well as a GitHub MCP tool.
 
-Scan your available tools and look for these patterns:
-
-| Pattern | Capability | What you can do |
-| ------- | ---------- | --------------- |
-| `mcp__*airflow*__*` | Pipeline orchestration (Airflow) | Trigger DAG runs, retry failed tasks, check task status |
-| `mcp__*dagster*__*` | Pipeline orchestration (Dagster) | Trigger pipeline runs, check run status |
-| `mcp__*prefect*__*` | Pipeline orchestration (Prefect) | Trigger flow runs, check run status |
-| `mcp__*dbt*__*` | dbt operations | Trigger dbt job runs, check run status, list jobs |
-| `mcp__*github*__*` | Code changes | Create PRs, open issues, create branches |
-| `mcp__*gitlab*__*` | Code changes | Create merge requests, open issues |
-| `mcp__*snowflake*__*`, `mcp__*bigquery*__*`, `mcp__*databricks*__*` | Data warehouse | Run queries, inspect tables directly |
-
-**If a capability is not found:** That's fine. Not every remediation requires every tool. The skill degrades gracefully — see "Graceful degradation" below.
+For detailed guidance on discovery across all three categories, read `references/tool-discovery.md`.
 
 #### Capability assessment
 
-After scanning, summarize what's available:
+After checking, summarize what's available:
 
-> "Based on your connected MCP servers, I can:
-> - ✅ Investigate via Monte Carlo (always available)
-> - ✅/❌ Restart pipelines (Airflow/Dagster/Prefect)
-> - ✅/❌ Rerun dbt jobs (dbt Cloud)
-> - ✅/❌ Create code changes (GitHub/GitLab)
-> - ✅/❌ Query the warehouse directly"
-
-For detailed guidance on tool discovery, read `references/tool-discovery.md`.
+> "For this remediation, I can:
+> - ✅ Investigate via Monte Carlo (MCP connected)
+> - ✅ Restart the Airflow DAG (Airflow MCP connected)
+> - ✅ Create a code fix (`gh` CLI available)
+> - ❌ Rerun the dbt job (no dbt Cloud MCP or `dbt` CLI found)"
 
 #### Graceful degradation
 
-When the needed execution tool is NOT available:
+When no tool (MCP, CLI, or API) is available for a needed action:
 
 1. **Always produce the remediation plan** — describe exactly what needs to happen, step by step
-2. **Provide runnable commands** — if the fix is "restart this Airflow DAG", give the user the `airflow dags trigger <dag_id>` command they can run manually
-3. **Present findings and ask for next steps** — tell the user what you found, what you recommend, and ask how they'd like to proceed. They may choose to run commands manually, notify their team via Slack, page on-call, or take a different approach entirely.
-4. **Document on the alert** — use `createOrUpdateAlertComment` to record the diagnosis and recommended fix, even if you can't execute it
+2. **Provide runnable commands** — give the user the exact commands they can run manually (e.g., `airflow dags trigger <dag_id>`, `dbt run --select <model>`)
+3. **Present findings and ask for next steps** — tell the user what you found, what you recommend, and ask how they'd like to proceed
+4. **Document on the alert** — use `createOrUpdateAlertComment` to record the diagnosis and recommended fix
 
 ---
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -282,17 +282,13 @@ Before executing, read `references/safety.md` for the full safety protocol. The 
 
 #### Step 1: Update the alert
 
-```
-updateAlert(
-  alert_id="<alert_uuid>",
-  status="FIXED"
-)
-```
+Ask the user what status to set:
 
-Use the appropriate status:
 - `FIXED` — the root cause was identified and remediated
 - `EXPECTED` — the alert fired on expected behavior (e.g., planned maintenance)
 - `NO_ACTION_NEEDED` — the issue resolved itself or is not actionable
+
+Then call `updateAlert(alert_id="<alert_uuid>", status="<chosen_status>")`.
 
 #### Step 2: Document the remediation
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: monte-carlo-remediation
+description: |
+  Activates when a user asks to remediate, fix, or respond to a data quality alert
+  or incident. Investigates the alert using Monte Carlo MCP tools (alerts, TSA root
+  cause analysis, lineage, table metadata), discovers what remediation tools are
+  available via connected MCP servers, reasons about the appropriate fix, and
+  executes it — or escalates to a human with full context when uncertain. Do not
+  wait to be asked for details: once activated, run the full investigation workflow
+  before proposing any action.
+version: 1.0.0
+---
+
+# Monte Carlo Remediation Skill
+
+This skill teaches you to investigate and remediate data quality issues detected by Monte Carlo. You use MC MCP tools to understand the alert context, run root cause analysis, assess blast radius, and then execute the appropriate remediation action using whatever external tools the user has connected.
+
+Reference files live next to this skill file. **Use the Read tool** (not MCP resources) to access them:
+
+- Common remediation patterns and examples: `references/patterns.md` (relative to this file)
+- How to discover available tools at runtime: `references/tool-discovery.md` (relative to this file)
+- Safety rails and escalation criteria: `references/safety.md` (relative to this file)
+
+## When to activate this skill
+
+Activate when the user:
+
+- Asks to remediate, fix, or respond to a data quality alert or incident
+- Mentions a specific alert ID, incident, or data quality issue they want resolved
+- Says something like "fix the freshness issue on X", "remediate this alert", "handle this incident"
+- Asks to triage AND fix an alert (triage alone without remediation intent → use the prevent skill's Workflow 3 instead)
+- Wants to automate a response to a recurring data quality pattern
+- Asks "what should I do about this alert?" or "how do I fix this?"
+
+## When NOT to activate this skill
+
+Do not activate when the user is:
+
+- Just triaging or investigating an alert without remediation intent (use prevent skill's Workflow 3)
+- Creating or configuring monitors (use the monitor-creation skill)
+- Running a change impact assessment before code changes (use the prevent skill's Workflow 4)
+- Asking about general data quality best practices without a specific incident
+- Exploring table health or lineage without an active issue to fix
+
+---
+
+## Available MCP tools
+
+### Monte Carlo tools (investigation + post-remediation)
+
+All tools are available via the `monte-carlo` MCP server.
+
+| Tool | Purpose |
+| ---- | ------- |
+| `getAlerts` | Fetch alert details — type, severity, affected tables, timestamps |
+| `alertAssessment` | Triage confidence + impact score — use as a gate before running TSA |
+| `runTroubleshootingAgent` | Launch TSA root cause analysis (async — returns immediately) |
+| `getTroubleshootingAgentResults` | Poll for TSA results — contains root cause `tldr` and detailed findings |
+| `getAssetLineage` | Upstream producers and downstream consumers — blast radius assessment |
+| `getTable` | Table schema, stats, freshness, volume, capabilities, monitoring status |
+| `getMonitors` | Existing monitoring coverage on affected tables |
+| `getQueriesForTable` | Recent query patterns — helps distinguish pipeline issues from ad-hoc problems |
+| `search` | Find assets by name when you don't have the MCON |
+| `updateAlert` | Update alert status (ACKNOWLEDGED, FIXED, EXPECTED, etc.) and severity |
+| `setAlertOwner` | Assign alert ownership to a specific user |
+| `createOrUpdateAlertComment` | Document findings and remediation actions on the alert |
+| `getCurrentTime` | ISO timestamp for API calls that need date ranges |
+
+### External tools (remediation execution)
+
+These are **not** Monte Carlo tools. They come from external MCP servers the user may have configured. Their availability varies — see Workflow 2 (Capability Discovery) for how to detect them at runtime.
+
+| Capability | Example MCP Servers | Example Tools |
+| ---------- | ------------------- | ------------- |
+| Pipeline orchestration | Airflow, Dagster, Prefect | `trigger_dag_run`, `get_task_status`, `retry_task` |
+| dbt operations | dbt Cloud | `trigger_run`, `get_run`, `list_jobs` |
+| Code changes | GitHub, GitLab | `create_pull_request`, `create_issue`, `create_branch` |
+| Notifications | Slack, PagerDuty, Teams | `send_message`, `create_incident`, `post_message` |
+| Data warehouse | Snowflake, BigQuery, Databricks | `execute_query`, `get_table_info` |
+
+---
+
+## Core workflow
+
+Follow these workflows in order. Each workflow builds on the context gathered by the previous one.
+
+### Workflow 1: Investigation
+
+**Goal:** Understand what happened, why it happened, and what's affected.
+
+Before proposing ANY remediation action, you MUST complete this investigation. Do not skip steps — incomplete context leads to wrong fixes.
+
+#### Step 1: Get alert context
+
+```
+getAlerts(
+  alert_ids=["<alert_id>"],
+)
+```
+
+If the user provided a table name instead of an alert ID:
+```
+search(query="<table_name>")
+→ extract MCON
+getAlerts(
+  table_mcons=["<mcon>"],
+  created_after="<7 days ago>",
+  created_before="<now>",
+  order_by="-createdTime",
+  statuses=["NOT_ACKNOWLEDGED", "WORK_IN_PROGRESS"]
+)
+```
+
+Extract from the alert: `alert_type` (Freshness, Volume, Schema Changes, etc.), `severity`, affected table MCONs, `created_time`.
+
+#### Step 2: Assess triage priority
+
+```
+alertAssessment(
+  incident_id="<alert_uuid>"
+)
+```
+
+This returns `triage_confidence` (HIGH/MEDIUM/LOW), `alert_impact` (HIGH/MEDIUM/LOW), and a summary. Use this to decide urgency:
+
+- **HIGH impact + HIGH confidence** → proceed immediately to TSA
+- **LOW impact or LOW confidence** → still run TSA, but note to the user that this may not warrant immediate remediation
+
+#### Step 3: Root cause analysis (TSA)
+
+```
+runTroubleshootingAgent(
+  incident_id="<alert_uuid>",
+  async_mode=true
+)
+```
+
+Then poll for results (wait 30s initially, then 60s intervals):
+```
+getTroubleshootingAgentResults(
+  incident_id="<alert_uuid>"
+)
+```
+
+Status values:
+- `not_found` → TSA hasn't been triggered yet
+- `running` → still analyzing (keep polling)
+- `success` → read the `tldr` for the root cause summary, `full_response` for details
+- `failed` → check `full_response` for error; proceed with manual investigation
+
+**The TSA `tldr` is your primary input for choosing a remediation action.** Read it carefully.
+
+#### Step 4: Assess blast radius
+
+```
+getAssetLineage(
+  mcons=["<affected_table_mcon>"],
+  direction="DOWNSTREAM"
+)
+```
+
+Then for upstream investigation:
+```
+getAssetLineage(
+  mcons=["<affected_table_mcon>"],
+  direction="UPSTREAM"
+)
+```
+
+Note: `has_relationships=false` means no dependencies tracked — do not assume missing relationships.
+
+#### Step 5: Gather table context
+
+```
+getTable(
+  mcon="<affected_table_mcon>",
+  include_fields=true,
+  include_table_capabilities=true
+)
+```
+
+Extract: last activity timestamps, row counts, schema, monitoring status, importance score.
+
+For key downstream tables identified in Step 4, also fetch their details:
+```
+getTable(mcon="<downstream_mcon>")
+```
+
+#### Step 6: Check monitoring coverage and recent queries
+
+```
+getMonitors(mcons=["<affected_table_mcon>"])
+```
+
+```
+getQueriesForTable(
+  mcon="<affected_table_mcon>",
+  query_type="destination",
+  limit=10
+)
+```
+
+Use `query_type="destination"` to find queries that write to this table (pipeline queries). This helps identify which pipeline or job is responsible for the data.
+
+#### Investigation summary
+
+After completing Steps 1–6, synthesize your findings into a clear summary:
+
+1. **What happened:** alert type, when it fired, severity
+2. **Root cause:** TSA findings (or your best assessment if TSA failed)
+3. **Blast radius:** N downstream consumers, any key assets affected
+4. **Pipeline context:** which queries/jobs write to this table, when they last ran
+5. **Monitoring:** what monitors exist, any gaps
+
+Present this summary to the user before proceeding to remediation.
+
+---
+
+### Workflow 2: Capability discovery
+
+**Goal:** Determine what remediation actions are possible given the tools you have available.
+
+Before attempting any remediation action, you must know what tools you can use. You cannot assume any external MCP server is connected.
+
+#### How tool discovery works
+
+Your available tools are listed in your system prompt or tool inventory. External MCP tools follow the naming convention `mcp__<server_name>__<tool_name>`.
+
+Scan your available tools and look for these patterns:
+
+| Pattern | Capability | What you can do |
+| ------- | ---------- | --------------- |
+| `mcp__*airflow*__*` | Pipeline orchestration (Airflow) | Trigger DAG runs, retry failed tasks, check task status |
+| `mcp__*dagster*__*` | Pipeline orchestration (Dagster) | Trigger pipeline runs, check run status |
+| `mcp__*prefect*__*` | Pipeline orchestration (Prefect) | Trigger flow runs, check run status |
+| `mcp__*dbt*__*` | dbt operations | Trigger dbt job runs, check run status, list jobs |
+| `mcp__*github*__*` | Code changes | Create PRs, open issues, create branches |
+| `mcp__*gitlab*__*` | Code changes | Create merge requests, open issues |
+| `mcp__*slack*__*` | Notifications | Send messages, post to channels |
+| `mcp__*pagerduty*__*` | Incident management | Create/escalate incidents, notify on-call |
+| `mcp__*snowflake*__*`, `mcp__*bigquery*__*`, `mcp__*databricks*__*` | Data warehouse | Run queries, inspect tables directly |
+
+**If a capability is not found:** That's fine. Not every remediation requires every tool. The skill degrades gracefully — see "Graceful degradation" below.
+
+#### Capability assessment
+
+After scanning, summarize what's available:
+
+> "Based on your connected MCP servers, I can:
+> - ✅ Investigate via Monte Carlo (always available)
+> - ✅/❌ Restart pipelines (Airflow/Dagster/Prefect)
+> - ✅/❌ Rerun dbt jobs (dbt Cloud)
+> - ✅/❌ Create code changes (GitHub/GitLab)
+> - ✅/❌ Send notifications (Slack/PagerDuty)
+> - ✅/❌ Query the warehouse directly"
+
+For detailed guidance on tool discovery, read `references/tool-discovery.md`.
+
+#### Graceful degradation
+
+When the needed execution tool is NOT available:
+
+1. **Always produce the remediation plan** — describe exactly what needs to happen, step by step
+2. **Provide runnable commands** — if the fix is "restart this Airflow DAG", give the user the `airflow dags trigger <dag_id>` command they can run manually
+3. **Escalate via available channels** — if Slack is connected but Airflow isn't, post the remediation plan to the appropriate channel
+4. **Document on the alert** — use `createOrUpdateAlertComment` to record the diagnosis and recommended fix, even if you can't execute it
+
+---
+
+### Workflow 3: Remediation execution
+
+**Goal:** Take the appropriate action to fix the root cause, with safety rails.
+
+Read `references/patterns.md` for detailed examples of common remediation patterns.
+
+#### Step 1: Select remediation action
+
+Based on the TSA root cause and available tools, determine the action:
+
+| Root Cause Signal (from TSA) | Typical Remediation | Required Capability |
+| ---------------------------- | ------------------- | ------------------- |
+| Pipeline/DAG failure or delay | Restart the failed pipeline or task | Pipeline orchestration |
+| dbt model failure | Rerun the failed dbt job | dbt operations |
+| Schema change (upstream) | Assess impact, update downstream models or revert | Code changes |
+| Volume anomaly (missing data) | Check upstream pipeline, trigger backfill | Pipeline orchestration + warehouse |
+| Volume anomaly (duplicate data) | Identify and remove duplicates, fix pipeline | Warehouse + code changes |
+| Permission/access error | Escalate to data platform team | Notifications |
+| Infrastructure issue | Escalate to platform/ops team | Notifications |
+| Unknown or complex root cause | Escalate with full context | Notifications |
+
+**If the root cause maps to multiple possible actions**, present the options to the user with tradeoffs and let them choose.
+
+**If the root cause doesn't clearly map to any pattern**, read `references/patterns.md` for the "Unknown / complex" pattern, which focuses on packaging context for escalation.
+
+#### Step 2: Present the remediation plan
+
+**BEFORE executing anything**, present the plan to the user:
+
+> "Based on the investigation:
+>
+> **Root cause:** [TSA summary]
+> **Proposed action:** [what you want to do]
+> **Reasoning:** [why this action addresses the root cause]
+> **Risk:** [what could go wrong, blast radius]
+> **Rollback:** [how to undo if the fix causes new problems]"
+
+Read `references/safety.md` for detailed safety protocols.
+
+#### Step 3: Execute (with safety rails)
+
+**Safety rules — these are non-negotiable:**
+
+1. **Always explain before executing.** Never run a remediation action without first telling the user what you're about to do and why.
+
+2. **Confirm destructive operations.** Any action that modifies data, restarts a pipeline, triggers a job, or changes configuration requires explicit user confirmation. Ask and wait for "yes", "go ahead", "proceed", or similar.
+
+3. **Escalate when uncertain.** If you're not confident the action will fix the issue without side effects, say so. Present what you know, what you're unsure about, and recommend the user verify before proceeding.
+
+4. **One action at a time.** Don't chain multiple remediation actions. Execute one, verify the result, then decide on the next step.
+
+5. **Log everything.** After each action, document what you did on the alert using `createOrUpdateAlertComment`.
+
+#### Step 4: Verify the fix
+
+After executing the remediation action, verify it worked:
+
+1. **Wait for the action to take effect** — pipeline runs take time, dbt jobs need to complete
+2. **Re-check the table:**
+   ```
+   getTable(mcon="<affected_table_mcon>")
+   ```
+   Check: has `last_activity` updated? Have row counts changed as expected?
+
+3. **Re-check the alert:**
+   ```
+   getAlerts(alert_ids=["<alert_id>"])
+   ```
+   Has the alert auto-resolved? Is the condition still firing?
+
+4. **Report to the user:**
+   > "Remediation result:
+   > - Action taken: [what was done]
+   > - Table status: [current freshness/volume/schema state]
+   > - Alert status: [resolved/still firing]
+   > - Next steps: [if any]"
+
+---
+
+### Workflow 4: Post-remediation
+
+**Goal:** Close out the incident properly — update status, document, and prevent recurrence.
+
+#### Step 1: Update the alert
+
+```
+updateAlert(
+  alert_id="<alert_uuid>",
+  status="FIXED"
+)
+```
+
+Use the appropriate status:
+- `FIXED` — the root cause was identified and remediated
+- `EXPECTED` — the alert fired on expected behavior (e.g., planned maintenance)
+- `NO_ACTION_NEEDED` — the issue resolved itself or is not actionable
+
+#### Step 2: Document the remediation
+
+```
+createOrUpdateAlertComment(
+  alert_id="<alert_uuid>",
+  comment="## Remediation Summary\n\n**Root cause:** [TSA findings]\n**Action taken:** [what was done]\n**Result:** [outcome]\n**Remediated by:** AI agent via remediation skill\n**Timestamp:** [ISO timestamp]"
+)
+```
+
+#### Step 3: Assign ownership (if escalated)
+
+If the issue was escalated or needs follow-up:
+```
+setAlertOwner(
+  alert_id="<alert_uuid>",
+  owner="<owner_email>"
+)
+```
+
+#### Step 4: Consider prevention
+
+After remediating, briefly assess whether this issue is likely to recur:
+
+- **If the root cause is systemic** (e.g., a flaky pipeline, a missing monitor): suggest adding a monitor or creating a ticket to address the underlying issue
+- **If it was a one-off** (e.g., infrastructure blip, manual error): document and move on
+
+Do not automatically create monitors or tickets — suggest them and let the user decide.
+
+---
+
+## Common mistakes to avoid
+
+- **NEVER execute a remediation action without presenting the plan first.** The user must understand what you're about to do.
+- **NEVER skip the investigation phase.** A wrong diagnosis leads to a wrong fix — or worse, a fix that causes new problems.
+- **NEVER assume external MCP tools are available.** Always check first. A missing tool is not an error — it just means you escalate instead of execute.
+- **NEVER chain multiple remediation actions without verifying each one.** One action at a time.
+- **NEVER modify data directly** (DELETE, UPDATE, DROP) without explicit user confirmation AND a clearly stated rollback plan.
+- **NEVER mark an alert as FIXED before verifying the fix.** Check that the underlying condition has actually improved.
+- **NEVER remediate silently.** Always document what was done via `createOrUpdateAlertComment`.

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -44,39 +44,15 @@ Do not activate when the user is:
 
 ---
 
-## Available MCP tools
+## Available tools
 
-### Monte Carlo tools (investigation + post-remediation)
+### Monte Carlo MCP server (investigation + post-remediation)
 
-All tools are available via the `monte-carlo` MCP server.
-
-| Tool | Purpose |
-| ---- | ------- |
-| `getAlerts` | Fetch alert details — type, severity, affected tables, timestamps |
-| `alertAssessment` | Triage confidence + impact score — use as a gate before running TSA |
-| `runTroubleshootingAgent` | Launch TSA root cause analysis (async — returns immediately) |
-| `getTroubleshootingAgentResults` | Poll for TSA results — contains root cause `tldr` and detailed findings |
-| `getAssetLineage` | Upstream producers and downstream consumers — blast radius assessment |
-| `getTable` | Table schema, stats, freshness, volume, capabilities, monitoring status |
-| `getMonitors` | Existing monitoring coverage on affected tables |
-| `getQueriesForTable` | Recent query patterns — helps distinguish pipeline issues from ad-hoc problems |
-| `search` | Find assets by name when you don't have the MCON |
-| `updateAlert` | Update alert status (ACKNOWLEDGED, FIXED, EXPECTED, etc.) and severity |
-| `setAlertOwner` | Assign alert ownership to a specific user |
-| `createOrUpdateAlertComment` | Document findings and remediation actions on the alert |
-| `getCurrentTime` | ISO timestamp for API calls that need date ranges |
+The Monte Carlo MCP server (`monte-carlo`) provides the investigation tools used in the workflows below. The workflows reference key tools by name (e.g., `getAlerts`, `runTroubleshootingAgent`, `getAssetLineage`), but **use any Monte Carlo tool that helps** — the server has additional tools beyond what the workflows explicitly call out. Explore what's available.
 
 ### External tools (remediation execution)
 
-These are **not** Monte Carlo tools. They may be available as MCP servers, CLI tools, or APIs. Their availability varies — see Workflow 2 (Capability Discovery) for how to detect them at runtime.
-
-| Capability | MCP Servers | CLI Tools | What they enable |
-| ---------- | ----------- | --------- | ---------------- |
-| Pipeline orchestration | Airflow, Dagster, Prefect | `airflow`, `dagster`, `prefect` | Trigger runs, retry tasks, check status |
-| dbt operations | dbt Cloud | `dbt` | Trigger job runs, rebuild models, run tests |
-| Code changes | GitHub, GitLab | `gh`, `git` | Create PRs, branches, issues |
-| Data warehouse | Snowflake, BigQuery, Databricks | `snowsql`, `bq`, `databricks` | Execute queries, inspect tables |
-| Any HTTP API | — | `curl` | Call any service REST API directly |
+Remediation actions are executed via whatever tools are available — MCP servers, CLI tools, or APIs. See Workflow 2 (Capability Discovery) and `references/tool-discovery.md` for how to detect and use them. Use whatever works; don't limit yourself to a prescribed list.
 
 ---
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -271,32 +271,8 @@ Before executing, read `references/safety.md` for the full safety protocol. The 
 - **Explain before executing** — never take action without telling the user what and why
 - **Confirm destructive operations** — wait for explicit user approval
 - **Ask the user when uncertain** — don't guess at a fix
-- **One action at a time** — execute, verify, then decide next step
+- **One action at a time** — execute one action, then decide next step
 - **Log everything** — document each action on the alert via `createOrUpdateAlertComment`
-
-#### Step 4: Verify the fix
-
-After executing the remediation action, verify it worked:
-
-1. **Wait for the action to take effect** — pipeline runs take time, dbt jobs need to complete
-2. **Re-check the table:**
-   ```
-   getTable(mcon="<affected_table_mcon>")
-   ```
-   Check: has `last_activity` updated? Have row counts changed as expected?
-
-3. **Re-check the alert:**
-   ```
-   getAlerts(alert_ids=["<alert_id>"])
-   ```
-   Has the alert auto-resolved? Is the condition still firing?
-
-4. **Report to the user:**
-   > "Remediation result:
-   > - Action taken: [what was done]
-   > - Table status: [current freshness/volume/schema state]
-   > - Alert status: [resolved/still firing]
-   > - Next steps: [if any]"
 
 ---
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: monte-carlo-remediation
-description: |
-  Activates when a user asks to remediate, fix, or respond to a data quality alert
-  or incident. Investigates the alert using Monte Carlo MCP tools (alerts, TSA root
-  cause analysis, lineage, table metadata), discovers what remediation tools are
-  available via connected MCP servers, reasons about the appropriate fix, and
-  executes it — or escalates to a human with full context when uncertain. Do not
-  wait to be asked for details: once activated, run the full investigation workflow
-  before proposing any action.
+description: Investigate and remediate data quality alerts using Monte Carlo MCP tools. Runs root cause analysis, assesses blast radius, discovers available tools (MCP/CLI/API), proposes and executes fixes, or escalates with full context when uncertain.
 version: 1.0.0
 ---
 
@@ -48,7 +41,9 @@ Do not activate when the user is:
 
 ### Monte Carlo MCP server (investigation + post-remediation)
 
-The Monte Carlo MCP server (`monte-carlo`) provides the investigation tools used in the workflows below. The workflows reference key tools by name (e.g., `getAlerts`, `runTroubleshootingAgent`, `getAssetLineage`), but **use any Monte Carlo tool that helps** — the server has additional tools beyond what the workflows explicitly call out. Explore what's available.
+The Monte Carlo MCP server (`monte-carlo`) provides the investigation tools used in the workflows below. The workflows reference key tools by name (e.g., `get_alerts`, `run_troubleshooting_agent`, `get_asset_lineage`), but **use any Monte Carlo tool that helps** — the server has additional tools beyond what the workflows explicitly call out. Explore what's available.
+
+> **Note on tool call examples:** The code blocks below show key parameters to guide you. Always check the tool's own description for the complete parameter list and exact parameter names — they are authoritative.
 
 ### External tools (remediation execution)
 
@@ -69,7 +64,7 @@ Before proposing ANY remediation action, you MUST complete this investigation. D
 #### Step 1: Get alert context
 
 ```
-getAlerts(
+get_alerts(
   alert_ids=["<alert_id>"],
 )
 ```
@@ -78,7 +73,7 @@ If the user provided a table name instead of an alert ID:
 ```
 search(query="<table_name>")
 → extract MCON
-getAlerts(
+get_alerts(
   table_mcons=["<mcon>"],
   created_after="<7 days ago>",
   created_before="<now>",
@@ -92,14 +87,14 @@ Extract from the alert: `alert_type` (Freshness, Volume, Schema Changes, etc.), 
 #### Step 2: Assess triage priority
 
 ```
-alertAssessment(
+alert_assessment(
   incident_id="<alert_uuid>"
 )
 ```
 
 This returns `triage_confidence` (HIGH/MEDIUM/LOW), `alert_impact` (HIGH/MEDIUM/LOW), and a summary. Use this to decide urgency:
 
-- **HIGH impact + HIGH confidence** → proceed immediately to TSA
+- **HIGH impact + HIGH confidence** → proceed immediately to Troubleshooting Agent (TSA) analysis
 - **LOW impact or LOW confidence** → still run TSA, but note to the user that this may not warrant immediate remediation
 
 #### Step 3: Root cause analysis (TSA)
@@ -107,7 +102,7 @@ This returns `triage_confidence` (HIGH/MEDIUM/LOW), `alert_impact` (HIGH/MEDIUM/
 **Always use async mode.** TSA analysis takes 4–8 minutes — sync mode will time out.
 
 ```
-runTroubleshootingAgent(
+run_troubleshooting_agent(
   incident_id="<alert_uuid>",
   async_mode=true
 )
@@ -116,7 +111,7 @@ runTroubleshootingAgent(
 **While TSA runs, proceed with Steps 4–6 in parallel** — gather lineage, table context, and query data while waiting. Then poll for TSA results:
 
 ```
-getTroubleshootingAgentResults(
+get_troubleshooting_agent_results(
   incident_id="<alert_uuid>"
 )
 ```
@@ -132,15 +127,22 @@ Status values:
 #### Step 4: Assess blast radius
 
 ```
-getAssetLineage(
+get_asset_lineage(
   mcons=["<affected_table_mcon>"],
   direction="DOWNSTREAM"
 )
 ```
 
+For BI report coverage:
+```
+get_downstream_bi_reports(
+  mcon="<affected_table_mcon>"
+)
+```
+
 Then for upstream investigation:
 ```
-getAssetLineage(
+get_asset_lineage(
   mcons=["<affected_table_mcon>"],
   direction="UPSTREAM"
 )
@@ -151,7 +153,7 @@ Note: `has_relationships=false` means no dependencies tracked — do not assume 
 #### Step 5: Gather table context
 
 ```
-getTable(
+get_table(
   mcon="<affected_table_mcon>",
   include_fields=true,
   include_table_capabilities=true
@@ -162,18 +164,18 @@ Extract: last activity timestamps, row counts, schema, monitoring status, import
 
 For key downstream tables identified in Step 4, also fetch their details:
 ```
-getTable(mcon="<downstream_mcon>")
+get_table(mcon="<downstream_mcon>")
 ```
 
-#### Step 6: Check monitoring coverage and recent queries
+#### Step 6: Check alert context, monitoring, and recent queries
 
 ```
-getMonitors(mcons=["<affected_table_mcon>"])
+get_monitors(mcons=["<affected_table_mcon>"])
 ```
 
 For **Custom SQL** or **Validation** alerts, also fetch the monitor configuration to understand the exact rule that breached:
 ```
-getMonitors(
+get_monitors(
   monitor_ids=["<monitor_id_from_alert>"],
   include_fields=["config"]
 )
@@ -181,7 +183,7 @@ getMonitors(
 The config contains the SQL query or validation conditions — this tells you exactly what the monitor checks, which is essential for understanding what went wrong and what the fix should be.
 
 ```
-getQueriesForTable(
+get_queries_for_table(
   mcon="<affected_table_mcon>",
   query_type="destination",
   limit=10
@@ -225,6 +227,7 @@ For detailed guidance on discovery across all three categories, read `references
 
 After checking, summarize what's available:
 
+**Example:**
 > "For this remediation, I can:
 > - ✅ Investigate via Monte Carlo (MCP connected)
 > - ✅ Restart the Airflow DAG (Airflow MCP connected)
@@ -238,7 +241,7 @@ When no tool (MCP, CLI, or API) is available for a needed action:
 1. **Always produce the remediation plan** — describe exactly what needs to happen, step by step
 2. **Provide runnable commands** — give the user the exact commands they can run manually (e.g., `airflow dags trigger <dag_id>`, `dbt run --select <model>`)
 3. **Present findings and ask for next steps** — tell the user what you found, what you recommend, and ask how they'd like to proceed
-4. **Document on the alert** — use `createOrUpdateAlertComment` to record the diagnosis and recommended fix
+4. **Document on the alert** — use `create_or_update_alert_comment` to record the diagnosis and recommended fix
 
 ---
 
@@ -287,7 +290,7 @@ Before executing, read `references/safety.md` for the full safety protocol. The 
 - **Confirm destructive operations** — wait for explicit user approval
 - **Ask the user when uncertain** — don't guess at a fix
 - **One action at a time** — execute one action, then decide next step
-- **Log everything** — document each action on the alert via `createOrUpdateAlertComment`
+- **Log everything** — document each action on the alert via `create_or_update_alert_comment`
 
 ---
 
@@ -303,12 +306,12 @@ Ask the user what status to set:
 - `EXPECTED` — the alert fired on expected behavior (e.g., planned maintenance)
 - `NO_ACTION_NEEDED` — the issue resolved itself or is not actionable
 
-Then call `updateAlert(alert_id="<alert_uuid>", status="<chosen_status>")`.
+Then call `update_alert(alert_id="<alert_uuid>", status="<chosen_status>")`.
 
 #### Step 2: Document the remediation
 
 ```
-createOrUpdateAlertComment(
+create_or_update_alert_comment(
   alert_id="<alert_uuid>",
   comment="## Remediation Summary\n\n**Root cause:** [TSA findings]\n**Action taken:** [what was done]\n**Result:** [outcome]\n**Remediated by:** AI agent via remediation skill\n**Timestamp:** [ISO timestamp]"
 )
@@ -333,4 +336,4 @@ Do not automatically create monitors or tickets — suggest them and let the use
 - **NEVER chain multiple remediation actions without verifying each one.** One action at a time.
 - **NEVER modify data directly** (DELETE, UPDATE, DROP) without explicit user confirmation AND a clearly stated rollback plan.
 - **NEVER mark an alert as FIXED before verifying the fix.** Check that the underlying condition has actually improved.
-- **NEVER remediate silently.** Always document what was done via `createOrUpdateAlertComment`.
+- **NEVER remediate silently.** Always document what was done via `create_or_update_alert_comment`.

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -75,7 +75,6 @@ These are **not** Monte Carlo tools. They come from external MCP servers the use
 | Pipeline orchestration | Airflow, Dagster, Prefect | `trigger_dag_run`, `get_task_status`, `retry_task` |
 | dbt operations | dbt Cloud | `trigger_run`, `get_run`, `list_jobs` |
 | Code changes | GitHub, GitLab | `create_pull_request`, `create_issue`, `create_branch` |
-| Notifications | Slack, PagerDuty, Teams | `send_message`, `create_incident`, `post_message` |
 | Data warehouse | Snowflake, BigQuery, Databricks | `execute_query`, `get_table_info` |
 
 ---
@@ -236,8 +235,6 @@ Scan your available tools and look for these patterns:
 | `mcp__*dbt*__*` | dbt operations | Trigger dbt job runs, check run status, list jobs |
 | `mcp__*github*__*` | Code changes | Create PRs, open issues, create branches |
 | `mcp__*gitlab*__*` | Code changes | Create merge requests, open issues |
-| `mcp__*slack*__*` | Notifications | Send messages, post to channels |
-| `mcp__*pagerduty*__*` | Incident management | Create/escalate incidents, notify on-call |
 | `mcp__*snowflake*__*`, `mcp__*bigquery*__*`, `mcp__*databricks*__*` | Data warehouse | Run queries, inspect tables directly |
 
 **If a capability is not found:** That's fine. Not every remediation requires every tool. The skill degrades gracefully — see "Graceful degradation" below.
@@ -251,7 +248,6 @@ After scanning, summarize what's available:
 > - ✅/❌ Restart pipelines (Airflow/Dagster/Prefect)
 > - ✅/❌ Rerun dbt jobs (dbt Cloud)
 > - ✅/❌ Create code changes (GitHub/GitLab)
-> - ✅/❌ Send notifications (Slack/PagerDuty)
 > - ✅/❌ Query the warehouse directly"
 
 For detailed guidance on tool discovery, read `references/tool-discovery.md`.
@@ -262,7 +258,7 @@ When the needed execution tool is NOT available:
 
 1. **Always produce the remediation plan** — describe exactly what needs to happen, step by step
 2. **Provide runnable commands** — if the fix is "restart this Airflow DAG", give the user the `airflow dags trigger <dag_id>` command they can run manually
-3. **Escalate via available channels** — if Slack is connected but Airflow isn't, post the remediation plan to the appropriate channel
+3. **Present findings and ask for next steps** — tell the user what you found, what you recommend, and ask how they'd like to proceed. They may choose to run commands manually, notify their team via Slack, page on-call, or take a different approach entirely.
 4. **Document on the alert** — use `createOrUpdateAlertComment` to record the diagnosis and recommended fix, even if you can't execute it
 
 ---
@@ -284,13 +280,13 @@ Based on the TSA root cause and available tools, determine the action:
 | Schema change (upstream) | Assess impact, update downstream models or revert | Code changes |
 | Volume anomaly (missing data) | Check upstream pipeline, trigger backfill | Pipeline orchestration + warehouse |
 | Volume anomaly (duplicate data) | Identify and remove duplicates, fix pipeline | Warehouse + code changes |
-| Permission/access error | Escalate to data platform team | Notifications |
-| Infrastructure issue | Escalate to platform/ops team | Notifications |
-| Unknown or complex root cause | Escalate with full context | Notifications |
+| Permission/access error | Present findings, recommend user escalates to data platform team | None (user decides) |
+| Infrastructure issue | Present findings, recommend user escalates to platform/ops team | None (user decides) |
+| Unknown or complex root cause | Present full context and ask user for next steps | None (user decides) |
 
 **If the root cause maps to multiple possible actions**, present the options to the user with tradeoffs and let them choose.
 
-**If the root cause doesn't clearly map to any pattern**, read `references/patterns.md` for the "Unknown / complex" pattern, which focuses on packaging context for escalation.
+**If the root cause doesn't clearly map to any pattern**, read `references/patterns.md` for the "Unknown / complex" pattern, which focuses on presenting full context to the user and asking for direction.
 
 #### Step 2: Present the remediation plan
 
@@ -314,7 +310,7 @@ Read `references/safety.md` for detailed safety protocols.
 
 2. **Confirm destructive operations.** Any action that modifies data, restarts a pipeline, triggers a job, or changes configuration requires explicit user confirmation. Ask and wait for "yes", "go ahead", "proceed", or similar.
 
-3. **Escalate when uncertain.** If you're not confident the action will fix the issue without side effects, say so. Present what you know, what you're unsure about, and recommend the user verify before proceeding.
+3. **Ask the user when uncertain.** If you're not confident the action will fix the issue without side effects, say so. Present what you know, what you're unsure about, and ask the user how they'd like to proceed.
 
 4. **One action at a time.** Don't chain multiple remediation actions. Execute one, verify the result, then decide on the next step.
 
@@ -373,17 +369,7 @@ createOrUpdateAlertComment(
 )
 ```
 
-#### Step 3: Assign ownership (if escalated)
-
-If the issue was escalated or needs follow-up:
-```
-setAlertOwner(
-  alert_id="<alert_uuid>",
-  owner="<owner_email>"
-)
-```
-
-#### Step 4: Consider prevention
+#### Step 3: Consider prevention
 
 After remediating, briefly assess whether this issue is likely to recur:
 
@@ -398,7 +384,7 @@ Do not automatically create monitors or tickets — suggest them and let the use
 
 - **NEVER execute a remediation action without presenting the plan first.** The user must understand what you're about to do.
 - **NEVER skip the investigation phase.** A wrong diagnosis leads to a wrong fix — or worse, a fix that causes new problems.
-- **NEVER assume external MCP tools are available.** Always check first. A missing tool is not an error — it just means you escalate instead of execute.
+- **NEVER assume external MCP tools are available.** Always check first. A missing tool is not an error — present findings to the user and ask for next steps.
 - **NEVER chain multiple remediation actions without verifying each one.** One action at a time.
 - **NEVER modify data directly** (DELETE, UPDATE, DROP) without explicit user confirmation AND a clearly stated rollback plan.
 - **NEVER mark an alert as FIXED before verifying the fix.** Check that the underlying condition has actually improved.

--- a/skills/remediation/references/patterns.md
+++ b/skills/remediation/references/patterns.md
@@ -49,7 +49,7 @@ Stale data usually means the pipeline that feeds this table has either failed or
 **If no execution tool is available:**
 - Document which pipeline is responsible (from query analysis)
 - Provide the manual commands: `airflow dags trigger <dag_id>` or `dbt run --select <model>`
-- Post to Slack or escalate via PagerDuty if available
+- Present the diagnosis and recommended fix to the user and ask for next steps
 - Comment on the alert with the diagnosis and recommended fix
 
 ### Verification
@@ -157,7 +157,7 @@ Schema changes can be intentional (upstream team made a planned change) or accid
 **If the change is accidental and should be reverted:**
 - If GitHub is available: create a PR reverting the upstream change
 - If the change was a direct DDL (not code-managed): provide the ALTER statement to revert
-- Escalate to the upstream table owner with context
+- Present findings to the user and recommend they contact the upstream table owner
 
 **If no execution tool is available:**
 - Document all affected downstream tables and the specific column changes
@@ -214,7 +214,7 @@ Volume anomalies can indicate: data loss (rows missing), data duplication (rows 
 **For missing data (row count drop):**
 - If pipeline orchestrator is available: trigger a backfill for the affected time range
 - If the drop is from a bad deployment: revert via GitHub, then rerun the pipeline
-- If upstream source stopped: escalate to the source system owner
+- If upstream source stopped: present findings to the user and recommend they contact the source system owner
 
 **For duplicate data:**
 - If warehouse access is available: run a deduplication query (with user confirmation!)
@@ -250,11 +250,11 @@ Volume anomalies can indicate: data loss (rows missing), data duplication (rows 
 
 ### Reasoning
 
-Not every issue has a clear, automatable fix. When the root cause is unclear or complex, the best remediation is comprehensive escalation with full context — not guessing at a fix.
+Not every issue has a clear, automatable fix. When the root cause is unclear or complex, the best approach is to present full context to the user and ask for direction — not guess at a fix.
 
-### Escalation package
+### Context package
 
-Compile a complete context package for the human responder:
+Compile a complete summary for the user:
 
 1. **Alert details:** type, severity, when it fired, affected tables
 2. **TSA findings:** whatever root cause analysis was available (even if partial)
@@ -264,48 +264,24 @@ Compile a complete context package for the human responder:
 6. **Monitoring coverage:** what monitors exist, any gaps
 7. **Your assessment:** what you think might be wrong and why, with confidence level
 
-### Remediation by available tools
+### What to do
 
-**If Slack is available:**
-```
-Post to the appropriate channel:
-"🔔 Data quality alert requires manual investigation
+Present the context package to the user and ask how they'd like to proceed. They may want to:
+- Notify their team via Slack or PagerDuty
+- Investigate further with specific queries
+- Assign the alert to a specific person
+- Take a manual remediation action you can help with
 
-Alert: [type] on [table]
-Severity: [level]
-TSA summary: [tldr or 'TSA inconclusive']
-
-Investigation findings:
-- [key finding 1]
-- [key finding 2]
-- [key finding 3]
-
-Recommended next steps:
-1. [specific action]
-2. [specific action]
-
-Full alert: [MC alert URL]"
-```
-
-**If PagerDuty is available:**
-- Create an incident with the escalation package
-- Set appropriate severity based on blast radius and impact
-
-**Always (regardless of tools):**
+**Document on the alert regardless:**
 ```
 createOrUpdateAlertComment(
   alert_id="<alert_uuid>",
-  comment="## Investigation Summary\n\n[full context package]\n\n**Escalation reason:** [why automated remediation was not attempted]\n**Recommended next steps:** [specific actions for the human responder]"
+  comment="## Investigation Summary\n\n[full context package]\n\n**Why automated remediation was not attempted:** [reason]\n**Recommended next steps:** [specific actions]"
 )
 
 updateAlert(
   alert_id="<alert_uuid>",
   status="WORK_IN_PROGRESS"
-)
-
-setAlertOwner(
-  alert_id="<alert_uuid>",
-  owner="<data_team_lead_email>"
 )
 ```
 

--- a/skills/remediation/references/patterns.md
+++ b/skills/remediation/references/patterns.md
@@ -1,0 +1,319 @@
+# Remediation Patterns
+
+Common data quality issue patterns with example remediation workflows. These are illustrative examples for reasoning — not rigid step-by-step procedures. Real incidents often combine multiple patterns or present unique variations. Use these as a starting point, then adapt based on the specific TSA findings and available tools.
+
+---
+
+## Pattern 1: Stale data (freshness alert)
+
+### Root cause signals (from TSA)
+
+- "Pipeline has not run since..."
+- "DAG/job failed at [timestamp]"
+- "No new rows since [timestamp]"
+- "Upstream table also stale" (cascading staleness)
+
+### Reasoning
+
+Stale data usually means the pipeline that feeds this table has either failed or not run. The first step is identifying which pipeline is responsible, then determining why it stopped.
+
+### Investigation steps
+
+1. Check upstream lineage — is the source table also stale?
+   ```
+   getAssetLineage(mcons=["<table_mcon>"], direction="UPSTREAM")
+   getTable(mcon="<upstream_mcon>")  # check freshness
+   ```
+
+2. Check recent write queries — what pipeline usually updates this table?
+   ```
+   getQueriesForTable(mcon="<table_mcon>", query_type="destination", limit=5)
+   ```
+
+3. If upstream is also stale, trace further upstream to find the true root cause.
+
+### Remediation by available tools
+
+**If pipeline orchestrator is available (Airflow, Dagster, Prefect):**
+- Identify the DAG/pipeline responsible for updating the table
+- Check if the last run failed or was delayed
+- Trigger a new run or retry the failed task
+- Example: "The DAG `etl_orders_daily` last ran 26 hours ago and failed on task `load_orders`. I'll retry that specific task."
+
+**If dbt Cloud is available:**
+- Identify the dbt job that builds this model
+- Check the last run status
+- Trigger a new run
+- Example: "The dbt job 'Daily Transform' failed 18 hours ago with a compilation error. After reviewing the error, I'll trigger a rerun."
+
+**If no execution tool is available:**
+- Document which pipeline is responsible (from query analysis)
+- Provide the manual commands: `airflow dags trigger <dag_id>` or `dbt run --select <model>`
+- Post to Slack or escalate via PagerDuty if available
+- Comment on the alert with the diagnosis and recommended fix
+
+### Verification
+
+After triggering the pipeline:
+- Wait for the job to complete (check status via the orchestrator MCP)
+- Re-check table freshness: `getTable(mcon="<table_mcon>")` — has `last_activity` updated?
+- Re-check the alert: `getAlerts(alert_ids=["<alert_id>"])` — has it resolved?
+
+---
+
+## Pattern 2: dbt model failure
+
+### Root cause signals (from TSA)
+
+- "dbt run failed with error..."
+- "Compilation error in model..."
+- "Database error during model execution"
+- "Dependency failed — upstream model did not complete"
+
+### Reasoning
+
+dbt failures can be compilation errors (code issues), database errors (permissions, resource limits), or dependency failures (upstream model failed first). The fix depends on the error type.
+
+### Investigation steps
+
+1. Read the TSA `full_response` carefully — it often contains the actual dbt error message.
+
+2. Check if the issue is the table itself or an upstream dependency:
+   ```
+   getAssetLineage(mcons=["<table_mcon>"], direction="UPSTREAM")
+   ```
+
+3. If upstream models also have alerts, the root cause is likely further upstream — remediate that first.
+
+### Remediation by available tools
+
+**If dbt Cloud is available:**
+- For compilation errors: the error likely needs a code fix → create a GitHub PR if GitHub MCP is available, otherwise describe the fix for the user
+- For transient database errors: rerun the job
+- For dependency failures: find and fix the upstream failure first, then rerun
+
+**If GitHub is available (for code fixes):**
+- Create a branch with the fix
+- Open a PR with clear description of what failed and why
+- Example: "The model `stg_orders` fails because column `order_status` was renamed to `status` upstream. Creating a PR to update the column reference."
+
+**If no execution tool is available:**
+- Describe the error and the fix needed
+- Provide the `dbt run --select <model>` command for manual execution
+- If it's a code issue, describe exactly what file and line needs changing
+
+### Verification
+
+- Check dbt job status via dbt Cloud MCP (if available)
+- Re-check table: `getTable(mcon="<table_mcon>")` — has the model been rebuilt?
+- Verify downstream tables are also refreshing
+
+---
+
+## Pattern 3: Schema change
+
+### Root cause signals (from TSA)
+
+- "Column added/removed/renamed"
+- "Column type changed"
+- "Schema differs from expected"
+
+### Reasoning
+
+Schema changes can be intentional (upstream team made a planned change) or accidental (a deployment error). The remediation depends on whether the change is expected and whether downstream consumers can handle it.
+
+### Investigation steps
+
+1. Identify what changed:
+   ```
+   getTable(mcon="<table_mcon>", include_fields=true)
+   ```
+
+2. Check blast radius — who consumes this table?
+   ```
+   getAssetLineage(mcons=["<table_mcon>"], direction="DOWNSTREAM")
+   ```
+
+3. Check if downstream tables are also alerting:
+   ```
+   getAlerts(
+     table_mcons=["<downstream_mcon_1>", "<downstream_mcon_2>"],
+     created_after="<24 hours ago>"
+   )
+   ```
+
+4. Check recent queries to identify who/what made the schema change:
+   ```
+   getQueriesForTable(mcon="<table_mcon>", query_type="destination", limit=10)
+   ```
+
+### Remediation by available tools
+
+**If the change is intentional and downstream needs updating:**
+- If GitHub is available: create a PR that updates downstream models to handle the new schema
+- If dbt Cloud is available: after fixing the code, trigger a full rebuild of affected models
+- Example: "Column `user_id` was renamed to `customer_id` in `raw_orders`. 4 downstream models reference this column. Creating a PR to update all references."
+
+**If the change is accidental and should be reverted:**
+- If GitHub is available: create a PR reverting the upstream change
+- If the change was a direct DDL (not code-managed): provide the ALTER statement to revert
+- Escalate to the upstream table owner with context
+
+**If no execution tool is available:**
+- Document all affected downstream tables and the specific column changes
+- List the files/models that need updating
+- Escalate with a complete impact report
+
+### Verification
+
+- Re-check table schema: `getTable(mcon="<table_mcon>", include_fields=true)`
+- Verify downstream models are rebuilding successfully
+- Check that schema change alerts resolve
+
+---
+
+## Pattern 4: Volume anomaly
+
+### Root cause signals (from TSA)
+
+- "Row count dropped by X%"
+- "Row count significantly higher than expected"
+- "No new rows in expected time window"
+- "Duplicate rows detected"
+
+### Reasoning
+
+Volume anomalies can indicate: data loss (rows missing), data duplication (rows doubled), source system issues (upstream stopped sending data), or filter/logic changes (a WHERE clause changed). The investigation must determine which case applies.
+
+### Investigation steps
+
+1. Quantify the anomaly:
+   ```
+   getTable(mcon="<table_mcon>")  # current row count
+   ```
+
+2. Check if the issue is in this table or upstream:
+   ```
+   getAssetLineage(mcons=["<table_mcon>"], direction="UPSTREAM")
+   getTable(mcon="<upstream_mcon>")  # check upstream row counts
+   ```
+
+3. Analyze recent write queries for clues:
+   ```
+   getQueriesForTable(mcon="<table_mcon>", query_type="destination", limit=10)
+   ```
+   Look for: unusual DELETE statements, changed WHERE clauses, failed INSERT operations.
+
+4. Check monitoring for more context:
+   ```
+   getMonitors(mcons=["<table_mcon>"])
+   ```
+
+### Remediation by available tools
+
+**For missing data (row count drop):**
+- If pipeline orchestrator is available: trigger a backfill for the affected time range
+- If the drop is from a bad deployment: revert via GitHub, then rerun the pipeline
+- If upstream source stopped: escalate to the source system owner
+
+**For duplicate data:**
+- If warehouse access is available: run a deduplication query (with user confirmation!)
+- Create a PR to fix the pipeline logic that caused duplication
+- Trigger a rebuild after the fix
+
+**For unexpected volume increase:**
+- Investigate whether this is a genuine increase or a data quality issue
+- Check if upstream sources are sending more data than expected
+- If it's a filter/logic change: review recent code changes
+
+**If no execution tool is available:**
+- Quantify the anomaly (expected vs actual row counts, affected time range)
+- Identify the likely cause from query analysis
+- Provide specific remediation steps for the user to execute manually
+
+### Verification
+
+- Re-check row counts: `getTable(mcon="<table_mcon>")`
+- Compare against expected values
+- Monitor over the next few pipeline runs to confirm stability
+
+---
+
+## Pattern 5: Unknown or complex root cause
+
+### Root cause signals (from TSA)
+
+- TSA returned `failed` status
+- TSA `tldr` is unclear or generic ("multiple issues detected")
+- Root cause spans multiple systems or teams
+- The issue is intermittent and hard to reproduce
+
+### Reasoning
+
+Not every issue has a clear, automatable fix. When the root cause is unclear or complex, the best remediation is comprehensive escalation with full context — not guessing at a fix.
+
+### Escalation package
+
+Compile a complete context package for the human responder:
+
+1. **Alert details:** type, severity, when it fired, affected tables
+2. **TSA findings:** whatever root cause analysis was available (even if partial)
+3. **Blast radius:** downstream consumers, key assets affected
+4. **Table state:** current freshness, row counts, schema
+5. **Recent queries:** pipeline activity, any anomalous patterns
+6. **Monitoring coverage:** what monitors exist, any gaps
+7. **Your assessment:** what you think might be wrong and why, with confidence level
+
+### Remediation by available tools
+
+**If Slack is available:**
+```
+Post to the appropriate channel:
+"🔔 Data quality alert requires manual investigation
+
+Alert: [type] on [table]
+Severity: [level]
+TSA summary: [tldr or 'TSA inconclusive']
+
+Investigation findings:
+- [key finding 1]
+- [key finding 2]
+- [key finding 3]
+
+Recommended next steps:
+1. [specific action]
+2. [specific action]
+
+Full alert: [MC alert URL]"
+```
+
+**If PagerDuty is available:**
+- Create an incident with the escalation package
+- Set appropriate severity based on blast radius and impact
+
+**Always (regardless of tools):**
+```
+createOrUpdateAlertComment(
+  alert_id="<alert_uuid>",
+  comment="## Investigation Summary\n\n[full context package]\n\n**Escalation reason:** [why automated remediation was not attempted]\n**Recommended next steps:** [specific actions for the human responder]"
+)
+
+updateAlert(
+  alert_id="<alert_uuid>",
+  status="WORK_IN_PROGRESS"
+)
+
+setAlertOwner(
+  alert_id="<alert_uuid>",
+  owner="<data_team_lead_email>"
+)
+```
+
+### When to use this pattern
+
+- TSA failed or returned unclear results
+- Root cause spans multiple systems (e.g., infrastructure + pipeline + data)
+- The fix requires access or permissions you don't have
+- You're not confident the proposed fix won't cause additional problems
+- The issue is intermittent and the current state looks normal
+- Multiple alerts are firing simultaneously on related tables (likely a systemic issue)

--- a/skills/remediation/references/safety.md
+++ b/skills/remediation/references/safety.md
@@ -82,9 +82,9 @@ For these, provide the exact commands and let the user execute them.
 
 ## Escalation criteria
 
-### When to escalate instead of remediating
+### When to stop and ask the user for direction
 
-Escalate to a human when ANY of these conditions are true:
+Present your findings and ask the user how to proceed when ANY of these conditions are true:
 
 1. **No clear root cause:** TSA failed or returned ambiguous results, and your manual investigation didn't identify a clear cause.
 
@@ -92,7 +92,7 @@ Escalate to a human when ANY of these conditions are true:
 
 3. **High blast radius + uncertain fix:** The affected table has >10 downstream consumers AND you're not confident the fix will work.
 
-4. **Data loss detected:** Any sign that data has been permanently deleted or corrupted. Do not attempt to fix data loss — escalate immediately.
+4. **Data loss detected:** Any sign that data has been permanently deleted or corrupted. Do not attempt to fix data loss — stop and tell the user immediately.
 
 5. **Permission or access issues:** The root cause involves permissions, credentials, or access controls. These require human intervention.
 
@@ -102,34 +102,28 @@ Escalate to a human when ANY of these conditions are true:
 
 8. **Production safety concern:** Any situation where the proposed fix could make things worse, even with a rollback plan.
 
-### How to escalate
+### How to hand off to the user
 
-1. **Document everything on the alert:**
+1. **Present your findings clearly:** Summarize what you investigated, what you found, and why you're not confident in an automated fix.
+
+2. **Document on the alert:**
    ```
    createOrUpdateAlertComment(
      alert_id="<alert_uuid>",
-     comment="## Escalation\n\n**Reason:** [why automated remediation is not appropriate]\n**Investigation findings:** [full summary]\n**Attempted actions:** [what was tried, if anything]\n**Recommended next steps for human responder:**\n1. [specific step]\n2. [specific step]"
+     comment="## Investigation Summary\n\n**Findings:** [full summary]\n**Why automated remediation was not attempted:** [reason]\n**Recommended next steps:**\n1. [specific step]\n2. [specific step]"
    )
    ```
 
-2. **Set status to WORK_IN_PROGRESS:**
+3. **Set status to WORK_IN_PROGRESS:**
    ```
    updateAlert(alert_id="<alert_uuid>", status="WORK_IN_PROGRESS")
    ```
 
-3. **Assign an owner if possible:**
-   ```
-   setAlertOwner(alert_id="<alert_uuid>", owner="<appropriate_person_email>")
-   ```
-
-4. **Notify via available channels** (Slack, PagerDuty, etc.)
-
-5. **Report to the user:**
-   > "I've escalated this incident because [reason]. Here's what I found and what I recommend the team investigate next: [summary]"
+4. **Ask the user for next steps:** They may want to notify their team, page on-call, investigate further, or take a manual action you can assist with.
 
 ## What "uncertain" means in practice
 
-You should consider yourself "uncertain" and escalate when:
+You should consider yourself "uncertain" and ask the user for direction when:
 
 - You can identify multiple plausible root causes and can't narrow it down
 - The TSA summary says one thing but your manual investigation suggests something different
@@ -140,7 +134,7 @@ You should consider yourself "uncertain" and escalate when:
 
 **When in doubt, state your confidence level:**
 
-> "I'm moderately confident (60-70%) that the root cause is [X], based on [evidence]. However, [alternative explanation] is also possible. I'd recommend [safer action] first, and if that doesn't resolve it, escalate to the data platform team for [deeper investigation]."
+> "I'm moderately confident (60-70%) that the root cause is [X], based on [evidence]. However, [alternative explanation] is also possible. I'd recommend [safer action] first. If that doesn't resolve it, the data platform team may need to investigate further. How would you like to proceed?"
 
 ## Rollback planning
 

--- a/skills/remediation/references/safety.md
+++ b/skills/remediation/references/safety.md
@@ -1,0 +1,165 @@
+# Safety Rails
+
+Detailed safety protocols for the remediation skill. These rules are non-negotiable — they apply in every remediation scenario, regardless of severity or urgency.
+
+## Core principles
+
+1. **Investigate before acting.** Never propose a fix without completing the investigation workflow.
+2. **Explain before executing.** Never run a remediation action without telling the user what you're about to do and why.
+3. **Confirm before destroying.** Any action that modifies data, restarts a pipeline, or changes configuration requires explicit user confirmation.
+4. **One step at a time.** Execute one remediation action, verify it, then decide on the next step.
+5. **Document everything.** Record all findings and actions on the alert.
+6. **Escalate when uncertain.** A clear "I don't know" is safer than a confident wrong fix.
+
+## Confirmation protocol
+
+### Actions that ALWAYS require confirmation
+
+These actions must not be executed without the user explicitly saying "yes", "go ahead", "proceed", or similar:
+
+- **Pipeline triggers:** Starting DAG runs, triggering dbt jobs, launching pipeline executions
+- **Data modifications:** Any SQL that includes INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE
+- **Configuration changes:** Modifying pipeline parameters, changing schedules, updating credentials
+- **Code changes:** Creating PRs, committing code, merging branches
+- **Incident escalation:** Paging on-call via PagerDuty, creating high-severity incidents
+- **Alert status changes:** Marking alerts as FIXED, EXPECTED, or NO_ACTION_NEEDED
+
+### Actions that do NOT require confirmation
+
+These are safe to execute without asking:
+
+- **Read-only investigation:** All Monte Carlo investigation tools (getAlerts, getTable, getAssetLineage, etc.)
+- **Adding comments:** `createOrUpdateAlertComment` — documenting findings is always safe
+- **Acknowledging alerts:** `updateAlert(status="ACKNOWLEDGED")` — this just signals awareness
+- **Setting ownership:** `setAlertOwner` — assigning someone to look at it
+- **Sending non-urgent notifications:** Posting informational messages to Slack channels (not paging)
+- **Status updates:** `updateAlert(status="WORK_IN_PROGRESS")` — tracking progress
+
+### How to ask for confirmation
+
+Present the action clearly and wait for an explicit response:
+
+> "I'd like to trigger a rerun of the Airflow DAG `etl_orders_daily`. This will:
+> - Start a new run of all tasks in the DAG
+> - Expected duration: ~45 minutes based on recent runs
+> - Risk: minimal — this is a standard rerun, not a backfill
+>
+> Should I proceed?"
+
+**Do NOT proceed on ambiguous responses.** "Maybe", "I guess", "hmm" are not confirmation. Ask again clearly: "Just to confirm — should I trigger the DAG rerun? (yes/no)"
+
+## Destructive operation handling
+
+### Definition
+
+A "destructive operation" is any action that:
+- Deletes or modifies existing data
+- Cannot be easily undone
+- Affects multiple systems or tables
+- Changes infrastructure or configuration
+
+### Required protocol for destructive operations
+
+1. **State the action explicitly:** "I want to execute: `DELETE FROM orders WHERE created_at < '2024-01-01'`"
+2. **Explain the impact:** "This will remove approximately 1.2M rows from the `orders` table"
+3. **Describe the rollback plan:** "If this causes issues, the data can be restored from the daily backup at s3://backups/orders/2024-01-15/"
+4. **Wait for explicit confirmation**
+5. **Execute the action**
+6. **Immediately verify the result**
+7. **Document what was done**
+
+### Actions that are NEVER automated
+
+Even with user confirmation, suggest these be done manually rather than by the agent:
+
+- Dropping tables or databases
+- Modifying production credentials or secrets
+- Changing IAM roles or permissions
+- Directly modifying production infrastructure (scaling, networking)
+- Running backfill operations that span more than 7 days of data
+
+For these, provide the exact commands and let the user execute them.
+
+## Escalation criteria
+
+### When to escalate instead of remediating
+
+Escalate to a human when ANY of these conditions are true:
+
+1. **No clear root cause:** TSA failed or returned ambiguous results, and your manual investigation didn't identify a clear cause.
+
+2. **Multiple simultaneous alerts:** More than 3 alerts firing on related tables suggests a systemic issue that needs human judgment.
+
+3. **High blast radius + uncertain fix:** The affected table has >10 downstream consumers AND you're not confident the fix will work.
+
+4. **Data loss detected:** Any sign that data has been permanently deleted or corrupted. Do not attempt to fix data loss — escalate immediately.
+
+5. **Permission or access issues:** The root cause involves permissions, credentials, or access controls. These require human intervention.
+
+6. **Cross-system failure:** The issue spans multiple systems (e.g., ingestion + transformation + serving) and no single fix addresses it.
+
+7. **Recurring incident:** The same alert has fired 3+ times in the past week. The underlying issue needs a permanent fix, not another band-aid.
+
+8. **Production safety concern:** Any situation where the proposed fix could make things worse, even with a rollback plan.
+
+### How to escalate
+
+1. **Document everything on the alert:**
+   ```
+   createOrUpdateAlertComment(
+     alert_id="<alert_uuid>",
+     comment="## Escalation\n\n**Reason:** [why automated remediation is not appropriate]\n**Investigation findings:** [full summary]\n**Attempted actions:** [what was tried, if anything]\n**Recommended next steps for human responder:**\n1. [specific step]\n2. [specific step]"
+   )
+   ```
+
+2. **Set status to WORK_IN_PROGRESS:**
+   ```
+   updateAlert(alert_id="<alert_uuid>", status="WORK_IN_PROGRESS")
+   ```
+
+3. **Assign an owner if possible:**
+   ```
+   setAlertOwner(alert_id="<alert_uuid>", owner="<appropriate_person_email>")
+   ```
+
+4. **Notify via available channels** (Slack, PagerDuty, etc.)
+
+5. **Report to the user:**
+   > "I've escalated this incident because [reason]. Here's what I found and what I recommend the team investigate next: [summary]"
+
+## What "uncertain" means in practice
+
+You should consider yourself "uncertain" and escalate when:
+
+- You can identify multiple plausible root causes and can't narrow it down
+- The TSA summary says one thing but your manual investigation suggests something different
+- The proposed fix addresses a symptom but not necessarily the root cause
+- You've never seen this pattern before in the reference examples
+- The fix requires making an assumption about the system that you can't verify
+- The user seems uncertain or is asking "are you sure?" — respect their caution
+
+**When in doubt, state your confidence level:**
+
+> "I'm moderately confident (60-70%) that the root cause is [X], based on [evidence]. However, [alternative explanation] is also possible. I'd recommend [safer action] first, and if that doesn't resolve it, escalate to the data platform team for [deeper investigation]."
+
+## Rollback planning
+
+Before executing any remediation action, have a rollback plan:
+
+### For pipeline restarts
+- **Rollback:** If the rerun produces bad data, the previous good state is usually available in the warehouse's time travel / versioning feature. Note the timestamp before triggering.
+
+### For dbt reruns
+- **Rollback:** dbt models can be rebuilt from source. If a rerun produces bad results, fix the model and rerun again. For incremental models, note the last successful run timestamp.
+
+### For code changes (PRs)
+- **Rollback:** Revert the PR. Always create changes as PRs (not direct commits) so they can be cleanly reverted.
+
+### For data modifications
+- **Rollback:** Before any data modification, recommend the user:
+  1. Create a backup: `CREATE TABLE backup_<table>_<timestamp> AS SELECT * FROM <table>`
+  2. Or verify that time travel / snapshots are available for recovery
+  3. Document the rollback command alongside the modification
+
+### For configuration changes
+- **Rollback:** Document the previous configuration value before changing it. If available, use version-controlled configuration.

--- a/skills/remediation/references/safety.md
+++ b/skills/remediation/references/safety.md
@@ -134,6 +134,7 @@ You should consider yourself "uncertain" and ask the user for direction when:
 
 **When in doubt, state your confidence level:**
 
+**Example:**
 > "I'm moderately confident (60-70%) that the root cause is [X], based on [evidence]. However, [alternative explanation] is also possible. I'd recommend [safer action] first. If that doesn't resolve it, the data platform team may need to investigate further. How would you like to proceed?"
 
 ## Rollback planning

--- a/skills/remediation/references/tool-discovery.md
+++ b/skills/remediation/references/tool-discovery.md
@@ -38,9 +38,6 @@ Use this mapping table to understand what each server enables:
 | `*dbt*` | dbt operations | Trigger job runs, get run status, list jobs, cancel runs |
 | `*github*` | Code changes | Create branches, create/update PRs, create issues, read file contents |
 | `*gitlab*` | Code changes | Create merge requests, create issues, read file contents |
-| `*slack*` | Notifications | Send messages to channels, post thread replies, search messages |
-| `*pagerduty*` | Incident management | Create incidents, escalate, acknowledge, resolve |
-| `*teams*` | Notifications | Send messages, create cards |
 | `*jira*` | Issue tracking | Create issues, update status, add comments |
 | `*snowflake*` | Warehouse access | Execute queries, get table info |
 | `*bigquery*` | Warehouse access | Execute queries, get table info |
@@ -52,8 +49,7 @@ Use this mapping table to understand what each server enables:
 For the current remediation task, determine:
 
 1. **Can I investigate?** — Monte Carlo MCP is always needed. If it's not connected, you cannot proceed.
-2. **Can I execute the fix?** — Check if the needed orchestration/code/notification tool is available.
-3. **Can I notify the right people?** — Check for Slack, PagerDuty, or similar.
+2. **Can I execute the fix?** — Check if the needed orchestration/code tool is available.
 
 ### Step 4: Report capabilities
 
@@ -62,8 +58,7 @@ Present what you found to the user before proceeding:
 > "I've checked your connected MCP servers. For this remediation, I can:
 > - ✅ Investigate the issue (Monte Carlo)
 > - ✅ Restart the Airflow DAG (Airflow MCP connected)
-> - ❌ Create a code fix (no GitHub/GitLab MCP)
-> - ✅ Notify the team (Slack MCP connected)"
+> - ❌ Create a code fix (no GitHub/GitLab MCP)"
 
 ## Graceful degradation
 
@@ -89,25 +84,9 @@ Or via CLI: dbt run --select stg_orders+"
   `user_id` to `customer_id`. Create a branch and PR with this change."
 ```
 
-### Priority 2: Escalate via available notification channels
+### Priority 2: Present findings and ask for next steps
 
-If Slack or PagerDuty is available, send the remediation plan:
-
-```
-Slack message format:
-"🔧 Remediation needed — [table_name]
-
-Alert: [type] ([severity])
-Root cause: [TSA summary]
-
-Required action: [specific fix]
-Manual steps:
-1. [step 1]
-2. [step 2]
-
-I couldn't execute this automatically because [reason].
-Alert link: [MC alert URL]"
-```
+Tell the user what you found, what the fix is, and ask how they'd like to proceed. They may run the commands themselves, notify their team, page on-call, or take a different approach.
 
 ### Priority 3: Document on the alert
 
@@ -152,20 +131,3 @@ Common tools you might find:
 
 **Best practice:** For code fixes, create a branch → make the change → open a PR. Don't push directly to main.
 
-### Slack MCP
-
-Common tools you might find:
-- `send_message` / `post_message` — send to a channel (needs `channel` and `text`)
-- `search_channels` — find the right channel
-- `send_message_draft` — create a draft for review before sending
-
-**Tip:** If you don't know which channel to post to, ask the user. Don't guess — posting to the wrong channel is noisy.
-
-### PagerDuty MCP
-
-Common tools you might find:
-- `create_incident` — create a new incident (needs `service_id`, `title`, `urgency`)
-- `acknowledge_incident` — acknowledge an existing incident
-- `resolve_incident` — mark incident as resolved
-
-**Use PagerDuty for HIGH severity alerts only.** Don't page people for low-severity issues that can wait.

--- a/skills/remediation/references/tool-discovery.md
+++ b/skills/remediation/references/tool-discovery.md
@@ -1,0 +1,171 @@
+# Tool Discovery at Runtime
+
+This reference explains how to discover what remediation tools are available to you at runtime. Since different users have different MCP servers configured, you must check before attempting any external action.
+
+## How MCP tools are named
+
+In Claude Code and other MCP-capable editors, external tools follow the naming convention:
+
+```
+mcp__<server_name>__<tool_name>
+```
+
+For example:
+- `mcp__airflow__trigger_dag_run` — an Airflow tool
+- `mcp__dbt_cloud__trigger_run` — a dbt Cloud tool
+- `mcp__github__create_pull_request` — a GitHub tool
+- `mcp__slack__send_message` — a Slack tool
+
+Monte Carlo tools also follow this pattern but may use different server names depending on configuration:
+- `mcp__monte_carlo__getAlerts`
+- `mcp__mc__search`
+
+## Discovery procedure
+
+### Step 1: Scan your available tools
+
+Look through your tool list (available in your system prompt or tool inventory) for any tools matching `mcp__*__*`. Group them by server name.
+
+### Step 2: Map servers to capabilities
+
+Use this mapping table to understand what each server enables:
+
+| Server Name Pattern | Capability | Remediation Actions |
+| ------------------- | ---------- | ------------------- |
+| `*airflow*` | Pipeline orchestration | Trigger DAG runs, retry failed tasks, check DAG/task status, pause/unpause DAGs |
+| `*dagster*` | Pipeline orchestration | Launch pipeline runs, check run status, terminate runs |
+| `*prefect*` | Pipeline orchestration | Create flow runs, check flow run status |
+| `*dbt*` | dbt operations | Trigger job runs, get run status, list jobs, cancel runs |
+| `*github*` | Code changes | Create branches, create/update PRs, create issues, read file contents |
+| `*gitlab*` | Code changes | Create merge requests, create issues, read file contents |
+| `*slack*` | Notifications | Send messages to channels, post thread replies, search messages |
+| `*pagerduty*` | Incident management | Create incidents, escalate, acknowledge, resolve |
+| `*teams*` | Notifications | Send messages, create cards |
+| `*jira*` | Issue tracking | Create issues, update status, add comments |
+| `*snowflake*` | Warehouse access | Execute queries, get table info |
+| `*bigquery*` | Warehouse access | Execute queries, get table info |
+| `*databricks*` | Warehouse access + orchestration | Execute queries, trigger jobs, check job status |
+| `*fivetran*` | Ingestion | Trigger connector sync, check sync status |
+
+### Step 3: Assess coverage
+
+For the current remediation task, determine:
+
+1. **Can I investigate?** — Monte Carlo MCP is always needed. If it's not connected, you cannot proceed.
+2. **Can I execute the fix?** — Check if the needed orchestration/code/notification tool is available.
+3. **Can I notify the right people?** — Check for Slack, PagerDuty, or similar.
+
+### Step 4: Report capabilities
+
+Present what you found to the user before proceeding:
+
+> "I've checked your connected MCP servers. For this remediation, I can:
+> - ✅ Investigate the issue (Monte Carlo)
+> - ✅ Restart the Airflow DAG (Airflow MCP connected)
+> - ❌ Create a code fix (no GitHub/GitLab MCP)
+> - ✅ Notify the team (Slack MCP connected)"
+
+## Graceful degradation
+
+When a needed tool is NOT available, follow this priority:
+
+### Priority 1: Provide actionable manual instructions
+
+Give the user the exact commands or steps to execute themselves:
+
+```
+# If Airflow MCP is not available but you identified the DAG:
+"The DAG `etl_orders_daily` needs to be triggered. Run:
+  airflow dags trigger etl_orders_daily
+Or via the Airflow UI: navigate to DAGs → etl_orders_daily → Trigger DAG"
+
+# If dbt Cloud MCP is not available:
+"dbt job 'Daily Transform' (job ID: 12345) needs to be rerun. Run:
+  dbt Cloud UI → Jobs → Daily Transform → Run Now
+Or via CLI: dbt run --select stg_orders+"
+
+# If GitHub MCP is not available:
+"File `models/staging/stg_orders.sql` needs line 14 changed from
+  `user_id` to `customer_id`. Create a branch and PR with this change."
+```
+
+### Priority 2: Escalate via available notification channels
+
+If Slack or PagerDuty is available, send the remediation plan:
+
+```
+Slack message format:
+"🔧 Remediation needed — [table_name]
+
+Alert: [type] ([severity])
+Root cause: [TSA summary]
+
+Required action: [specific fix]
+Manual steps:
+1. [step 1]
+2. [step 2]
+
+I couldn't execute this automatically because [reason].
+Alert link: [MC alert URL]"
+```
+
+### Priority 3: Document on the alert
+
+Always, regardless of what other tools are available:
+
+```
+createOrUpdateAlertComment(
+  alert_id="<alert_uuid>",
+  comment="## Remediation Plan\n\n**Root cause:** [summary]\n**Required action:** [specific fix]\n**Manual steps:**\n1. [step]\n2. [step]\n\n**Note:** Automated execution was not possible — [tool name] MCP not connected.\n**Investigated by:** AI agent via remediation skill"
+)
+```
+
+## Tool-specific notes
+
+### Airflow MCP
+
+Common tools you might find:
+- `trigger_dag_run` — start a DAG run (may need `dag_id`, optionally `conf` for parameters)
+- `get_dag_runs` — check recent runs and their status
+- `get_task_instances` — get task-level status for a specific run
+- `clear_task_instances` — retry failed tasks (resets their state)
+
+**Caution:** `trigger_dag_run` starts a NEW run. If the issue was a failed task in an existing run, `clear_task_instances` (retry) may be more appropriate than starting fresh.
+
+### dbt Cloud MCP
+
+Common tools you might find:
+- `trigger_run` / `trigger_job` — start a dbt job run (needs `job_id` or `account_id` + `job_id`)
+- `get_run` — check run status and results
+- `list_jobs` — find the right job ID
+- `cancel_run` — stop a running job
+
+**Note:** dbt Cloud jobs often include multiple models. Triggering a job reruns ALL models in that job, not just the failed one. Consider whether a full rerun is appropriate.
+
+### GitHub MCP
+
+Common tools you might find:
+- `create_pull_request` — open a PR (needs `owner`, `repo`, `title`, `body`, `head`, `base`)
+- `create_issue` — open an issue for tracking
+- `create_or_update_file` — directly edit a file on a branch
+- `create_branch` — create a new branch for the fix
+
+**Best practice:** For code fixes, create a branch → make the change → open a PR. Don't push directly to main.
+
+### Slack MCP
+
+Common tools you might find:
+- `send_message` / `post_message` — send to a channel (needs `channel` and `text`)
+- `search_channels` — find the right channel
+- `send_message_draft` — create a draft for review before sending
+
+**Tip:** If you don't know which channel to post to, ask the user. Don't guess — posting to the wrong channel is noisy.
+
+### PagerDuty MCP
+
+Common tools you might find:
+- `create_incident` — create a new incident (needs `service_id`, `title`, `urgency`)
+- `acknowledge_incident` — acknowledge an existing incident
+- `resolve_incident` — mark incident as resolved
+
+**Use PagerDuty for HIGH severity alerts only.** Don't page people for low-severity issues that can wait.

--- a/skills/remediation/references/tool-discovery.md
+++ b/skills/remediation/references/tool-discovery.md
@@ -1,92 +1,136 @@
 # Tool Discovery at Runtime
 
-This reference explains how to discover what remediation tools are available to you at runtime. Since different users have different MCP servers configured, you must check before attempting any external action.
+This reference explains how to discover what remediation tools are available to you at runtime. You have three categories of tools to check: MCP servers, CLI tools (via shell access), and APIs (via `curl` or language-specific clients). Check all three before deciding what's possible.
 
-## How MCP tools are named
+## Category 1: MCP servers
 
-In Claude Code and other MCP-capable editors, external tools follow the naming convention:
+In Claude Code and other MCP-capable editors, MCP tools follow the naming convention:
 
 ```
 mcp__<server_name>__<tool_name>
 ```
 
 For example:
-- `mcp__airflow__trigger_dag_run` — an Airflow tool
-- `mcp__dbt_cloud__trigger_run` — a dbt Cloud tool
-- `mcp__github__create_pull_request` — a GitHub tool
-- `mcp__slack__send_message` — a Slack tool
+- `mcp__airflow__trigger_dag_run` — an Airflow MCP tool
+- `mcp__dbt_cloud__trigger_run` — a dbt Cloud MCP tool
+- `mcp__github__create_pull_request` — a GitHub MCP tool
 
 Monte Carlo tools also follow this pattern but may use different server names depending on configuration:
 - `mcp__monte_carlo__getAlerts`
 - `mcp__mc__search`
 
+Scan your tool list for any `mcp__*__*` patterns and group by server name.
+
+## Category 2: CLI tools
+
+You have shell access. Many remediation actions can be done via CLI tools that may already be installed:
+
+| CLI Tool | Capability | Example Commands |
+| -------- | ---------- | ---------------- |
+| `gh` | GitHub operations | `gh pr create`, `gh issue create`, `gh api` |
+| `git` | Code changes | `git checkout -b fix/...`, `git commit`, `git push` |
+| `dbt` | dbt operations | `dbt run --select <model>`, `dbt test`, `dbt retry` |
+| `airflow` | Airflow operations | `airflow dags trigger <dag_id>`, `airflow tasks run` |
+| `montecarlo` | Monte Carlo CLI | `montecarlo monitors apply`, `montecarlo collectors test-connection` |
+| `curl` | Any HTTP API | Call REST APIs directly for any service with an API |
+| `snowsql` / `bq` / `databricks` | Warehouse CLIs | Execute SQL queries, check table state |
+
+**Check availability** by running `which <tool>` or `<tool> --version` before using a CLI tool.
+
+## Category 3: APIs (via curl or HTTP)
+
+If neither an MCP server nor a CLI tool is available for a service, you can often call its REST API directly using `curl`. This is the most flexible option — any service with an API is reachable.
+
+Examples:
+```
+# Trigger an Airflow DAG via REST API
+curl -X POST "https://airflow.example.com/api/v1/dags/<dag_id>/dagRuns" \
+  -H "Authorization: Bearer $AIRFLOW_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"conf": {}}'
+
+# Trigger a dbt Cloud job via REST API
+curl -X POST "https://cloud.getdbt.com/api/v2/accounts/<account_id>/jobs/<job_id>/run/" \
+  -H "Authorization: Token $DBT_CLOUD_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cause": "Triggered by remediation skill"}'
+```
+
+**Note:** API calls require credentials. If you don't have the right tokens or environment variables, ask the user — don't guess at authentication.
+
 ## Discovery procedure
 
-### Step 1: Scan your available tools
+### Step 1: Check MCP servers
 
-Look through your tool list (available in your system prompt or tool inventory) for any tools matching `mcp__*__*`. Group them by server name.
+Scan your tool list for `mcp__*__*` patterns. Common MCP servers relevant to remediation:
 
-### Step 2: Map servers to capabilities
+| Server Name Pattern | Capability |
+| ------------------- | ---------- |
+| `*airflow*` | Pipeline orchestration — trigger DAG runs, retry failed tasks |
+| `*dagster*` | Pipeline orchestration — launch runs, check status |
+| `*prefect*` | Pipeline orchestration — create flow runs, check status |
+| `*dbt*` | dbt operations — trigger job runs, get status, list jobs |
+| `*github*` | Code changes — create PRs, issues, branches |
+| `*gitlab*` | Code changes — create merge requests, issues |
+| `*snowflake*` | Warehouse access — execute queries, get table info |
+| `*bigquery*` | Warehouse access — execute queries, get table info |
+| `*databricks*` | Warehouse access + orchestration — queries, trigger jobs |
+| `*fivetran*` | Ingestion — trigger connector sync, check status |
+| `*jira*` | Issue tracking — create issues, update status |
 
-Use this mapping table to understand what each server enables:
+### Step 2: Check CLI tools
 
-| Server Name Pattern | Capability | Remediation Actions |
-| ------------------- | ---------- | ------------------- |
-| `*airflow*` | Pipeline orchestration | Trigger DAG runs, retry failed tasks, check DAG/task status, pause/unpause DAGs |
-| `*dagster*` | Pipeline orchestration | Launch pipeline runs, check run status, terminate runs |
-| `*prefect*` | Pipeline orchestration | Create flow runs, check flow run status |
-| `*dbt*` | dbt operations | Trigger job runs, get run status, list jobs, cancel runs |
-| `*github*` | Code changes | Create branches, create/update PRs, create issues, read file contents |
-| `*gitlab*` | Code changes | Create merge requests, create issues, read file contents |
-| `*jira*` | Issue tracking | Create issues, update status, add comments |
-| `*snowflake*` | Warehouse access | Execute queries, get table info |
-| `*bigquery*` | Warehouse access | Execute queries, get table info |
-| `*databricks*` | Warehouse access + orchestration | Execute queries, trigger jobs, check job status |
-| `*fivetran*` | Ingestion | Trigger connector sync, check sync status |
+For any capability not covered by MCP, check if a relevant CLI tool is available. The most common:
+
+- `gh` — covers GitHub operations (PRs, issues, API calls) without needing a GitHub MCP
+- `dbt` — covers dbt operations (run, test, retry) without needing a dbt Cloud MCP
+- `git` — always available for code changes
+- `curl` — always available for calling any REST API
 
 ### Step 3: Assess coverage
 
 For the current remediation task, determine:
 
 1. **Can I investigate?** — Monte Carlo MCP is always needed. If it's not connected, you cannot proceed.
-2. **Can I execute the fix?** — Check if the needed orchestration/code tool is available.
+2. **Can I execute the fix?** — Check MCP servers first, then CLI tools, then API access.
 
 ### Step 4: Report capabilities
 
 Present what you found to the user before proceeding:
 
-> "I've checked your connected MCP servers. For this remediation, I can:
-> - ✅ Investigate the issue (Monte Carlo)
+> "For this remediation, I can:
+> - ✅ Investigate the issue (Monte Carlo MCP)
 > - ✅ Restart the Airflow DAG (Airflow MCP connected)
-> - ❌ Create a code fix (no GitHub/GitLab MCP)"
+> - ✅ Create a code fix (`gh` CLI available — no GitHub MCP needed)
+> - ❌ Rerun the dbt job (no dbt Cloud MCP or `dbt` CLI found)"
 
 ## Graceful degradation
 
-When a needed tool is NOT available, follow this priority:
+When no tool (MCP, CLI, or API) is available for a needed action:
 
-### Priority 1: Provide actionable manual instructions
+### Priority 1: Provide actionable instructions
 
 Give the user the exact commands or steps to execute themselves:
 
 ```
-# If Airflow MCP is not available but you identified the DAG:
+# If no Airflow tool is available but you identified the DAG:
 "The DAG `etl_orders_daily` needs to be triggered. Run:
   airflow dags trigger etl_orders_daily
 Or via the Airflow UI: navigate to DAGs → etl_orders_daily → Trigger DAG"
 
-# If dbt Cloud MCP is not available:
-"dbt job 'Daily Transform' (job ID: 12345) needs to be rerun. Run:
-  dbt Cloud UI → Jobs → Daily Transform → Run Now
-Or via CLI: dbt run --select stg_orders+"
+# If no dbt tool is available:
+"dbt model `stg_orders` needs to be rebuilt. Run:
+  dbt run --select stg_orders+
+Or via dbt Cloud UI: Jobs → Daily Transform → Run Now"
 
-# If GitHub MCP is not available:
+# If no GitHub tool is available:
 "File `models/staging/stg_orders.sql` needs line 14 changed from
   `user_id` to `customer_id`. Create a branch and PR with this change."
 ```
 
 ### Priority 2: Present findings and ask for next steps
 
-Tell the user what you found, what the fix is, and ask how they'd like to proceed. They may run the commands themselves, notify their team, page on-call, or take a different approach.
+Tell the user what you found, what the fix is, and ask how they'd like to proceed. They may run the commands themselves, notify their team, or take a different approach.
 
 ### Priority 3: Document on the alert
 
@@ -95,39 +139,34 @@ Always, regardless of what other tools are available:
 ```
 createOrUpdateAlertComment(
   alert_id="<alert_uuid>",
-  comment="## Remediation Plan\n\n**Root cause:** [summary]\n**Required action:** [specific fix]\n**Manual steps:**\n1. [step]\n2. [step]\n\n**Note:** Automated execution was not possible — [tool name] MCP not connected.\n**Investigated by:** AI agent via remediation skill"
+  comment="## Remediation Plan\n\n**Root cause:** [summary]\n**Required action:** [specific fix]\n**Manual steps:**\n1. [step]\n2. [step]\n\n**Investigated by:** AI agent via remediation skill"
 )
 ```
 
 ## Tool-specific notes
 
-### Airflow MCP
+### Airflow
 
-Common tools you might find:
-- `trigger_dag_run` — start a DAG run (may need `dag_id`, optionally `conf` for parameters)
-- `get_dag_runs` — check recent runs and their status
-- `get_task_instances` — get task-level status for a specific run
-- `clear_task_instances` — retry failed tasks (resets their state)
+**MCP tools:** `trigger_dag_run`, `get_dag_runs`, `get_task_instances`, `clear_task_instances`
+**CLI:** `airflow dags trigger <dag_id>`, `airflow tasks run <dag_id> <task_id> <execution_date>`
+**API:** `POST /api/v1/dags/<dag_id>/dagRuns`
 
 **Caution:** `trigger_dag_run` starts a NEW run. If the issue was a failed task in an existing run, `clear_task_instances` (retry) may be more appropriate than starting fresh.
 
-### dbt Cloud MCP
+### dbt
 
-Common tools you might find:
-- `trigger_run` / `trigger_job` — start a dbt job run (needs `job_id` or `account_id` + `job_id`)
-- `get_run` — check run status and results
-- `list_jobs` — find the right job ID
-- `cancel_run` — stop a running job
+**MCP tools:** `trigger_run` / `trigger_job`, `get_run`, `list_jobs`, `cancel_run`
+**CLI:** `dbt run --select <model>`, `dbt retry`, `dbt test --select <model>`
+**API:** `POST /api/v2/accounts/<id>/jobs/<id>/run/`
 
-**Note:** dbt Cloud jobs often include multiple models. Triggering a job reruns ALL models in that job, not just the failed one. Consider whether a full rerun is appropriate.
+**Note:** dbt Cloud jobs often include multiple models. Triggering a job reruns ALL models in that job, not just the failed one. The `dbt` CLI with `--select` gives more granular control.
 
-### GitHub MCP
+### GitHub
 
-Common tools you might find:
-- `create_pull_request` — open a PR (needs `owner`, `repo`, `title`, `body`, `head`, `base`)
-- `create_issue` — open an issue for tracking
-- `create_or_update_file` — directly edit a file on a branch
-- `create_branch` — create a new branch for the fix
+**MCP tools:** `create_pull_request`, `create_issue`, `create_or_update_file`, `create_branch`
+**CLI:** `gh pr create`, `gh issue create`, `gh api`
+**Git:** `git checkout -b`, `git commit`, `git push`
+
+The `gh` CLI is often the most practical option — it doesn't require a GitHub MCP server and supports the full GitHub API via `gh api`.
 
 **Best practice:** For code fixes, create a branch → make the change → open a PR. Don't push directly to main.
-


### PR DESCRIPTION
## Summary

- Adds `skills/remediation/` — a new skill that teaches AI coding agents to investigate and remediate data quality alerts using MC MCP tools for root cause analysis and any available tools (MCP servers, CLI tools, APIs) for execution
- Single-document design (SKILL.md + reference examples) rather than per-pattern playbooks, optimized for how Opus-class models reason
- Built-in tool discovery: agents scan for available tools at runtime (MCP servers via `mcp__*` patterns, CLI tools via `which`, APIs via `curl`) and degrade gracefully when tools are missing

## What changed (13 commits after initial implementation, driven by live testing)

**Core skill (SKILL.md):**
- 4-workflow structure: Investigation → Capability Discovery → Remediation Execution → Post-remediation
- TSA always runs async (sync times out); Steps 4-6 run in parallel while waiting
- Agent waits for TSA to complete before presenting findings — no partial results
- Fetches monitor config (`include_fields=["config"]`) for Custom SQL/Validation alerts to understand exact breaching rules
- Surfaces TSA verifications section as actionable remediation steps
- Flags recurring alert patterns (chronic vs one-off)
- Asks user for alert status (FIXED/EXPECTED/NO_ACTION_NEEDED) instead of assuming
- No prescriptive tool tables — agent discovers and uses whatever helps
- Safety rules summarized in SKILL.md, detailed in safety.md (single source of truth)

**Reference docs:**
- `patterns.md` — 5 common patterns (stale data, dbt failure, schema change, volume anomaly, unknown/complex)
- `tool-discovery.md` — 3 categories (MCP servers, CLI tools like `gh`/`dbt`/`airflow`, APIs via `curl`), capability mapping, graceful degradation
- `safety.md` — Confirmation protocols, destructive operation handling, escalation = present findings and ask user for next steps

**Escalation model:** Simplified — "escalate" just means present findings to the user and ask for direction. The user decides whether to use Slack, PagerDuty, or anything else.

## Key Decisions

- **Single-doc over playbooks:** Opus-class models generalize better from examples + principles than rigid branching. Handles edge cases, combined root causes, and novel scenarios naturally — avoids N-playbook maintenance burden
- **Tool-agnostic execution:** `gh pr create` works as well as a GitHub MCP tool. The skill teaches agents to check MCP servers, CLI tools, and APIs — not just MCP
- **No verification step after remediation:** Pipeline restarts and dbt reruns don't show results immediately in MC. Removed the unreliable "re-check table" step
- **User decides alert status:** The agent can't determine if an alert should be FIXED vs EXPECTED vs NO_ACTION_NEEDED — that's a human judgment call
- See [Autonomous remediation experiment](https://www.notion.so/montecarlodata/Autonomous-remediation-335334399e6580b6b0a5e8eb75cff31d) for full design context

## Test plan

- [x] SKILL.md frontmatter valid, follows existing skill conventions (prevent, monitor-creation)
- [x] All MC MCP tools referenced in workflows exist in the MCP server (12/13 confirmed; `alertAssessment` is extended-only, skill works without it)
- [x] End-to-end validation against 6 real MC alerts with TSA results:
  - Volume alert — upstream monolith source reduction → EXPECTED
  - Custom SQL alert (data quality) — missing Metronome IDs in Salesforce → manual fix needed
  - Metric alert (dimension tracking) — late-arriving S3 firehose files → transient, self-resolved
  - Custom SQL alert (error rate) — SQL parser grammar gaps (chronic + transient) → parser fix / monitor exclusion
  - Freshness + Volume alert — Cox Automotive bulk monitor provisioning → legitimate activity
  - Freshness alert (pipeline failure) — Databricks SnowparkSQLException in Airflow DAG → code bug, self-resolved
- [x] `skills/README.md` and `CONTRIBUTING.md` correctly list the new skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)