### PR TITLE
feat(tune-monitor): add per-type references for metric and custom SQL monitors

### DIFF
--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune-monitor
-description: Analyze a Monte Carlo metric monitor and recommend configuration improvements to reduce alert noise. Fetches a monitor's report, identifies alert patterns, and suggests sensitivity, segment, and schedule changes.
+description: Analyze a Monte Carlo monitor and recommend configuration changes to reduce alert noise. Supports metric monitors and custom SQL monitors. Fetches the report, identifies patterns, and suggests tuning.
 version: 1.0.0
 ---
 
@@ -11,6 +11,12 @@ a file for reference, analyze the alert patterns, and recommend concrete configu
 reduce noise without sacrificing real signal.
 
 **Arguments:** $ARGUMENTS
+
+Reference files live next to this skill file. **Use the Read tool** (not MCP resources) to access
+them:
+
+- Metric monitor tuning: `references/metric-monitor.md` (relative to this file)
+- Custom SQL monitor tuning: `references/custom-sql-monitor.md` (relative to this file)
 
 ---
 
@@ -49,6 +55,29 @@ Run both calls in parallel.
 
 ---
 
+## Phase 1.5: Determine Monitor Type and Load Reference
+
+From the `get_monitors` config response, determine the monitor type:
+
+| Config indicator | Type | Reference file |
+|---|---|---|
+| Monitor type is a metric monitor variant (e.g., metric, field health) | Metric | `references/metric-monitor.md` |
+| Monitor type is a custom SQL rule / custom monitor | Custom SQL | `references/custom-sql-monitor.md` |
+
+**Read** the appropriate reference file using the Read tool with the path relative to this skill
+file. The reference contains type-specific config fields to extract, recommendation guidance, and
+apply-changes instructions.
+
+If the monitor type is not metric or custom SQL, tell the user:
+
+> This skill currently supports tuning metric monitors and custom SQL monitors. This monitor is a
+> {type} monitor — I can still analyze its report, but I won't have type-specific tuning
+> recommendations.
+
+Then proceed with Phase 2 using only the general recommendations from this file.
+
+---
+
 ## Phase 2: Analyze the Report
 
 Analyze the monitor report and config together. Focus on:
@@ -65,13 +94,12 @@ Analyze the monitor report and config together. Focus on:
 - Are anomalies caused by known operational events (deployments, batch jobs, bulk user actions)?
 
 ### 2c. Current configuration
-Extract from the config:
-- Monitor type and metric (e.g., `RELATIVE_ROW_COUNT`)
-- Segment field(s) and any `where_condition`
-- Sensitivity setting (explicit or `AUTO`)
+Extract the current configuration. The specific fields to look for are documented in the per-type
+reference loaded in Phase 1.5. At minimum, extract:
+- Monitor type and what it measures
 - Schedule interval
-- Collection lag
 - Audiences / notification channels
+- Whether the monitor uses ML thresholds or explicit thresholds
 
 ### 2d. Troubleshooting analysis (if available)
 Look at any troubleshooting TL;DRs in the report. Note:
@@ -88,49 +116,37 @@ Based on the analysis, produce a prioritized list of recommendations. For each r
 - Give the **specific config change** (use exact field names from the MC config schema)
 - Explain the **trade-off** (what signal might be lost)
 
-Use this framework to generate recommendations:
+### General recommendations (all monitor types)
 
-### Sensitivity tuning
+#### Sensitivity tuning (ML thresholds only)
+This applies to any monitor that uses ML thresholds — both metric monitors and custom SQL monitors.
+If the monitor uses explicit thresholds, skip this section (for custom SQL monitors, see threshold
+adjustment in the per-type reference instead).
+
 - If anomalies are consistently marginal (observed value just barely above threshold) AND assessed
   as normal variation → recommend lowering sensitivity one step:
   - If current sensitivity is `HIGH` → recommend `"sensitivity": "medium"`
   - If current sensitivity is `MEDIUM` or `AUTO` → recommend `"sensitivity": "low"`
 - If current sensitivity is already `LOW` and still noisy → note this isn't a sensitivity issue
 
-### WHERE condition / segment exclusion
-- If one or more specific segment values fire repeatedly and are assessed as expected behavior
-  (e.g., a sparse/bursty event type, a scheduled batch event) → recommend adding a `where_condition`
-  to exclude them, e.g.:
-  ```yaml
-  where_condition: "event_type NOT IN ('inactive_monitor', 'agent_evaluation_anom')"
-  ```
-- If the segment field has very high cardinality with many sparse values → recommend
-  `"high_segment_count": true` or consider removing segmentation
-
-### Schedule / collection lag / aggregation bucket
-- If the monitor fires twice per day but anomalies always resolve within hours → recommend
+#### Schedule / interval
+- If the monitor fires multiple times per day but anomalies always resolve within hours → recommend
   increasing schedule interval (e.g., from 720 min to 1440 min) to reduce duplicate alerts
-- If the monitor aggregates by `hour` and anomalies are caused by sparse or bursty segments
-  (e.g., event types that fire only at certain hours), switching to `"aggregate_by": "day"` can
-  dramatically reduce false positives — the daily bucket smooths out intra-day spikes that are
-  normal over a 24-hour window. Trade-off: you lose hourly granularity and may detect issues later.
-  Recommend this when: anomaly values are marginal at the hour level but would be within range
-  at the daily level, OR when the segment naturally has low and variable hourly counts.
 - If anomalies are caused by data arriving late → recommend increasing `collection_lag`
 
-### Snooze / training period
+#### Snooze / training period
 - If the monitor was recently created (<30 days) and is still learning patterns → recommend
   waiting for the model to stabilize before tuning
 
-### Audience / notification routing
+#### Audience / notification routing
 - If the monitor has no audiences configured and is generating noise → recommend adding audiences
   only for high-severity anomalies, or removing notifications entirely for known-noisy monitors
 
-### Monitor restructure
-- If different segment values have fundamentally different expected behaviors → recommend splitting
-  into separate monitors with targeted WHERE conditions per segment
-- If no single where_condition can cleanly reduce noise → recommend reviewing whether the metric
-  and field combination is the right approach
+### Type-specific recommendations
+
+For type-specific recommendations (WHERE conditions, segment exclusion, aggregation changes,
+threshold adjustment, SQL modifications), follow the guidance in the per-type reference loaded
+in Phase 1.5.
 
 ---
 
@@ -142,15 +158,16 @@ Output a structured analysis. **This is the primary output — include it in ful
 ## Monitor Tune Report: {monitor_uuid}
 
 **Monitor:** {display_name or mac_name}
+**Type:** {monitor type — metric or custom SQL}
 **Table:** {table}
-**Metric:** {metric} segmented by {segment_fields}
-**Current sensitivity:** {sensitivity or "AUTO (default)"}
+**What it monitors:** {metric and segments, or SQL query summary}
+**Current sensitivity:** {sensitivity or "AUTO (default)" or "N/A (explicit thresholds)"}
 **Schedule:** every {interval_minutes / 60}h
 
 ### Alert Summary (last 30 days)
 - Total alerts: {count}
 - Firing frequency: {e.g., "~twice daily", "daily", "sporadic"}
-- Most noisy segments: {top 2-3 segment values by alert count}
+- Most noisy segments: {top 2-3 segment values by alert count, or N/A for custom SQL}
 
 ### Root Cause Pattern
 {1-3 sentence summary of what the alerts represent — operational events, bursty data, model
@@ -186,15 +203,12 @@ history further?"
 
 ## Phase 5: Apply Changes (if user requests)
 
-If the user asks to apply a recommendation, use `create_metric_monitor` to update the monitor.
-Always pass the existing `uuid` to update rather than create.
+To apply changes, follow the apply-changes instructions in the per-type reference loaded in
+Phase 1.5. Each reference specifies the correct tool and constraints for that monitor type.
 
-### Applying changes
-1. **Always dry-run first** (`dry_run=True`, the default) — show the user the preview and confirm
-   before applying.
-2. **On confirmation**, call again with `dry_run=False`.
-3. **Check the returned UUID** — if it differs from the one you passed, tell the user the old
-   monitor was replaced with a new one.
+General rules for all types:
+1. **Always preview first** — show the user what will change before applying.
+2. **Get explicit confirmation** before applying any change.
 
 ---
 

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -68,13 +68,10 @@ From the `get_monitors` config response, determine the monitor type:
 file. The reference contains type-specific config fields to extract, recommendation guidance, and
 apply-changes instructions.
 
-If the monitor type is not metric or custom SQL, tell the user:
+If the monitor type is not metric or custom SQL, stop and tell the user:
 
-> This skill currently supports tuning metric monitors and custom SQL monitors. This monitor is a
-> {type} monitor — I can still analyze its report, but I won't have type-specific tuning
-> recommendations.
-
-Then proceed with Phase 2 using only the general recommendations from this file.
+> This skill supports tuning metric monitors and custom SQL monitors. This monitor is a {type}
+> monitor, which is not supported.
 
 ---
 

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -20,6 +20,23 @@ them:
 
 ---
 
+## Prerequisites
+
+- **Required:** Monte Carlo MCP server (`monte-carlo-mcp`) must be configured and authenticated
+
+---
+
+## Available MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `get_monitor_report` | Fetch a monitor's alert history, incident details, and troubleshooting summaries |
+| `get_monitors` | Fetch monitor configuration (type, thresholds, schedule, segments) |
+| `create_metric_monitor` | Update a metric monitor's configuration (used in Phase 5) |
+| `create_custom_rule` | Update a custom SQL monitor's configuration (used in Phase 5) |
+
+---
+
 ## Phase 0: Validate Input
 
 Extract the monitor UUID from `$ARGUMENTS`. It must be a valid UUID (format:

--- a/skills/tune-monitor/references/custom-sql-monitor.md
+++ b/skills/tune-monitor/references/custom-sql-monitor.md
@@ -1,0 +1,96 @@
+# Tuning Custom SQL Monitors
+
+This reference covers type-specific tuning guidance for custom SQL monitors (custom rules).
+Read this file after determining the monitor type in Phase 1.5.
+
+## Config fields to extract
+
+Extract these from the `get_monitors` config response for your Phase 2 analysis:
+
+- SQL query text (`sql` or `custom_sql`)
+- Alert conditions — each has an `operator` and either a `thresholdValue` (explicit) or ML
+  threshold configuration
+- Warehouse name
+- Schedule interval
+
+**IMPORTANT:** Determine whether the monitor uses **ML thresholds** or **explicit thresholds**.
+This affects which tuning levers are available. ML-threshold monitors support sensitivity tuning
+(covered in Phase 3 of SKILL.md). Explicit-threshold monitors require direct threshold adjustment
+(covered below).
+
+---
+
+## Threshold adjustment (explicit thresholds)
+
+For monitors with explicit thresholds (`GT`, `LT`, `GTE`, `LTE`, `EQ`, `NE`):
+
+**When to recommend loosening a threshold:**
+- Anomalies are consistently marginal — the observed value just barely crosses the threshold
+- The margin between observed and threshold is small relative to the metric's natural variance
+- Most alerts are assessed as normal variation, not genuine issues
+
+**CRITICAL:** Always explain what the threshold value represents in business terms before
+recommending a change. The user needs to understand what "changing GT 0 to GT 5" means for their
+data quality.
+
+**Common pattern:** If the query returns a count of "bad" rows and the threshold is 0, but normal
+operations produce 1-3 rows that match the condition (e.g., stale records, delayed updates),
+recommend raising the threshold to a reasonable floor based on observed values.
+
+**Examples:**
+```yaml
+# Before: fires on any bad row
+alert_conditions:
+  - operator: GT
+    thresholdValue: 0
+
+# After: tolerates up to 5 (based on observed noise floor of 1-3)
+alert_conditions:
+  - operator: GT
+    thresholdValue: 5
+```
+
+**NEVER** recommend a threshold change without citing the observed anomaly values from the report.
+
+---
+
+## SQL query modifications
+
+When the SQL itself contributes to noise, recommend targeted modifications:
+
+**When to recommend SQL changes:**
+- The query lacks time-window filters and picks up stale data
+- Certain dimensions or categories are known-noisy and should be excluded
+- NULL handling is missing and causes spurious results
+- The query could benefit from a more targeted WHERE clause
+
+**NEVER** rewrite the full SQL without showing a diff. Present the original query and the proposed
+change side by side so the user can review exactly what changed.
+
+**IMPORTANT:** SQL syntax varies by warehouse. When suggesting modifications, match the warehouse
+dialect:
+
+| Warehouse | Date arithmetic example |
+|-----------|------------------------|
+| Snowflake | `DATEADD('day', -7, CURRENT_TIMESTAMP())` |
+| BigQuery | `TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)` |
+| Redshift | `DATEADD(day, -7, GETDATE())` |
+| Databricks | `DATE_SUB(CURRENT_TIMESTAMP(), 7)` |
+
+---
+
+## Applying changes
+
+Use `create_custom_rule` to update the monitor.
+
+1. **Always pass the existing identifier** to update rather than create a new monitor.
+2. **Always dry-run first** — show the user the preview and ask for confirmation before applying.
+3. **On confirmation**, apply the change.
+
+### Common mistakes
+
+- **NEVER** apply changes without showing the preview first.
+- **CRITICAL:** When modifying the SQL query, ensure the query still returns a single numeric
+  value. A query that returns multiple rows or non-numeric data will break the monitor.
+- **IMPORTANT:** If the monitor has multiple alert conditions, ensure all conditions are included
+  in the update — the tool replaces the full config, not individual conditions.

--- a/skills/tune-monitor/references/metric-monitor.md
+++ b/skills/tune-monitor/references/metric-monitor.md
@@ -1,0 +1,106 @@
+# Tuning Metric Monitors
+
+This reference covers type-specific tuning guidance for metric monitors. Read this file after
+determining the monitor type in Phase 1.5.
+
+## Config fields to extract
+
+Extract these from the `get_monitors` config response for your Phase 2 analysis:
+
+- Monitor metric (e.g., `RELATIVE_ROW_COUNT`, `NULL_RATE`, `NUMERIC_MEAN`)
+- Segment field(s) (`segment_fields`)
+- WHERE condition (`where_condition`)
+- Aggregation bucket (`aggregate_by`: `hour`, `day`, `week`, `month`)
+- Aggregation time field (`aggregate_time_field`)
+- Collection lag (`collection_lag_minutes`)
+
+---
+
+## Threshold adjustment (explicit thresholds)
+
+For metric monitors using explicit thresholds (`GT`, `LT`, `GTE`, `LTE`, `EQ`, `NE`) instead of
+`AUTO`:
+
+- If anomalies are consistently marginal — the observed value just barely crosses the threshold —
+  recommend loosening the threshold based on observed values from the report.
+- **CRITICAL:** Always explain what the threshold value represents in the context of the metric
+  before recommending a change. For example, "NULL_RATE GT 0.05 means alert when more than 5% of
+  values are null."
+- **NEVER** recommend a threshold change without citing observed anomaly values from the report.
+
+---
+
+## WHERE condition / segment exclusion
+
+**When to recommend a WHERE condition:**
+- One or more specific segment values fire repeatedly and are assessed as expected behavior
+  (e.g., a sparse/bursty event type, a scheduled batch event)
+- The noisy segments are identifiable from the incident history
+
+**Syntax examples:**
+```yaml
+where_condition: "event_type NOT IN ('inactive_monitor', 'agent_evaluation_anom')"
+```
+```yaml
+where_condition: "status != 'test'"
+```
+
+**IMPORTANT:** Always verify the column name and values exist in the table before recommending a
+WHERE condition. Reference specific segment values from the monitor report.
+
+**High-cardinality segments:**
+- If the segment field has very high cardinality with many sparse values → recommend
+  `"high_segment_count": true` or consider removing segmentation entirely
+- **NEVER** recommend removing segmentation without explaining what signal would be lost
+
+---
+
+## Aggregation bucket changes
+
+If the monitor aggregates by `hour` and anomalies are caused by sparse or bursty segments
+(e.g., event types that fire only at certain hours), switching to `"aggregate_by": "day"` can
+dramatically reduce false positives. The daily bucket smooths out intra-day spikes that are
+normal over a 24-hour window.
+
+**When to recommend:**
+- Anomaly values are marginal at the hour level but would be within range at the daily level
+- The segment naturally has low and variable hourly counts
+
+**Trade-off:** You lose hourly granularity and may detect issues later. Always state this.
+
+**CRITICAL:** Do not recommend changing `aggregate_by` without also checking whether the
+`interval_minutes` needs to align. Hourly aggregation requires a schedule ≥60 min; daily
+requires ≥1440 min.
+
+---
+
+## Monitor restructure
+
+Recommend splitting into separate monitors when:
+- Different segment values have fundamentally different expected behaviors (e.g., one segment
+  is bursty by design, another should be steady)
+- No single `where_condition` can cleanly separate noisy segments from signal-carrying ones
+
+Recommend reviewing whether the metric and field combination is the right approach when:
+- The monitor consistently fires on patterns that are inherent to the data shape
+- A different metric would better capture the actual data quality concern
+
+---
+
+## Applying changes
+
+Use `create_metric_monitor` to update the monitor.
+
+1. **Always pass the existing `uuid`** to update rather than create a new monitor.
+2. **Always dry-run first** (`dry_run=True`, the default) — show the user the YAML preview and
+   ask for confirmation before applying.
+3. **On confirmation**, call again with `dry_run=False`.
+4. **Check the returned UUID** — if it differs from the one you passed, tell the user the old
+   monitor was replaced with a new one.
+
+### Common mistakes
+
+- **NEVER** omit the `uuid` field — this creates a duplicate monitor instead of updating.
+- **NEVER** apply changes without showing the dry-run preview first.
+- **IMPORTANT:** When updating a single field (e.g., `where_condition`), you must still pass all
+  required parameters. The tool replaces the full config, not individual fields.


### PR DESCRIPTION
## Summary

- Refactors SKILL.md into a Tier 1 router that detects monitor type after fetching the report, then dynamically loads the appropriate per-type reference file
- Adds `references/metric-monitor.md` — threshold adjustment, WHERE/segment exclusion, aggregation bucket changes, monitor restructure, apply via `create_metric_monitor`
- Adds `references/custom-sql-monitor.md` — threshold adjustment, SQL query modifications, apply via `create_custom_rule`
- General recommendations (sensitivity for ML thresholds, schedule, snooze, audience) stay in SKILL.md since they apply to both types

Builds on #55.

## Test plan

- [ ] Test with a metric monitor UUID — verify the agent reads `references/metric-monitor.md` and produces metric-specific recommendations
- [ ] Test with a custom SQL monitor UUID — verify the agent reads `references/custom-sql-monitor.md` and produces SQL-specific recommendations
- [ ] Verify `create_custom_rule` is available in the `monte-carlo-mcp` server

🤖 Generated with [Claude Code](https://claude.com/claude-code)