### PR TITLE
fix: add missing skill registrations — READMEs, symlinks, and sync rules

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -50,3 +50,12 @@ getAssetLineage(...)
 ```
 
 The actual MCP tool names follow the `mcp__<server>__<tool_name>` convention where `tool_name` is always snake_case. Using camelCase causes the agent to hallucinate tool names that don't exist.
+
+## Keep READMEs in sync when adding or renaming skills
+
+When adding a new skill or renaming an existing one, update the skill tables in **both**:
+
+1. `README.md` (root) — the Features table
+2. `skills/README.md` — the Available Skills table
+
+These are the two places users discover skills. A skill that exists but isn't listed in both READMEs is effectively invisible.

--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -51,6 +51,20 @@ getAssetLineage(...)
 
 The actual MCP tool names follow the `mcp__<server>__<tool_name>` convention where `tool_name` is always snake_case. Using camelCase causes the agent to hallucinate tool names that don't exist.
 
+## Create symlinks in all editor plugins when adding a skill
+
+Every skill in `skills/` must have a corresponding symlink in **every** editor plugin's `skills/` directory:
+
+- `plugins/claude-code/skills/<name> → ../../../skills/<name>`
+- `plugins/cursor/skills/<name> → ../../../skills/<name>`
+- `plugins/codex/skills/<name> → ../../../skills/<name>`
+- `plugins/copilot/skills/<name> → ../../../skills/<name>`
+- `plugins/opencode/skills/<name> → ../../../skills/<name>`
+
+Without these symlinks, the skill won't be discovered by the editor plugin — even if it exists in `skills/` and is listed in the READMEs.
+
+**Verify after adding:** count the directories in `skills/` (excluding `README.md`) and confirm each editor plugin's `skills/` directory has the same count of symlinks.
+
 ## Keep READMEs in sync when adding or renaming skills
 
 When adding a new skill or renaming an existing one, update the skill tables in **both**:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The toolkit bundles the following capabilities as a single **mc-agent-toolkit** 
 | **Generate Validation Notebook** | Generates SQL validation notebooks for dbt model changes, with targeted queries comparing baseline and development data. | [README](skills/generate-validation-notebook/README.md) |
 | **Push Ingestion** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. | [README](skills/push-ingestion/README.md) |
 | **Automated Triage** | Guides AI agents through automated alert triage — scoring alerts, running deep troubleshooting on high-signal ones, classifying, and taking actions. | [SKILL](skills/automated-triage/SKILL.md) |
+| **Storage Cost Analysis** | Identifies storage waste patterns (unread, zombie, dead-end tables) and recommends safe cleanup with cost estimates. | [README](skills/storage-cost-analysis/README.md) |
+| **Performance Diagnosis** | Diagnoses slow pipelines and expensive queries across Airflow, dbt, and Databricks with tiered investigation. | [README](skills/performance-diagnosis/README.md) |
+| **Remediation** | Investigates and remediates data quality alerts — runs TSA root cause analysis, discovers available tools, executes fixes (or escalates), and documents the resolution. | [README](skills/remediation/README.md) |
+| **Agent Monitoring** | Investigation and monitor creation guide for AI agent observability. | [README](skills/agent-monitoring/README.md) |
 
 ## Installing the plugin (recommended)
 

--- a/docs/plugin-architecture-guide.md
+++ b/docs/plugin-architecture-guide.md
@@ -66,16 +66,17 @@ This reflects the **current repository structure**.
 ```
 mc-agent-toolkit/
 ├── skills/                              # Shared skill definitions (platform-agnostic)
-│   ├── monitor-creation/
-│   │   ├── SKILL.md
-│   │   └── references/
-│   ├── prevent/
-│   │   ├── SKILL.md
-│   │   └── references/
+│   ├── agent-monitoring/
+│   ├── analyze-root-cause/
+│   ├── automated-triage/
 │   ├── generate-validation-notebook/
-│   │   └── SKILL.md
-│   └── push-ingestion/
-│       └── SKILL.md
+│   ├── monitor-creation/
+│   ├── monitoring-advisor/
+│   ├── performance-diagnosis/
+│   ├── prevent/
+│   ├── push-ingestion/
+│   ├── remediation/
+│   └── storage-cost-analysis/
 │
 ├── plugins/
 │   │
@@ -91,16 +92,13 @@ mc-agent-toolkit/
 │   │       └── cache.py                 # Separate cache (mc_<skill>_* prefixed)
 │   │
 │   │  # --- Each editor: ONE mc-agent-toolkit plugin ---
+│   │  # --- Each editor's skills/ dir must symlink ALL skills from skills/ ---
 │   ├── claude-code/                     # mc-agent-toolkit plugin for Claude Code
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── .mcp.json
 │   │   ├── hooks/
 │   │   │   └── prevent/                 # Thin adapters → plugins/shared/prevent/lib/
-│   │   ├── skills/
-│   │   │   ├── monitor-creation → symlink
-│   │   │   ├── prevent → symlink
-│   │   │   ├── generate-validation-notebook → symlink
-│   │   │   └── push-ingestion → symlink
+│   │   ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │   │   └── commands/
 │   │       ├── prevent/
 │   │       └── push-ingestion/
@@ -109,14 +107,13 @@ mc-agent-toolkit/
 │   │   ├── .cursor-plugin/plugin.json
 │   │   ├── hooks/
 │   │   │   └── prevent/                 # MC Prevent hook adapters
-│   │   ├── skills/
-│   │   │   ├── monitor-creation → symlink
-│   │   │   └── prevent → symlink
+│   │   ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │   │   └── mcp.json
 │   │
 │   ├── opencode/                        # mc-agent-toolkit plugin for OpenCode
 │   │   ├── src/
 │   │   │   └── prevent/                 # TypeScript feature module (ported from Python)
+│   │   ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │   │   ├── package.json
 │   │   └── opencode.json
 │   │
@@ -129,17 +126,13 @@ mc-agent-toolkit/
 │   │   │       ├── lib → symlink        # Shared hook logic (sibling of scripts)
 │   │   │       ├── pre_edit_hook.py
 │   │   │       └── ...
-│   │   ├── skills/
-│   │   │   ├── monitor-creation → symlink
-│   │   │   └── prevent → symlink
+│   │   ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │   │   └── scripts/
 │   │       ├── install.sh               # Installs hooks to .github/hooks/
 │   │       └── mc-prevent.json          # Hook registration template for target project
 │   │
 │   └── codex/                           # mc-agent-toolkit plugin for Codex
-│       └── skills/
-│           ├── monitor-creation → symlink
-│           └── prevent → symlink
+│       └── skills/                      # One symlink per skill → ../../../skills/<name>
 ```
 
 **Key distinctions:**

--- a/plugins/claude-code/skills/remediation
+++ b/plugins/claude-code/skills/remediation
@@ -1,0 +1,1 @@
+../../../skills/remediation

--- a/plugins/codex/skills/remediation
+++ b/plugins/codex/skills/remediation
@@ -1,0 +1,1 @@
+../../../skills/remediation

--- a/plugins/copilot/skills/remediation
+++ b/plugins/copilot/skills/remediation
@@ -1,0 +1,1 @@
+../../../skills/remediation

--- a/plugins/cursor/skills/remediation
+++ b/plugins/cursor/skills/remediation
@@ -1,0 +1,1 @@
+../../../skills/remediation

--- a/plugins/opencode/skills/remediation
+++ b/plugins/opencode/skills/remediation
@@ -1,0 +1,1 @@
+../../../skills/remediation

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,7 @@ Skills are platform-agnostic instruction sets that tell an AI coding agent what 
 | **[Storage Cost Analysis](storage-cost-analysis/)** | Identifies storage waste patterns (unread, zombie, dead-end tables) and recommends safe cleanup with cost estimates. |
 | **[Performance Diagnosis](performance-diagnosis/)** | Diagnoses slow pipelines and expensive queries across Airflow, dbt, and Databricks with tiered investigation. |
 | **[Remediation](remediation/)** | Investigates and remediates data quality alerts — runs TSA root cause analysis, discovers available tools, executes fixes (or escalates), and documents the resolution. |
+| **[Agent Monitoring](agent-monitoring/)** | Investigation and monitor creation guide for AI agent observability. |
 
 ## Standalone Installation
 


### PR DESCRIPTION
## Summary
- Added Storage Cost Analysis, Performance Diagnosis, Remediation, and Agent Monitoring to the root README features table
- Added Agent Monitoring to skills/README.md (the only one missing there)
- Added missing `remediation` symlinks to all 5 editor plugins (claude-code, cursor, codex, copilot, opencode) — the skill existed in `skills/` but was never symlinked, making it invisible to all editors
- Added a "Keep READMEs in sync" rule to `.claude/rules/skills.md` so new skills don't get missed in the future
- Added a "Create symlinks in all editor plugins" rule to `.claude/rules/skills.md` to enforce symlink creation for new skills
- Updated `docs/plugin-architecture-guide.md` directory tree to reflect all 11 current skills

## Test plan
- [x] Verify all skill directories have a corresponding entry in both README tables
- [x] Verify links point to correct README paths
- [x] Verify `remediation` symlink resolves in all 5 editor plugin `skills/` directories
- [x] Verify symlink count matches skill directory count

🤖 Generated with [Claude Code](https://claude.com/claude-code)