### PR TITLE
Update MCP server domain to mcp.getmontecarlo.com

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,12 +1,12 @@
 {
-  "_comment": "Legacy fallback for MCP clients without HTTP transport. Preferred method: claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp (see https://docs.getmontecarlo.com/docs/mcp-server).",
+  "_comment": "Legacy fallback for MCP clients without HTTP transport. Preferred method: claude mcp add --transport http monte-carlo-mcp https://mcp.getmontecarlo.com/mcp (see https://docs.getmontecarlo.com/docs/mcp-server).",
   "mcpServers": {
     "monte-carlo-mcp": {
       "command": "npx",
       "args": [
         "-y",
         "mcp-remote",
-        "https://integrations.getmontecarlo.com/mcp/",
+        "https://mcp.getmontecarlo.com/mcp",
         "--header",
         "x-mcd-id: <KEY_ID>",
         "--header",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Skills can also be used standalone without the plugin. This is for users who wan
 - A [Monte Carlo](https://www.montecarlodata.com) account with Editor role or above
 - Monte Carlo MCP server — configure with:
   ```
-  claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+  claude mcp add --transport http monte-carlo-mcp https://mcp.getmontecarlo.com/mcp
   ```
   Then authenticate: run `/mcp` in your editor, select `monte-carlo-mcp`, and complete the OAuth flow.
 

--- a/plugins/claude-code/.mcp.json
+++ b/plugins/claude-code/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   }
 }

--- a/plugins/codex/.mcp.json
+++ b/plugins/codex/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   }
 }

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -20,7 +20,7 @@ CONFIG_DIR="$HOME/.codex"
 CONFIG_FILE="$CONFIG_DIR/config.toml"
 HOOKS_FILE=""  # set after TARGET_REPO is resolved
 SERVER_NAME="monte-carlo-mcp"
-SERVER_URL="https://integrations.getmontecarlo.com/mcp"
+SERVER_URL="https://mcp.getmontecarlo.com/mcp"
 
 # --- Parse arguments ---
 # Usage: install.sh [--local /path/to/mcd-agent-toolkit] <target-repo>

--- a/plugins/copilot/.mcp.json
+++ b/plugins/copilot/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   }
 }

--- a/plugins/cursor/mcp.json
+++ b/plugins/cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "monte-carlo-mcp": {
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   }
 }

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -76,7 +76,7 @@ cp plugins/opencode/commands/mc-validate.md .opencode/commands/
   "mcp": {
     "monte-carlo-mcp": {
       "type": "remote",
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   }
 }

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -89,7 +89,7 @@ if [ -f "$OPENCODE_JSON" ]; then
     echo "  ✓ MCP server already configured in opencode.json"
   else
     echo "  ⚠ monte-carlo-mcp MCP is not configured."
-    echo '    Add under "mcp": { "monte-carlo-mcp": { "type": "remote", "url": "https://integrations.getmontecarlo.com/mcp" } }'
+    echo '    Add under "mcp": { "monte-carlo-mcp": { "type": "remote", "url": "https://mcp.getmontecarlo.com/mcp" } }'
     NEEDS_GUIDANCE=true
   fi
 

--- a/plugins/opencode/opencode.json
+++ b/plugins/opencode/opencode.json
@@ -4,7 +4,7 @@
   "mcp": {
     "monte-carlo-mcp": {
       "type": "remote",
-      "url": "https://integrations.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp"
     }
   },
   "permission": {

--- a/skills/monitor-creation/README.md
+++ b/skills/monitor-creation/README.md
@@ -24,7 +24,7 @@ Install the plugin for your editor — it bundles the skill, hooks, MCP server, 
 
 1. Configure the Monte Carlo MCP server:
    ```
-   claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+   claude mcp add --transport http monte-carlo-mcp https://mcp.getmontecarlo.com/mcp
    ```
 
 2. Install the skill:

--- a/skills/monitoring-advisor/README.md
+++ b/skills/monitoring-advisor/README.md
@@ -25,7 +25,7 @@ Install the plugin for your editor — it bundles the skill, hooks, MCP server, 
 
 1. Configure the Monte Carlo MCP server:
    ```
-   claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+   claude mcp add --transport http monte-carlo-mcp https://mcp.getmontecarlo.com/mcp
    ```
 
 2. Install the skill:

--- a/skills/prevent/README.md
+++ b/skills/prevent/README.md
@@ -41,7 +41,7 @@ Install the plugin for your editor — it bundles the skill, hooks, MCP server, 
 
 1. Configure the Monte Carlo MCP server:
    ```
-   claude mcp add --transport http monte-carlo-mcp https://integrations.getmontecarlo.com/mcp
+   claude mcp add --transport http monte-carlo-mcp https://mcp.getmontecarlo.com/mcp
    ```
 
 2. Install the skill:

--- a/skills/prevent/references/TROUBLESHOOTING.md
+++ b/skills/prevent/references/TROUBLESHOOTING.md
@@ -3,7 +3,7 @@
 ### MCP connection fails:
 ```bash
 # Verify the server is reachable
-curl -s -o /dev/null -w "%{http_code}" https://integrations.getmontecarlo.com/mcp/
+curl -s -o /dev/null -w "%{http_code}" https://mcp.getmontecarlo.com/mcp
 ```
 
 **If using the plugin (OAuth):** Run `/mcp` in Claude Code, select the `monte-carlo` server, and re-authenticate. If the browser flow doesn't complete, copy the callback URL from your browser's address bar into the URL prompt that appears in Claude Code.


### PR DESCRIPTION
## Summary
- Replace all references to `integrations.getmontecarlo.com` with `mcp.getmontecarlo.com` across plugin configs, install scripts, READMEs, and skill docs (14 files)

## Test plan
- [ ] Verify MCP server is reachable at new domain: `curl -s -o /dev/null -w "%{http_code}" https://mcp.getmontecarlo.com/mcp`
- [ ] Test plugin installation with updated configs
- [ ] Confirm OAuth flow works against new domain