### PR TITLE
feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-17
+
+### Changed
+
+- d8f0509 chore(automated-triage): bump version to 1.1.1
+- 580ece7 feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage by domain/audience
+- 5d75040 Add Connection Auth Rules skill (#51)
+- 48f1322 feat(automated-triage): add interactive triage mode and action guard (AI-192) (#54)
+
 ## [1.6.1] - 2026-04-16
 
 ### Changed

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-17
+
+### Changed
+
+- d8f0509 chore(automated-triage): bump version to 1.1.1
+- 580ece7 feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage by domain/audience
+- 5d75040 Add Connection Auth Rules skill (#51)
+- 48f1322 feat(automated-triage): add interactive triage mode and action guard (AI-192) (#54)
+
 ## [1.6.1] - 2026-04-16
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-17
+
+### Changed
+
+- d8f0509 chore(automated-triage): bump version to 1.1.1
+- 580ece7 feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage by domain/audience
+- 5d75040 Add Connection Auth Rules skill (#51)
+- 48f1322 feat(automated-triage): add interactive triage mode and action guard (AI-192) (#54)
+
 ## [1.6.1] - 2026-04-16
 
 ### Changed

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-17
+
+### Changed
+
+- d8f0509 chore(automated-triage): bump version to 1.1.1
+- 580ece7 feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage by domain/audience
+- 5d75040 Add Connection Auth Rules skill (#51)
+- 48f1322 feat(automated-triage): add interactive triage mode and action guard (AI-192) (#54)
+
 ## [1.6.1] - 2026-04-16
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-17
+
+### Changed
+
+- d8f0509 chore(automated-triage): bump version to 1.1.1
+- 580ece7 feat(automated-triage): add mark_event_as_normal guidance and scope interactive triage by domain/audience
+- 5d75040 Add Connection Auth Rules skill (#51)
+- 48f1322 feat(automated-triage): add interactive triage mode and action guard (AI-192) (#54)
+
 ## [1.6.1] - 2026-04-16
 
 ### Changed

--- a/skills/automated-triage/SKILL.md
+++ b/skills/automated-triage/SKILL.md
@@ -49,6 +49,7 @@ All tools are available via the `monte-carlo` MCP server.
 | `update_alert`                        | default  | Update an alert's status and/or declare an incident by setting severity                                           |
 | `set_alert_owner`                     | default  | Assign an owner to an alert by email                                                                              |
 | `create_or_update_alert_comment`      | default  | Post or update a triage comment on an alert                                                                       |
+| `mark_event_as_normal`                | default  | Mark all anomaly events in an alert as normal, triggering ML threshold recalibration to prevent re-alerting on the same pattern |
 
 ---
 
@@ -98,12 +99,12 @@ If the user's request already makes the intent clear — e.g. "triage my freshne
 
 The user wants to look at specific alerts now. Use the triage tools directly to investigate and report findings. Do not frame this as workflow-building.
 
-1. Clarify scope if needed — which alert types, time window, or specific tables? If the user already specified (e.g. "recent freshness alerts"), proceed without asking.
-2. Fetch alerts with `get_alerts`, run `alert_assessment` in parallel on all of them, and report the results clearly.
+1. ALWAYS Clarify the scope (Ask about the time window and whether the user is interested in a specific domain, audience or alert type).
+2. Fetch alerts with `get_alerts` (applying any domain or audience filter from step 1), run `alert_assessment` in parallel on all of them, and report the results clearly.
 3. For any alert where both confidence and impact are MEDIUM or higher, offer to run `run_troubleshooting_agent` for a deeper root cause analysis. Wait for confirmation before running it.
 4. Summarise findings. Do not prompt to save a workflow file or set up automation unless the user brings it up.
 
-**Write tools in interactive triage:** After findings are clear, proactively offer relevant actions — updating status, declaring a severity, assigning an owner, or posting a comment. Ask before executing.
+**Write tools in interactive triage:** After findings are clear, proactively offer relevant actions — updating status, declaring a severity, assigning an owner, posting a comment, or marking events as normal (for alerts that are natural data variation). Ask before executing.
 
 ---
 

--- a/skills/automated-triage/SKILL.md
+++ b/skills/automated-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monte-carlo-automated-triage
 description: Triage Monte Carlo alerts interactively or build an automated workflow. Fetch, score, and troubleshoot alerts using MCP tools now, or design a reusable workflow that runs on a schedule.
-version: 1.1.0
+version: 1.1.1
 ---
 
 # Monte Carlo Automated Triage
@@ -99,7 +99,7 @@ If the user's request already makes the intent clear — e.g. "triage my freshne
 
 The user wants to look at specific alerts now. Use the triage tools directly to investigate and report findings. Do not frame this as workflow-building.
 
-1. ALWAYS Clarify the scope (Ask about the time window and whether the user is interested in a specific domain, audience or alert type).
+1. Clarify the scope (Ask about the time window and whether the user is interested in a specific domain, audience or alert type).
 2. Fetch alerts with `get_alerts` (applying any domain or audience filter from step 1), run `alert_assessment` in parallel on all of them, and report the results clearly.
 3. For any alert where both confidence and impact are MEDIUM or higher, offer to run `run_troubleshooting_agent` for a deeper root cause analysis. Wait for confirmation before running it.
 4. Summarise findings. Do not prompt to save a workflow file or set up automation unless the user brings it up.

--- a/skills/automated-triage/references/triage-example.md
+++ b/skills/automated-triage/references/triage-example.md
@@ -80,6 +80,8 @@ Then call `update_alert` for each classified alert:
 | Possible data incident      | *(no change)*        |
 | Other                       | *(no change)*        |
 
+For alerts classified as **natural data variation**, also call `mark_event_as_normal` — this signals the ML threshold detector to recalibrate and avoid re-alerting on the same pattern. Only has an effect on monitors using automated (ML-based) thresholds.
+
 Do not update status for untroubleshot alerts.
 
 **Recommendation mode:**
@@ -87,6 +89,7 @@ Do not update status for untroubleshot alerts.
 Do not call any write tools. Instead, for each alert output:
 - The comment you would post
 - The status you would set (or "no change")
+- Whether you would call `mark_event_as_normal`
 
 ---
 

--- a/skills/automated-triage/references/triage-stages.md
+++ b/skills/automated-triage/references/triage-stages.md
@@ -122,9 +122,9 @@ Only update status for alerts that went through full troubleshooting. Leave untr
 
 ### Additional Monte Carlo actions
 
+- **Mark events as normal** — for alerts classified as natural variation, marking the underlying events as normal allows the detector to adapt thresholds to prevent further alerts on similar patterns. Only applies to monitors using automated (ML-based) thresholds — has no effect on static-threshold monitors.
 - **Declare an incident** (`update_alert` with `declared_incident_severity`) — promotes the alert to an incident, escalating visibility. Values: `SEV_1`–`SEV_4`. Use `NO_SEVERITY` to clear. Appropriate for verified ongoing incidents.
 - **Assign ownership** (`set_alert_owner`) — route a confirmed incident or required investigation to the right person.
-- **Mark events as normal** — for alerts classified as natural variation, marking the underlying events as normal allows the detector to adapt thresholds to prevent further alerts on similar patterns. (Not yet available via MCP).
 
 ### External integrations
 


### PR DESCRIPTION
## What this PR does

Improves the `automated-triage` skill in two ways:

**1. `mark_event_as_normal` support**

The tool is now available via the Monte Carlo MCP server. This PR:
- Adds it to the tools table in `SKILL.md`
- Documents when to use it (natural data variation — seasonal patterns, expected volatility) and when **not** to (genuine anomalies from real incidents or intentional changes, which would corrupt the ML detector's calibration)
- Wires it into the example workflow's action mode: after setting status to `NO_ACTION_NEEDED` for natural variation alerts, the example now also calls `mark_event_as_normal`
- Mentions it in the interactive triage write-tools offer

**2. Scoped interactive triage**

Branch A previously jumped straight into fetching and triaging all alerts. It now asks whether the user is interested in a specific domain or audience first, applying that as a filter to `get_alerts`. This avoids overwhelming results on large data estates and makes triage more focused from the start.

## Key Decisions

- **Use/don't-use guidance kept concise** — triage-stages.md documents the rule in one bullet rather than a callout block, consistent with how other actions in Stage 5 are documented.
- **mark_event_as_normal in example, not just stages** — added to the concrete example workflow so teams copying it get the behaviour by default, not just as a reference they might miss.
- **Scope question added to Branch A step 1** — rather than a separate pre-flight step, it's folded into the existing "clarify scope" step alongside time window, keeping the flow natural.

## Checklist

- [x] Skill version bumped (1.1.0 → 1.1.1)
- [x] Plugin version bumped (1.6.0 → 1.6.1)
- [na] Tests (skill is pure markdown)
- [na] New skill symlinks (no new skill added)

Closes [AI-194](https://linear.app/montecarlodata/issue/AI-194)