### PR TITLE
release: v1.5.0

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-15
+
+### Changed
+
+- Add asset-health skill (#33)
+- Add AI agent monitoring to monitoring-advisor skill (#48)
+
 ## [1.4.0] - 2026-04-14
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,6 +1,18 @@
-# Changelog — mc-agent-toolkit (Codex)
+# Changelog
 
-## v1.0.0 (2026-04-02)
+All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.0] - 2026-04-15
+
+### Changed
+
+- Add asset-health skill (#33)
+- Add AI agent monitoring to monitoring-advisor skill (#48)
+
+## [1.0.0] - 2026-04-02
 
 - Initial Codex plugin for Monte Carlo Agent Toolkit
 - Shared core library with thin Codex adapters

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## 1.0.0 — 2026-04-06
+All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.0] - 2026-04-15
+
+### Changed
+
+- Add asset-health skill (#33)
+- Add AI agent monitoring to monitoring-advisor skill (#48)
+
+## [1.0.0] - 2026-04-06
 
 Initial release of the Monte Carlo Agent Toolkit plugin for GitHub Copilot CLI.
 

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-15
+
+### Changed
+
+- Add asset-health skill (#33)
+- Add AI agent monitoring to monitoring-advisor skill (#48)
+
 ## [1.4.0] - 2026-04-14
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-15
+
+### Changed
+
+- Add asset-health skill (#33)
+- Add AI agent monitoring to monitoring-advisor skill (#48)
+
 ## [1.4.0] - 2026-04-14
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump version from 1.4.0 to 1.5.0 across all 5 plugin configs
- Add changelog entries for new features since v1.4.0
- Normalize codex and copilot changelogs to Keep a Changelog format so `bump-version.sh` can update them correctly
- Exclude #44 (release tooling changes) from changelogs — not related to plugins

## Changes since v1.4.0
- Add asset-health skill (#33)
- Add AI agent monitoring to monitoring-advisor skill (#48)