### PR TITLE
Simplify release process and add versioning review checks

### DIFF
--- a/.claude/agents/reviewers/versioning.md
+++ b/.claude/agents/reviewers/versioning.md
@@ -1,0 +1,75 @@
+always: true
+
+# Versioning Reviewer
+
+You are reviewing this change to ensure the plugin version is bumped when needed.
+
+**Context:** This repo distributes skills and hooks as editor plugins. Each plugin has a
+`plugin.json` (or `package.json`) with a `"version"` field. Editor clients use this version
+to detect updates — if it doesn't change, users won't get the new code. All 5 plugin config
+files must stay in sync (the release script handles this, but the diff should show at least
+the primary one changing).
+
+## Version files (any of these changing counts as a bump)
+
+- `plugins/claude-code/.claude-plugin/plugin.json`
+- `plugins/cursor/.cursor-plugin/plugin.json`
+- `plugins/copilot/plugin.json`
+- `plugins/codex/.codex-plugin/plugin.json`
+- `plugins/opencode/package.json`
+
+## When a bump is required
+
+A version bump is required when the diff touches **any** of these paths:
+
+- `skills/**` — skill content (SKILL.md, references, scripts, assets)
+- `plugins/*/hooks/**` — hook adapters or shared hook logic
+- `plugins/*/commands/**` — command definitions
+- `plugins/*/.claude-plugin/plugin.json` or equivalent — plugin config (other than version itself)
+- `plugins/shared/**` — shared logic consumed by plugins
+
+A version bump is **not** required for changes limited to:
+
+- `README.md`, `CONTRIBUTING.md`, `LICENSE`, `SECURITY.md` (repo-level docs)
+- `.github/**` (CI/CD workflows)
+- `scripts/**` (development tooling)
+- `.claude/**` (Claude Code configuration — rules, agents, next-step prompts)
+- `docs/**` (documentation not shipped in plugins)
+
+## Bump level classification
+
+When a bump is missing, suggest the appropriate level:
+
+| Level     | Criteria | Examples |
+|-----------|----------|----------|
+| **Major** | Breaking changes to skill behavior, hook interfaces, or plugin config schema | Renaming a skill, changing hook input/output contract, removing a command |
+| **Minor** | New capabilities — new skills, new commands, significant skill content changes | Adding `monitoring-advisor` skill, adding a new hook, major SKILL.md rewrite |
+| **Patch** | Bug fixes, minor content improvements, small tweaks | Fixing a typo in SKILL.md that affects behavior, correcting a tool name, small logic fix in a hook |
+
+## How to check
+
+1. Look at the diff for changes to any version file listed above. If at least one shows a
+   `"version"` change, the bump is present — note whether all 5 are in sync.
+2. If no version change is present, check whether the diff touches any bump-required path.
+3. If it does, raise a finding with the suggested bump level.
+
+## Finding format
+
+If a bump is missing:
+
+- Severity: **ISSUE** — users won't receive the update without a version bump.
+- Suggestion: include the specific bump level and the command to run:
+  `./scripts/bump-version.sh <patch|minor|major>`
+- Confidence: high (90+) when the diff clearly touches shipped content.
+
+If version files are out of sync (some bumped, some not):
+
+- Severity: **ISSUE** — all 5 plugin configs must have the same version.
+- Suggestion: run the bump script to synchronize.
+
+Do NOT flag:
+
+- PRs that only touch non-shipped paths (docs, CI, scripts, .claude config).
+- Version bumps that are already present and consistent across all plugin configs.
+- The choice of bump level when one is already present — trust the author's judgment unless
+  it's clearly wrong (e.g., a patch bump for a breaking change).

--- a/.claude/next-step-prompts/ship.md
+++ b/.claude/next-step-prompts/ship.md
@@ -1,0 +1,13 @@
+## Version bump reminder
+
+If this branch changes files under `skills/` or `plugins/` (other than docs or `.claude/` config),
+check whether the plugin version was bumped. If not, ask:
+
+> "This change touches shipped plugin content but I don't see a version bump. Want me to run
+> `./scripts/bump-version.sh <patch|minor|major>` before shipping? Without a bump, editor
+> clients won't pick up the update."
+
+Suggest the bump level based on the change:
+- **major** — breaking changes to skill behavior, hook interfaces, or plugin config schema
+- **minor** — new skills, new commands, significant skill content rewrites
+- **patch** — bug fixes, minor content improvements

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,27 +1,40 @@
-name: Create Release on Merge
+name: Create Release on Version Bump
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - 'plugins/claude-code/.claude-plugin/plugin.json'
 
 permissions:
   contents: write
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-      - name: Extract version from branch name
+      - name: Detect version change
         id: version
-        run: echo "tag=${GITHUB_HEAD_REF#release/}" >> "$GITHUB_OUTPUT"
+        run: |
+          NEW_VERSION=$(grep -o '"version": *"[^"]*"' plugins/claude-code/.claude-plugin/plugin.json | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
+          OLD_VERSION=$(git show HEAD~1:plugins/claude-code/.claude-plugin/plugin.json 2>/dev/null | grep -o '"version": *"[^"]*"' | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/' || echo "")
+          if [[ "$NEW_VERSION" != "$OLD_VERSION" && -n "$NEW_VERSION" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $OLD_VERSION → $NEW_VERSION"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No version change detected"
+          fi
 
       - name: Create tag and GitHub Release
+        if: steps.version.outputs.changed == 'true'
         run: |
-          git tag "$TAG" "${{ github.sha }}"
+          git tag "$TAG"
           git push origin "$TAG"
           gh release create "$TAG" --generate-notes --latest
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,12 +79,12 @@ Plugins reference skills via symlinks so that skills are authored once and share
 ## Updating an existing skill
 
 1. Edit files directly under `skills/<skill-name>/`. The corresponding plugin picks up changes automatically via the symlink — no additional steps needed.
-2. If the change is user-facing, bump the `version` in the corresponding plugin's `plugin.json`. Claude Code uses the version field to determine whether to update an installed plugin.
+2. If the change is user-facing, bump the version: `./scripts/bump-version.sh patch` (or `minor`/`major` — see [Version bumping](#version-bumping)). This updates all 5 plugin config files in sync. Claude Code uses the version field to determine whether to update an installed plugin.
 
 ## Fixing a bug
 
-1. For skill content bugs: fix in `skills/<skill-name>/` and bump the plugin version.
-2. For plugin-level bugs (hooks, plugin.json config): fix in `plugins/claude-code/<skill-name>/` and bump the plugin version.
+1. For skill content bugs: fix in `skills/<skill-name>/` and bump the version with `./scripts/bump-version.sh patch`.
+2. For plugin-level bugs (hooks, plugin.json config): fix in `plugins/claude-code/<skill-name>/` and bump the version with `./scripts/bump-version.sh patch`.
 
 ## Pull request guidelines
 
@@ -103,52 +103,45 @@ Plugins reference skills via symlinks so that skills are authored once and share
 
 ## Releasing
 
-Use `scripts/release.sh` to cut a release. It bumps the version in all 5 plugin config files, opens your editor for a changelog entry, commits, and tags.
+Version is tracked in code (the 5 plugin config files). Bump it as part of your feature PR — no separate release step needed. When the version change merges to `main`, a GitHub Actions workflow automatically creates the corresponding git tag and GitHub Release.
 
-### Prerequisites
+### Bump the version
 
-- A baseline tag must exist (e.g., `v1.0.0`). If this is the first release, create one manually:
-  ```bash
-  git tag v1.0.0
-  git push origin v1.0.0
-  ```
-- You must be on `main` with a clean working tree.
-
-### Usage
+Use the convenience script to update all 5 plugin config files and changelogs in one step:
 
 ```bash
-# Bump patch version (1.0.0 → 1.0.1), commit + tag locally
-./scripts/release.sh patch
+# Bump patch version (1.0.0 → 1.0.1)
+./scripts/bump-version.sh patch
 
-# Bump minor version, push branch + tag, and open PR
-./scripts/release.sh minor --push
+# Bump minor version (1.0.0 → 1.1.0)
+./scripts/bump-version.sh minor
 
 # Set an explicit version
-./scripts/release.sh 2.0.0
+./scripts/bump-version.sh 2.0.0
 
 # Preview what would happen without making changes
-./scripts/release.sh patch --dry-run
+./scripts/bump-version.sh patch --dry-run
 ```
 
-### What the script does
-
+The script:
 1. Reads the current version from `plugins/claude-code/.claude-plugin/plugin.json`
 2. Computes the next version based on the bump type
 3. Opens `$EDITOR` with a changelog template pre-filled with commits since the last tag
 4. Updates `"version"` in all 5 plugin config files
 5. Prepends the changelog entry to all 5 `CHANGELOG.md` files
-6. Creates a `release/vX.Y.Z` branch and commits (`release: vX.Y.Z`)
 
-Without `--push`, the branch and commit stay local so you can inspect before pushing. To publish:
+Commit the resulting changes as part of your PR.
 
-```bash
-git push -u origin release/vX.Y.Z
-gh pr create --title 'release: vX.Y.Z'
-```
+### Automated checks
+
+Two automated checks help catch missing version bumps:
+
+- **`/ship`** — before opening a PR, checks whether the diff touches shipped content (`skills/`, `plugins/`) without a version bump, and prompts you to run the script.
+- **`/code-review`** — the `versioning` reviewer agent runs on every PR and flags missing or inconsistent version bumps as an ISSUE-level finding, with a suggested bump level.
 
 ### GitHub Release
 
-When a `release/v*` PR merges to `main`, a GitHub Actions workflow (`.github/workflows/release-on-tag.yml`) automatically tags the merge commit and creates a GitHub Release with auto-generated release notes.
+When a version bump merges to `main`, the GitHub Actions workflow (`.github/workflows/release-on-tag.yml`) automatically creates a git tag and GitHub Release with auto-generated release notes from PR titles.
 
 ## Architecture
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 #
-# release.sh — Bump versions, update changelogs, and open a release PR.
+# bump-version.sh — Bump versions and update changelogs across all plugins.
+#
+# Run this on your feature branch before committing. It updates all 5 plugin
+# config files and changelogs in one step. Commit the result as part of your PR.
 #
 # Usage:
-#   ./scripts/release.sh <patch|minor|major|X.Y.Z> [--push] [--dry-run] [--force]
+#   ./scripts/bump-version.sh <patch|minor|major|X.Y.Z> [--dry-run]
 #
 # Examples:
-#   ./scripts/release.sh patch              # 1.0.0 → 1.0.1, branch + commit locally
-#   ./scripts/release.sh minor --push       # 1.0.0 → 1.1.0, push branch + open PR
-#   ./scripts/release.sh 2.0.0 --dry-run    # Preview what would happen
-#
-# After the PR merges, a GitHub Actions workflow tags the commit and creates
-# a GitHub Release automatically.
+#   ./scripts/bump-version.sh patch          # 1.0.0 → 1.0.1
+#   ./scripts/bump-version.sh minor          # 1.0.0 → 1.1.0
+#   ./scripts/bump-version.sh 2.0.0          # Set explicit version
+#   ./scripts/bump-version.sh patch --dry-run  # Preview without changes
 #
 set -euo pipefail
 
@@ -44,22 +45,18 @@ CHANGELOG_FILES=(
 )
 
 # ── Defaults ────────────────────────────────────────────────────────────────
-PUSH=false
 DRY_RUN=false
-FORCE=false
 BUMP_TYPE=""
 
 # ── Parse arguments ─────────────────────────────────────────────────────────
 usage() {
-  echo "Usage: $0 <patch|minor|major|X.Y.Z> [--push] [--dry-run]"
+  echo "Usage: $0 <patch|minor|major|X.Y.Z> [--dry-run]"
   exit 1
 }
 
 for arg in "$@"; do
   case "$arg" in
-    --push)    PUSH=true ;;
     --dry-run) DRY_RUN=true ;;
-    --force)   FORCE=true ;;
     patch|minor|major) BUMP_TYPE="$arg" ;;
     [0-9]*.[0-9]*.[0-9]*)  BUMP_TYPE="explicit"; EXPLICIT_VERSION="$arg" ;;
     -h|--help) usage ;;
@@ -97,26 +94,8 @@ echo ""
 
 # ── Preflight checks ───────────────────────────────────────────────────────
 if [[ "$DRY_RUN" == false ]]; then
-  if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
-    echo "Error: Working tree is not clean. Commit or stash changes first."
-    exit 1
-  fi
-
-  CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
-  if [[ "$CURRENT_BRANCH" != "main" && "$FORCE" == false ]]; then
-    echo "Error: Must be on 'main' to release (currently on '$CURRENT_BRANCH')."
-    echo "       Use --force to override."
-    exit 1
-  fi
-
   if git -C "$REPO_ROOT" rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
     echo "Error: Tag v$NEW_VERSION already exists."
-    exit 1
-  fi
-
-  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/release/v$NEW_VERSION" 2>/dev/null ||
-     git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "release/v$NEW_VERSION" >/dev/null 2>&1; then
-    echo "Error: Branch release/v$NEW_VERSION already exists."
     exit 1
   fi
 fi
@@ -195,44 +174,9 @@ for file in "${CHANGELOG_FILES[@]}"; do
   fi
 done
 
-# ── Create release branch and commit ──────────────────────────────────────
-RELEASE_BRANCH="release/v$NEW_VERSION"
+# ── Done ──────────────────────────────────────────────────────────────────
 echo ""
-if [[ "$DRY_RUN" == true ]]; then
-  echo "[dry-run] Would create branch: $RELEASE_BRANCH"
-  echo "[dry-run] Would commit: release: v$NEW_VERSION"
-else
-  cd "$REPO_ROOT"
-  git checkout -b "$RELEASE_BRANCH"
-  git add "${VERSION_FILES[@]}" "${CHANGELOG_FILES[@]}"
-  git commit -m "release: v$NEW_VERSION"
-  echo "Created branch: $RELEASE_BRANCH"
-  echo "Committed: release: v$NEW_VERSION"
-fi
-
-# ── Push and open PR ──────────────────────────────────────────────────────
-echo ""
-if [[ "$PUSH" == true ]]; then
-  if [[ "$DRY_RUN" == true ]]; then
-    echo "[dry-run] Would push branch and open PR"
-  else
-    git -C "$REPO_ROOT" push -u origin "$RELEASE_BRANCH"
-    if command -v gh &>/dev/null; then
-      gh pr create --title "release: v$NEW_VERSION" --body "Bump version to $NEW_VERSION and update changelogs."
-      echo ""
-      echo "PR created. Merging it will automatically tag and create a GitHub Release."
-    else
-      echo "Pushed branch. Open a PR manually:"
-      echo "  gh pr create --title 'release: v$NEW_VERSION'"
-    fi
-  fi
-else
-  if [[ "$DRY_RUN" == false ]]; then
-    echo "Done! To publish the release, push the branch and open a PR:"
-    echo "  git push -u origin $RELEASE_BRANCH"
-    echo "  gh pr create --title 'release: v$NEW_VERSION'"
-    echo ""
-    echo "Or next time, use --push to do this automatically:"
-    echo "  ./scripts/release.sh $BUMP_TYPE --push"
-  fi
+if [[ "$DRY_RUN" == false ]]; then
+  echo "Version bumped to $NEW_VERSION."
+  echo "Files updated — commit them as part of your PR."
 fi


### PR DESCRIPTION
## Summary

- Replace `release.sh` (which committed directly to main or required release branches) with `bump-version.sh` — a simpler script that only updates version files and changelogs, meant to run on feature branches
- GH Actions workflow now auto-creates tags and GitHub Releases when a version change merges to main — no manual tagging or release branches needed
- Add a `versioning` reviewer agent (`.claude/agents/reviewers/`) that flags missing version bumps during `/code-review`, with a suggested bump level (major/minor/patch)
- Add a `/ship` next-step prompt that catches missing bumps before PR creation
- Simplify `.gitignore` — only ignore `.claude/settings.local.json` instead of blanket-ignoring `.claude/`
- Update CONTRIBUTING.md to document the new process

## Context

Discussion: https://montecarloai.slack.com/archives/C09JE0S4FLL/p1775848619734579

The old release script tried to push directly to main (blocked by branch protection) or required a separate release branch PR for every release. The new flow is simpler: bump the version as part of your feature PR, and the release happens automatically on merge.

## Test plan

- [x] Verify `./scripts/bump-version.sh patch --dry-run` works correctly
- [ ] Verify the GH Actions workflow triggers on a version bump merge to main (can only verify after merge)
- [x] Verify `/code-review` picks up the versioning reviewer agent (`versioning` appears in always-on list)
- [x] Verify `/ship` shows the version bump nudge when shipping skill/plugin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)