### PR TITLE
fix(plugin): add missing incident-response and proactive-monitoring command files (v1.8.1)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-04-20
+
+### Fixed
+
+- Plugin update failed on 1.8.0 with `commands path not found` for `incident-response` and `proactive-monitoring`. The 1.8.0 manifest declared these command paths but the directories were never committed. Added the missing `/monte-carlo-incident-response` and `/monte-carlo-proactive-monitoring` slash-command files so the paths resolve and the workflows documented in `/mc` are actually invokable.
+
 ## [1.8.0] - 2026-04-20
 
 ### Added

--- a/plugins/claude-code/commands/incident-response/monte-carlo-incident-response.md
+++ b/plugins/claude-code/commands/incident-response/monte-carlo-incident-response.md
@@ -1,0 +1,5 @@
+---
+description: Triage, investigate, fix, and prevent Monte Carlo data incidents
+---
+
+Activate the Monte Carlo Incident Response workflow skill.

--- a/plugins/claude-code/commands/proactive-monitoring/monte-carlo-proactive-monitoring.md
+++ b/plugins/claude-code/commands/proactive-monitoring/monte-carlo-proactive-monitoring.md
@@ -1,0 +1,5 @@
+---
+description: Assess coverage gaps and create monitors across your data estate
+---
+
+Activate the Monte Carlo Proactive Monitoring workflow skill.


### PR DESCRIPTION
## Summary

- v1.8.0 fails to load on `claude plugin update` with `commands path not found: .../commands/incident-response` and `.../commands/proactive-monitoring`.
- Root cause: PR #56 added those two paths to the `commands` array in `plugins/claude-code/.claude-plugin/plugin.json` but never committed the directories or any command `.md` files. The plugin loader validates every declared path and errors out.
- Fix: add the two missing slash-command files using the names already advertised by the `/mc` catalog (`/monte-carlo-incident-response`, `/monte-carlo-proactive-monitoring`), bump plugin version to `1.8.1`, update the changelog.

## Verification

- `python3 -m json.tool plugin.json` passes.
- All 8 `commands` paths now resolve on disk.
- `/mc` catalog no longer points at non-existent commands.

## Test plan

- [x] JSON validates
- [x] Each declared `commands` path exists on disk
- [ ] Install locally and confirm `/monte-carlo-incident-response` and `/monte-carlo-proactive-monitoring` appear in the slash-command menu and activate the correct skills
- [ ] `claude plugin update mc-agent-toolkit` succeeds without `commands path not found` errors

## Follow-up

The v1.8.0 test plan claimed `/mc-incident-response` + `/mc-proactive-monitoring` were verified, yet neither the commands nor those exact names ever existed. Worth tightening the release checklist to actually exercise every path declared in the manifest before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)