### PR TITLE
docs(mon-adv): reduce create_*_monitor_mac failures from prod DD analysis

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-04-23
+
+### Changed
+
+- `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
+
 ## [1.8.1] - 2026-04-20
 
 ### Fixed

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
 
+### Fixed
+
+- `scripts/bump-version.sh` normalizes drifted plugin versions. Before this release, claude-code was at 1.8.1 while codex/copilot/cursor/opencode were stuck at 1.7.0 because the script's sed only matched the claude-code version. The non-monotonic 1.7.0 → 1.8.2 jump on those four plugins is intentional — they caught up to the canonical version in this PR. Future bumps stay in sync automatically.
+
 ## [1.8.1] - 2026-04-20
 
 ### Fixed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.7.0",
+  "version": "1.8.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-04-23
+
+### Changed
+
+- `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
 
+### Fixed
+
+- `scripts/bump-version.sh` normalizes drifted plugin versions. Before this release, claude-code was at 1.8.1 while codex/copilot/cursor/opencode were stuck at 1.7.0 because the script's sed only matched the claude-code version. The non-monotonic 1.7.0 → 1.8.2 jump on those four plugins is intentional — they caught up to the canonical version in this PR. Future bumps stay in sync automatically.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-04-23
+
+### Changed
+
+- `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
 
+### Fixed
+
+- `scripts/bump-version.sh` normalizes drifted plugin versions. Before this release, claude-code was at 1.8.1 while codex/copilot/cursor/opencode were stuck at 1.7.0 because the script's sed only matched the claude-code version. The non-monotonic 1.7.0 → 1.8.2 jump on those four plugins is intentional — they caught up to the canonical version in this PR. Future bumps stay in sync automatically.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.7.0",
+    "version": "1.8.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.7.0",
+    "version": "1.8.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-04-23
+
+### Changed
+
+- `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
 
+### Fixed
+
+- `scripts/bump-version.sh` normalizes drifted plugin versions. Before this release, claude-code was at 1.8.1 while codex/copilot/cursor/opencode were stuck at 1.7.0 because the script's sed only matched the claude-code version. The non-monotonic 1.7.0 → 1.8.2 jump on those four plugins is intentional — they caught up to the canonical version in this PR. Future bumps stay in sync automatically.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-04-23
+
+### Changed
+
+- `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `monitoring-advisor`: hardened the `create_*_monitor_mac` guidance against the top failure modes seen in production over the last 7 days (70 events across 14 categories). Changes span `data-monitor-creation.md` (domain-uuid resolution, warehouse-UUID requirement, column-verification gate, enum discipline, table existence check) and the per-type references (`alert_condition` shape constraints in `data-validation-monitor`, metric-name and operator-enum corrections in `data-metric-monitor` / `data-custom-sql-monitor`, `change`-threshold documentation in `data-custom-sql-monitor`, datetime-type requirement for `aggregate_time_field`, arg-shape constraints in `data-table-monitor` and `data-validation-monitor`, predicate/field-type semantics in `data-validation-monitor`, `threshold_value` requirement clarification in `data-comparison-monitor`). See [PR #66](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/66) for the full error → fix mapping.
 
+### Fixed
+
+- `scripts/bump-version.sh` normalizes drifted plugin versions. Before this release, claude-code was at 1.8.1 while codex/copilot/cursor/opencode were stuck at 1.7.0 because the script's sed only matched the claude-code version. The non-monotonic 1.7.0 → 1.8.2 jump on those four plugins is intentional — they caught up to the canonical version in this PR. Future bumps stay in sync automatically.
+
 ## [1.7.1] - 2026-04-17
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.7.0",
+  "version": "1.8.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -148,7 +148,9 @@ for file in "${VERSION_FILES[@]}"; do
   if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would update version in $file"
   else
-    sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" "$filepath"
+    # Replace the first "version" field regardless of its current value, so
+    # plugins that drifted out of sync get normalized to $NEW_VERSION.
+    sed -i '' -E '1,/"version"[[:space:]]*:/s|("version"[[:space:]]*:[[:space:]]*")[^"]*(")|\1'"$NEW_VERSION"'\2|' "$filepath"
     echo "Updated version in $file"
   fi
 done

--- a/skills/monitoring-advisor/references/data-comparison-monitor.md
+++ b/skills/monitoring-advisor/references/data-comparison-monitor.md
@@ -74,7 +74,7 @@ Each condition compares a metric between the source and target tables.
 | `metric` | string | Yes | The metric to compare (see Metrics Reference below). |
 | `sourceField` | string | For field-level metrics | Column in the source table. Required for ALL metrics except `ROW_COUNT`. |
 | `targetField` | string | For field-level metrics | Column in the target table. Required for ALL metrics except `ROW_COUNT`. |
-| `thresholdValue` | number | No | Threshold for acceptable difference between source and target. |
+| `thresholdValue` | number | **Required for `comparison_delta`-type conditions**; optional for `AUTO`-type anomaly detection. | Threshold for acceptable difference between source and target. Omitting it on a delta-type condition is rejected with `threshold_value is required for comparison_delta type`. |
 | `isThresholdRelative` | boolean | No | `false` = absolute difference (default), `true` = percentage difference. |
 | `customMetric` | object | No | Custom SQL expressions for source and target (see Custom Metrics below). |
 

--- a/skills/monitoring-advisor/references/data-comparison-monitor.md
+++ b/skills/monitoring-advisor/references/data-comparison-monitor.md
@@ -48,7 +48,7 @@ Before constructing alert conditions, you MUST verify that both tables exist and
 | `source_warehouse` | string | Warehouse name or UUID for the source table. Required if `source_table` is not an MCON. |
 | `target_warehouse` | string | Warehouse name or UUID for the target table. Required if `target_table` is not an MCON. |
 | `segment_fields` | array of string | Fields to segment the comparison by. Must exist in BOTH tables with the same name. |
-| `domain_id` | string (uuid) | Domain UUID (use `get_domains` to list). Only one domain can be assigned per monitor. |
+| `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
 
 ---
 
@@ -72,11 +72,23 @@ Each condition compares a metric between the source and target tables.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `metric` | string | Yes | The metric to compare (see Metrics Reference below). |
+| `type` | string | Yes (for non-AUTO thresholds) | Threshold type — one of `comparison_delta` (static threshold on source↔target diff) or `AUTO` (anomaly detection). Omitting `type` defaults to AUTO-style behavior. |
 | `sourceField` | string | For field-level metrics | Column in the source table. Required for ALL metrics except `ROW_COUNT`. |
 | `targetField` | string | For field-level metrics | Column in the target table. Required for ALL metrics except `ROW_COUNT`. |
 | `thresholdValue` | number | **Required for `comparison_delta`-type conditions**; optional for `AUTO`-type anomaly detection. | Threshold for acceptable difference between source and target. Omitting it on a delta-type condition is rejected with `threshold_value is required for comparison_delta type`. |
 | `isThresholdRelative` | boolean | No | `false` = absolute difference (default), `true` = percentage difference. |
 | `customMetric` | object | No | Custom SQL expressions for source and target (see Custom Metrics below). |
+
+### Threshold types
+
+Two threshold types are supported on comparison alert conditions:
+
+| `type` | Behavior | Required fields |
+|---|---|---|
+| `AUTO` (default when `type` is omitted) | Monte Carlo learns normal variance and alerts on anomalies. | `metric`, `sourceField` / `targetField` (unless `ROW_COUNT`) |
+| `comparison_delta` | Static threshold on the source↔target difference. | `metric`, `sourceField` / `targetField` (unless `ROW_COUNT`), `thresholdValue` |
+
+If the user wants a specific numeric tolerance (e.g. "alert if source and target row counts differ by more than 100"), use `comparison_delta` and set `thresholdValue`. If they want "alert when the difference looks unusual," use `AUTO` — no `thresholdValue` needed.
 
 ---
 
@@ -404,7 +416,7 @@ Compare both row counts and field-level metrics in a single monitor.
   "description": "Full comparison of orders between staging and production",
   "source_table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++staging:core.orders",
   "target_table": "MCON++b2c3d4e5-f6a7-8901-bcde-f12345678901++1++1++production:core.orders",
-  "domain_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "domain_uuids": ["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
   "alert_conditions": [
     {
       "metric": "ROW_COUNT",

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -47,7 +47,7 @@ If you find yourself contorting another monitor type to fit the user's intent, s
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `domain_id` | string (uuid) | Domain UUID (use `get_domains` to list). Only one domain can be assigned per monitor. |
+| `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
 
 ---
 
@@ -58,7 +58,7 @@ Each alert condition compares the query result against a threshold.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `operator` | string | Yes | One of: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`, `NOOP`. Note: the inequality operator is `NEQ` (not `NE`). |
-| `thresholdValue` | number | Yes | Numeric threshold to compare the query result against. |
+| `threshold_value` | number | Yes | Numeric threshold to compare the query result against. |
 
 ### Threshold types
 
@@ -147,7 +147,7 @@ Alert when orders reference customers that don't exist.
   "alert_conditions": [
     {
       "operator": "GT",
-      "thresholdValue": 0
+      "threshold_value": 0
     }
   ]
 }
@@ -166,7 +166,7 @@ Alert when total revenue for the past 24 hours drops below a minimum.
   "alert_conditions": [
     {
       "operator": "LT",
-      "thresholdValue": 10000
+      "threshold_value": 10000
     }
   ]
 }
@@ -185,7 +185,7 @@ Alert when the duplicate rate on a key field exceeds 1%.
   "alert_conditions": [
     {
       "operator": "GT",
-      "thresholdValue": 0.01
+      "threshold_value": 0.01
     }
   ]
 }
@@ -204,11 +204,11 @@ Alert when a value falls outside an acceptable range. Multiple conditions act as
   "alert_conditions": [
     {
       "operator": "LT",
-      "thresholdValue": 20
+      "threshold_value": 20
     },
     {
       "operator": "GT",
-      "thresholdValue": 500
+      "threshold_value": 500
     }
   ]
 }
@@ -227,7 +227,7 @@ Alert when the latest row in a downstream table is more than 2 hours behind the 
   "alert_conditions": [
     {
       "operator": "GT",
-      "thresholdValue": 120
+      "threshold_value": 120
     }
   ]
 }

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -60,9 +60,26 @@ Each alert condition compares the query result against a threshold.
 | `operator` | string | Yes | One of: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`, `NOOP`. Note: the inequality operator is `NEQ` (not `NE`). |
 | `thresholdValue` | number | Yes | Numeric threshold to compare the query result against. |
 
+### Threshold types
+
+Custom SQL monitors support two threshold types — `absolute` (default) and `change`. Each requires a different set of fields:
+
+| `type` | Behavior | Required fields (in addition to `operator`) |
+|---|---|---|
+| `absolute` (default) | Compare the query result directly against a fixed value. | `threshold_value` |
+| `change` | Compare the query result against a recent baseline (e.g. 2-day rolling MAX). | `threshold_value`, `baseline_agg_function`, `baseline_interval_minutes`, `is_threshold_relative` |
+
+**`change`-type required fields:**
+
+- `baseline_agg_function` — how to aggregate baseline samples. One of: `AVG`, `MIN`, `MAX`. Backend rejects anything else: `Must be one of: AVG, MIN, MAX.`
+- `baseline_interval_minutes` — lookback window for the baseline, in minutes. Must be between `0` and `129600` (90 days).
+- `is_threshold_relative` — `true` if `threshold_value` is a percentage (relative to baseline), `false` if it is an absolute delta. Required — the backend rejects with `is_threshold_relative is a required field. Set to True if threshold value is % else False`.
+
+Omitting any of these on a `change`-type condition produces stacked `required` / `Aggregate function is required` / `Lookback Interval in minutes should be between 0 and 129600` errors. Use snake_case for all field names here — mixing camelCase (`baselineAggFunction`) causes `Unknown field` rejections.
+
 ### Operator subsets by threshold type
 
-Not every operator is accepted for every threshold type. The **Absolute Threshold** type (used for static thresholds) only supports: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`. Using e.g. `NOOP` with an Absolute Threshold is rejected as `Absolute Threshold only supports these operators: {EQ, NEQ, LT, LTE, GT, GTE, OUTSIDE_RANGE, INSIDE_RANGE}`.
+Not every operator is accepted for every threshold type. The `absolute` threshold type only supports: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`. Using e.g. `NOOP` with an Absolute Threshold is rejected as `Absolute Threshold only supports these operators: {EQ, NEQ, LT, LTE, GT, GTE, OUTSIDE_RANGE, INSIDE_RANGE}`.
 
 ### No AUTO Support
 

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -57,12 +57,16 @@ Each alert condition compares the query result against a threshold.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `operator` | string | Yes | `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NE"` |
+| `operator` | string | Yes | One of: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`, `NOOP`. Note: the inequality operator is `NEQ` (not `NE`). |
 | `thresholdValue` | number | Yes | Numeric threshold to compare the query result against. |
+
+### Operator subsets by threshold type
+
+Not every operator is accepted for every threshold type. The **Absolute Threshold** type (used for static thresholds) only supports: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`. Using e.g. `NOOP` with an Absolute Threshold is rejected as `Absolute Threshold only supports these operators: {EQ, NEQ, LT, LTE, GT, GTE, OUTSIDE_RANGE, INSIDE_RANGE}`.
 
 ### No AUTO Support
 
-Custom SQL monitors do **NOT** support `AUTO` (anomaly detection). You must specify an explicit operator and threshold for every alert condition. This is a common mistake -- if the user asks for anomaly detection, steer them toward a metric monitor instead, which does support `AUTO`.
+Custom SQL monitors do **NOT** support `AUTO` / `AUTO_HIGH` / `AUTO_LOW` (anomaly detection). You must specify an explicit operator and threshold for every alert condition. This is a common mistake -- if the user asks for anomaly detection, steer them toward a metric monitor instead, which does support `AUTO`.
 
 If the user is unsure what threshold to set, help them reason about it: "What value would indicate a problem? If the query returns X, should that fire an alert?"
 

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -74,14 +74,15 @@ When omitted, the monitor queries all rows on each run. This works well for smal
 
 ### How to pick it
 
-1. You should already have the column names from `get_table` with `include_fields: true` (done in Step 2 of the main skill).
+1. You should already have the column names **and their data types** from `get_table` with `include_fields: true` (done in Step 2 of the main skill).
 2. Look for columns whose names suggest a timestamp: `created_at`, `updated_at`, `modified_at`, `timestamp`, `event_timestamp`, or columns with `_ts`, `_dt`, `_time` suffixes, or `date`, `datetime`.
-3. If the user specified one, verify it exists in the column list.
-4. If exactly one obvious candidate exists, suggest it.
-5. If multiple candidates exist, present them and ask the user.
-6. If NO obvious timestamp columns exist, omit the field — the monitor will do a whole-table scan. For very large tables, consider whether a custom SQL monitor would be more efficient.
+3. **Verify the column's data type is an actual datetime/timestamp/date type** — not a string, number, or other type that happens to have a timestampy name. The backend rejects non-datetime types with `Field <name> is not a valid type to group the metrics by; it cannot be interpreted as a datetime.`
+4. If the user specified one, verify it exists in the column list AND has a datetime type.
+5. If exactly one obvious candidate exists (correct type), suggest it.
+6. If multiple candidates exist, present them and ask the user.
+7. If NO datetime-typed columns exist, omit the field — the monitor will do a whole-table scan. For very large tables, consider whether a custom SQL monitor would be more efficient.
 
-**NEVER** guess a timestamp field name — either confirm it exists in the schema or omit it.
+**NEVER** guess a timestamp field name, and never pick a column based on its name alone — always confirm the datatype from `get_table`, or omit the field.
 
 ### Common timestamp field mistakes
 

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -135,8 +135,8 @@ Each alert condition has:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `metric` | string | Yes | The metric to monitor (see Metrics Reference below). |
-| `operator` | string | Yes | `"AUTO"` (anomaly detection), `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NE"`. |
-| `threshold` | number | For explicit operators | The threshold value. Required when using `GT`, `LT`, `EQ`, `GTE`, `LTE`, or `NE`. Not used with `AUTO`. |
+| `operator` | string | Yes | `"AUTO"` (anomaly detection), `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NEQ"`. Note: the inequality operator is `NEQ`, not `NE`. |
+| `threshold` | number | For explicit operators | The threshold value. Required when using `GT`, `LT`, `EQ`, `GTE`, `LTE`, or `NEQ`. Not used with `AUTO`. |
 | `fields` | array of string | Depends | Column names to apply the metric to. Required for field-level metrics. Not needed for table-level metrics. |
 
 ---

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -111,6 +111,21 @@ When omitted, the monitor queries all rows on each run. This works well for smal
 - **NEVER** apply `FUTURE_TIMESTAMP_COUNT`, `PAST_TIMESTAMP_COUNT`, or `UNIX_ZERO_TIMESTAMP_COUNT` to non-timestamp columns.
 - When in doubt, `NULL_COUNT`, `NULL_RATE`, `UNIQUE_COUNT`, and `UNIQUE_RATE` are safe for any column type.
 
+### Common metric-name mistakes
+
+The `NUMERIC_*` prefix pattern covers mean/median/min/max/stddev but **not** sum: the metric is `SUM`, not `NUMERIC_SUM`. Backend rejects with `Invalid metric: NUMERIC_SUM`.
+
+Other names agents guess-and-get-wrong:
+
+| Guessed (wrong) | Use instead |
+|---|---|
+| `NUMERIC_SUM` | `SUM` |
+| `APPROX_DISTINCT_COUNT`, `COUNT_DISTINCT` | `UNIQUE_COUNT` |
+| `COUNT_NULL`, `NULLS` | `NULL_COUNT` |
+| `ROW_COUNT` (as a column metric) | `ROW_COUNT_CHANGE` (table-level only) |
+
+If the metric you want isn't in the compatibility matrix above, it doesn't exist — use the closest alternative or fall back to a custom SQL monitor.
+
 ---
 
 ## Alert Conditions

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -40,7 +40,7 @@ Use a metric monitor when the user wants to:
 | `aggregate_by` | string | `"day"` | Time interval: `"hour"`, `"day"`, `"week"`, `"month"`. |
 | `where_condition` | string | none | SQL WHERE clause (without `WHERE` keyword) to filter rows before computing metrics. |
 | `interval_minutes` | int | auto | Schedule interval in minutes. Must be compatible with `aggregate_by` (see note below). If not specified, the tool defaults to the minimum valid interval for the chosen `aggregate_by`. |
-| `domain_id` | string (uuid) | none | Domain UUID (use `get_domains` to list). |
+| `domain_uuids` | array of string (uuid) | none | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
 
 ---
 
@@ -150,7 +150,7 @@ Each alert condition has:
 - Works well for organic metrics that vary day-to-day (row counts, null rates on evolving data, numeric distributions).
 - Some metrics **require** `AUTO` -- see the table below.
 
-### When to use explicit thresholds (`GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE`)
+### When to use explicit thresholds (`GT`, `LT`, `EQ`, `GTE`, `LTE`, `NEQ`)
 
 - Use when there is a known business rule or data contract (e.g., "null rate on `email` should never exceed 5%", "order amount must always be greater than 0").
 - Provides deterministic alerting -- no training period needed, alerts fire immediately when the condition is met.
@@ -163,7 +163,7 @@ Each alert condition has:
 | `ROW_COUNT_CHANGE` | `AUTO` only | Anomaly detection on row count delta. |
 | `TIME_SINCE_LAST_ROW_COUNT_CHANGE` | `AUTO` only | Anomaly detection on staleness duration. |
 | `RELATIVE_ROW_COUNT` | `AUTO` only | Anomaly detection on segment distribution. Requires `segment_fields`. |
-| All other metrics | `AUTO`, `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE` | Any operator is valid. |
+| All other metrics | `AUTO`, `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NEQ` | Any operator is valid. |
 
 ---
 
@@ -306,7 +306,7 @@ Each alert condition has:
   "table": "MCON++a1b2c3d4-e5f6-7890-abcd-ef1234567890++1++1++warehouse:billing.payments",
   "aggregate_time_field": "processed_at",
   "aggregate_by": "day",
-  "domain_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "domain_uuids": ["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
   "alert_conditions": [
     {
       "metric": "NUMERIC_MEAN",

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -31,6 +31,14 @@ If you already have the MCON:
 
 **CRITICAL: You need the actual column names from `get_table` results. NEVER guess or hallucinate column names.** This is the most common source of monitor creation failures.
 
+**Pre-call column-verification gate (run this immediately before calling any creation tool):**
+
+1. List every column name you intend to put in the tool arguments — across every slot: `fields`, `segment_fields`, `aggregate_time_field`, BINARY `left`/`right` FIELD references, comparison `source_field`/`target_field`, and any per-type slot listed in the Tier-3 reference.
+2. For each name, confirm it appears verbatim in the `get_table.fields` list you fetched in this step. Names are case-sensitive on most warehouses (Snowflake often returns uppercase column names — match exactly).
+3. If any name is missing, STOP. Do not call the creation tool. Ask the user to confirm the correct column name, or suggest the closest matches from the actual column list — do NOT substitute a similar-sounding name on your own.
+
+If you reached this step without calling `get_table` (or equivalent) for the target table, go back — you cannot skip the fetch.
+
 For monitor types that require a timestamp column (metric monitors), review the column names and identify likely timestamp candidates. Present them to the user if ambiguous.
 
 **CRITICAL: The `warehouse` parameter on creation tools is a UUID, not a name.** Extract it from the `get_table` response (the resource / warehouse UUID). If you only have a warehouse name and no MCON, call `get_warehouses` to resolve it -- NEVER pass a warehouse name string like `databricks-aws-agent` or `snowflake-prod`, the backend will reject with `Warehouse not found`.

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -29,6 +29,8 @@ If you don't have the table MCON:
 If you already have the MCON:
 1. Call `get_table` with the MCON, `include_fields: true`, and `include_table_capabilities: true`.
 
+**If `search` returns zero results, or `get_table` shows the table is not ingested:** STOP. The table must already exist in Monte Carlo before a monitor can be created against it. Ask the user to confirm the correct table name, or to ingest the table first — do not call the creation tool with an unverified table.
+
 **CRITICAL: You need the actual column names from `get_table` results. NEVER guess or hallucinate column names.** This is the most common source of monitor creation failures.
 
 **Pre-call column-verification gate (run this immediately before calling any creation tool):**

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -35,15 +35,17 @@ For monitor types that require a timestamp column (metric monitors), review the 
 
 ### Step 3: Handle domain assignment
 
-**ALWAYS check the table's `domains` BEFORE calling any creation tool.**
+**ALWAYS resolve a `domain_uuids` value BEFORE calling any creation tool.** Missing or empty domain assignment is one of the top failure modes — the backend will reject the monitor with `Domain assignment is required for this monitor. Please provide one and only one valid domain UUID.`
 
-Monitors must be assigned to a domain that contains the table being monitored. The `get_table` response includes a `domains` list with `uuid` and `name`.
+The tool field is `domain_uuids` (a list). For data monitors, provide exactly one UUID.
 
-1. If `domains` is empty: skip domain assignment.
-2. If `domains` has exactly one entry: default `domain_id` to that domain's UUID.
-3. If `domains` has multiple entries: present only those domains and ask the user to pick.
+Use the `domains` list on the `get_table` response (each entry has `uuid` and `name`):
 
-Do NOT present all account domains as options -- only domains that contain the table are valid.
+1. If the table's `domains` has exactly one entry: default `domain_uuids` to `[<that uuid>]`.
+2. If the table's `domains` has multiple entries: present only those domains and ask the user to pick.
+3. If the table's `domains` is empty: call `get_domains` to see the account's domains. If the account has one or more, ask the user to pick one (do not invent a selection) -- note that domains that don't contain the table may still be rejected on apply. If `get_domains` returns zero domains, only then may `domain_uuids` be omitted.
+
+Do NOT present all account domains as options when the table already has domains listed -- prefer domains that contain the table.
 
 ---
 

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -77,6 +77,15 @@ Based on the monitor type, read the detailed reference for parameter guidance:
 
 All reference files are in the same directory as this file.
 
+**CRITICAL: Enum values come from the per-type reference. Never invent them by analogy.** The tool call will be rejected if you pass an enum value that isn't in the backend's accepted set. This applies to every enum-shaped parameter:
+
+- `metric` (metric monitor, comparison monitor) — the per-type file lists the valid names; guessing by pattern fails (e.g. `NUMERIC_SUM` looks plausible but the real name is `SUM`; `APPROX_DISTINCT_COUNT` and `COUNT_DISTINCT` aren't valid — use `UNIQUE_COUNT`).
+- `operator` (metric, custom_sql, comparison) — stick to the list in the per-type reference; subsets apply per threshold type (e.g. Absolute Threshold in custom_sql supports fewer operators than the full set).
+- predicate `name` (validation monitor) — confirm with `get_validation_predicates` before using anything beyond the common ones; guessing predicates like `match_pattern` or `regex_match` without confirming fails with `Predicate '<name>' not supported`.
+- `schedule.type`, `aggregate_by`, `threshold type` — lowercase/uppercase and exact spelling matter; don't approximate.
+
+If you're unsure whether an enum value is valid, ask the user or fall back to the safest documented value (`AUTO` for operator, `UNIQUE_COUNT` / `NULL_COUNT` for metric, etc.) — never guess.
+
 ### Step 5: Ask about scheduling
 
 **Skip this step for table monitors.** Table monitors do not support the `schedule` field in MaC YAML -- adding it will cause a validation error on `montecarlo monitors apply`. Table monitor scheduling is managed automatically by Monte Carlo.

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -33,6 +33,8 @@ If you already have the MCON:
 
 For monitor types that require a timestamp column (metric monitors), review the column names and identify likely timestamp candidates. Present them to the user if ambiguous.
 
+**CRITICAL: The `warehouse` parameter on creation tools is a UUID, not a name.** Extract it from the `get_table` response (the resource / warehouse UUID). If you only have a warehouse name and no MCON, call `get_warehouses` to resolve it -- NEVER pass a warehouse name string like `databricks-aws-agent` or `snowflake-prod`, the backend will reject with `Warehouse not found`.
+
 ### Step 3: Handle domain assignment
 
 **ALWAYS resolve a `domain_uuids` value BEFORE calling any creation tool.** Missing or empty domain assignment is one of the top failure modes — the backend will reject the monitor with `Domain assignment is required for this monitor. Please provide one and only one valid domain UUID.`
@@ -169,6 +171,7 @@ All tools are available via the `monte-carlo` MCP server.
 | `get_table`                     | Schema, stats, metadata, domain membership, capabilities     |
 | `get_validation_predicates`     | List available validation rule types for a warehouse         |
 | `get_domains`                   | List MC domains (only needed if table has no domain info)    |
+| `get_warehouses`                | Resolve warehouse UUIDs from names; needed when a name is the only identifier |
 | `create_metric_monitor_mac`     | Generate metric monitor YAML (dry-run)                       |
 | `create_validation_monitor_mac` | Generate validation monitor YAML (dry-run)                   |
 | `create_comparison_monitor_mac` | Generate comparison monitor YAML (dry-run)                   |

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -35,7 +35,7 @@ If you already have the MCON:
 
 **Pre-call column-verification gate (run this immediately before calling any creation tool):**
 
-1. List every column name you intend to put in the tool arguments — across every slot: `fields`, `segment_fields`, `aggregate_time_field`, BINARY `left`/`right` FIELD references, comparison `source_field`/`target_field`, and any per-type slot listed in the Tier-3 reference.
+1. List every column name you plan to put in the tool arguments, in every slot the per-type reference describes (see the Tier-3 file for the authoritative list of column-bearing parameters).
 2. For each name, confirm it appears verbatim in the `get_table.fields` list you fetched in this step. Names are case-sensitive on most warehouses (Snowflake often returns uppercase column names — match exactly).
 3. If any name is missing, STOP. Do not call the creation tool. Ask the user to confirm the correct column name, or suggest the closest matches from the actual column list — do NOT substitute a similar-sounding name on your own.
 
@@ -79,14 +79,7 @@ Based on the monitor type, read the detailed reference for parameter guidance:
 
 All reference files are in the same directory as this file.
 
-**CRITICAL: Enum values come from the per-type reference. Never invent them by analogy.** The tool call will be rejected if you pass an enum value that isn't in the backend's accepted set. This applies to every enum-shaped parameter:
-
-- `metric` (metric monitor, comparison monitor) — the per-type file lists the valid names; guessing by pattern fails (e.g. `NUMERIC_SUM` looks plausible but the real name is `SUM`; `APPROX_DISTINCT_COUNT` and `COUNT_DISTINCT` aren't valid — use `UNIQUE_COUNT`).
-- `operator` (metric, custom_sql, comparison) — stick to the list in the per-type reference; subsets apply per threshold type (e.g. Absolute Threshold in custom_sql supports fewer operators than the full set).
-- predicate `name` (validation monitor) — confirm with `get_validation_predicates` before using anything beyond the common ones; guessing predicates like `match_pattern` or `regex_match` without confirming fails with `Predicate '<name>' not supported`.
-- `schedule.type`, `aggregate_by`, `threshold type` — lowercase/uppercase and exact spelling matter; don't approximate.
-
-If you're unsure whether an enum value is valid, ask the user or fall back to the safest documented value (`AUTO` for operator, `UNIQUE_COUNT` / `NULL_COUNT` for metric, etc.) — never guess.
+**CRITICAL: Every enum value comes from the per-type reference.** `metric`, `operator`, predicate `name`, `schedule.type`, `aggregate_by`, and any other enum-shaped parameter must match the exact strings documented in the Tier-3 file for this monitor type. Never invent values by analogy or adjust casing — the backend rejects anything outside the documented set. Subsets apply per threshold type (e.g. custom_sql Absolute Threshold allows fewer operators than the full list); the per-type file spells those out too. If you're unsure, ask the user rather than guessing.
 
 ### Step 5: Ask about scheduling
 

--- a/skills/monitoring-advisor/references/data-table-monitor.md
+++ b/skills/monitoring-advisor/references/data-table-monitor.md
@@ -5,6 +5,7 @@ Detailed reference for building `create_table_monitor_mac` tool calls.
 ## Critical Constraints
 
 - **NEVER guess column names.** Always verify table and schema names from `get_table` or `search` before building the asset selection.
+- **`alert_conditions` is a flat list of strings** — metric names like `"last_updated_on"`, `"schema"`, `"total_row_count"`. NEVER pass dicts like `{"metric": "last_updated_on", "operator": "AUTO"}`. That shape is rejected with `Input should be a valid string [type=string_type, input_value={'metric': '...', 'operator': 'AUTO'}]`. Table monitors do not take per-condition operators — they use anomaly detection on the named metrics by default.
 
 ---
 

--- a/skills/monitoring-advisor/references/data-table-monitor.md
+++ b/skills/monitoring-advisor/references/data-table-monitor.md
@@ -41,7 +41,7 @@ Use a table monitor when the user wants to:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `alert_conditions` | array of strings | `["last_updated_on", "schema", "total_row_count", "total_row_count_last_changed_on"]` | Metric names to monitor (see Alert Conditions below). |
-| `domain_id` | string (uuid) | none | Domain UUID (use `get_domains` to list). |
+| `domain_uuids` | array of string (uuid) | none | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -66,7 +66,7 @@ Before constructing the `alert_condition`, verify that every field name you plan
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `warehouse` | string | Warehouse name or UUID. Required if `table` is not an MCON. |
-| `domain_id` | string (uuid) | Domain UUID (use `get_domains` to list). |
+| `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -9,6 +9,7 @@ Detailed reference for building `create_validation_monitor_mac` tool calls.
 - **NEVER put a SELECT statement in a condition-level `SQL` node.** `{"type": "SQL", "sql": "..."}` as a top-level condition must be a boolean predicate expression (e.g. `amount < 0 OR amount > 1e9`), not a full query. Backend error: `Invalid SQL expression. Please provide a direct expression; it shouldn't begin with SELECT.`
 - **NEVER use an aggregate or SQL expression in a `FIELD` value.** `{"type": "FIELD", "field": "COUNT(*)"}` is rejected as `Field "COUNT(*)" doesn't exist`. Fields are column names only — use `get_table` to list valid ones. For counts/aggregates, fall back to a custom SQL monitor.
 - **NEVER put a `SQL` value on the LEFT side of a BINARY condition.** Only `FIELD` references are allowed on the left. A `SQL` value is valid only on the right side (typically as a scalar subquery). Backend error: `Filter left side value must be a field or map key: FilterValueSql(...)`.
+- **`alert_condition` is a dict (JSON object), NEVER a JSON-encoded string.** Pass the condition tree as a structured object — `{"type": "GROUP", "operator": "AND", "conditions": [...]}`. Serializing it to a string first is rejected with `Input should be a valid dictionary [type=dict_type, input_value='{"conditions":[...]'...]`.
 
 ---
 

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -196,6 +196,13 @@ Any predicate can be inverted by setting `"negated": true` in the predicate obje
 - **"status must be in [active, pending]"** becomes `in_set` with values `["active", "pending"]` and `negated: true` -- meaning "alert when status is NOT in [active, pending]".
 - **"id must not be null"** becomes `null` with `negated: false` -- meaning "alert when id IS null" (no inversion needed since the condition already matches invalid data).
 
+### Semantic gotchas
+
+Two constraints the backend enforces that don't show up in the predicate list:
+
+- **Predicate/field-type compatibility.** Predicates have a target data type. `is_not_a_number` (NaN detection), `is_negative`, `is_between_0_and_1`, `numeric_*` — these only work on numeric columns; the backend rejects them on string/text fields with messages like `'not a number (NaN)' does not support fields of type 'string'`. Same pattern for `is_future_date` on non-timestamp columns. Use `get_validation_predicates` to confirm a predicate is supported for the target column type, and check the column's type from `get_table` before picking one.
+- **Field references on the RIGHT side of a BINARY.** The right-hand side is usually a `LITERAL` or `SQL` (subquery). You can put a `FIELD` reference on the right **only** when the left field is a date/timestamp column, OR when the operator is `in_set` (`in`). Other combinations are rejected with `Fields are only allowed on the right side for date and timestamp fields, or when using the 'in' operator`.
+
 ---
 
 ## Examples

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -6,6 +6,9 @@ Detailed reference for building `create_validation_monitor_mac` tool calls.
 
 - **NEVER guess column names.** Always get them from `get_table`. Every field referenced in a validation condition must exist in the table schema exactly as spelled.
 - **IMPORTANT: Conditions match INVALID data, not valid data.** The monitor alerts when it finds rows matching the condition, so the condition must describe the BAD rows. Getting this backwards is the number one mistake with validation monitors.
+- **NEVER put a SELECT statement in a condition-level `SQL` node.** `{"type": "SQL", "sql": "..."}` as a top-level condition must be a boolean predicate expression (e.g. `amount < 0 OR amount > 1e9`), not a full query. Backend error: `Invalid SQL expression. Please provide a direct expression; it shouldn't begin with SELECT.`
+- **NEVER use an aggregate or SQL expression in a `FIELD` value.** `{"type": "FIELD", "field": "COUNT(*)"}` is rejected as `Field "COUNT(*)" doesn't exist`. Fields are column names only — use `get_table` to list valid ones. For counts/aggregates, fall back to a custom SQL monitor.
+- **NEVER put a `SQL` value on the LEFT side of a BINARY condition.** Only `FIELD` references are allowed on the left. A `SQL` value is valid only on the right side (typically as a scalar subquery). Backend error: `Filter left side value must be a field or map key: FilterValueSql(...)`.
 
 ---
 
@@ -149,9 +152,9 @@ Value descriptors appear in the `value`, `left`, and `right` arrays of UNARY and
 
 | Type | Field | Description | Example |
 |------|-------|-------------|---------|
-| `FIELD` | `"field": "column_name"` | References a column in the table. | `{"type": "FIELD", "field": "user_id"}` |
+| `FIELD` | `"field": "column_name"` | References a column in the table. Must be a plain column name — never an aggregate like `COUNT(*)` or a SQL snippet. | `{"type": "FIELD", "field": "user_id"}` |
 | `LITERAL` | `"literal": "value"` | A static value (always a string, even for numbers). | `{"type": "LITERAL", "literal": "100"}` |
-| `SQL` | `"sql": "SELECT ..."` | A SQL expression or subquery. | `{"type": "SQL", "sql": "SELECT MAX(id) FROM ref_table"}` |
+| `SQL` | `"sql": "..."` | A scalar SQL expression or subquery. **Right-side only** — cannot appear on the `left` of a BINARY. Valid forms: a scalar subquery (`SELECT MAX(id) FROM ref_table`) or a scalar expression. | `{"type": "SQL", "sql": "SELECT MAX(id) FROM ref_table"}` |
 
 ---
 


### PR DESCRIPTION
## Summary

Improves the `monitoring-advisor` skill so AI agents produce fewer invalid `create_*_monitor_mac` tool calls. Based on 70 prod `mcp_request_failed` events over 7 days (2026-04-14 → 2026-04-21) from the [mcp-server dashboard](https://app.datadoghq.com/dashboard/745-xaa-tsf/mcp-server-dashboard).

No backend, MCP-server, or feature changes — all edits are to `skills/monitoring-advisor/references/*.md`.

## Error → fix map

| Error (example) | Monitor types | Fix |
|---|---|---|
| `Domain assignment is required for this monitor. Please provide one and only one valid domain UUID.` | all MaC tools | Step 3 always resolves `domain_uuids`; falls back to `get_domains` when the table has none ([7de7775](../../commit/7de7775)) |
| `Warehouse not found` | all MaC tools | Step 2 CRITICAL: `warehouse` is a UUID, not a name; resolve via `get_warehouses` ([433294a](../../commit/433294a)) |
| `Invalid SQL expression... shouldn't begin with SELECT` / `Field 'COUNT(*)' doesn't exist` / `Filter left side... FilterValueSql(...)` | validation | 3 Critical Constraints on `alert_condition`: condition-SQL is a predicate expression; FIELD is a column name; SQL value is right-side only ([00d04b8](../../commit/00d04b8)) |
| `Field <x> doesn't exist` in `fields` / `segment_fields` / BINARY | metric, validation, comparison, custom_sql | Pre-call column-verification gate enumerates every slot and requires matching against `get_table.fields` ([5455faf](../../commit/5455faf)) |
| Any enum rejection (`metric`, `operator`, predicate, `scheduleType`, `aggregate_by`) | all | Shared enum-discipline CRITICAL in Step 4 — never invent enum values by analogy ([690d39c](../../commit/690d39c)) |
| `Invalid metric: NUMERIC_SUM` | metric, comparison | Common metric-name mistakes table (`NUMERIC_SUM → SUM`, `COUNT_DISTINCT → UNIQUE_COUNT`, etc.) ([ec18252](../../commit/ec18252)) |
| `Must be one of: AUTO, AUTO_HIGH, ..., NEQ, ..., NOOP` / `Absolute Threshold only supports {...}` | custom_sql, metric | Fixed `NE → NEQ`, added `OUTSIDE_RANGE` / `INSIDE_RANGE` / `NOOP`; new "Operator subsets by threshold type" subsection ([3154936](../../commit/3154936)) |
| `baseline_agg_function: Must be one of: AVG, MIN, MAX` / `baseline_agg_function: Unknown field` | custom_sql | New "Threshold types" subsection documenting `absolute` vs `change` + required fields for `change` in snake_case ([61cddab](../../commit/61cddab)) |
| `threshold_value is required for comparison_delta type` | comparison | `thresholdValue` row in Alert Conditions table marked required-for-delta with exact error quote ([aa1bd02](../../commit/aa1bd02)) |
| `Table '<qualified>' does not exist...` | all MaC tools | Step 2 STOP instruction if `search` returns zero or `get_table` shows not-ingested ([8850266](../../commit/8850266)) |
| `Field <x> is not a valid type to group the metrics by; it cannot be interpreted as a datetime.` | metric | `aggregate_time_field` selection now requires verifying datetime type, not just name ([d57e426](../../commit/d57e426)) |
| `Input should be a valid string [input_value={'metric': ..., 'operator': ...}]` | table | NEVER pass dicts into `alert_conditions` — flat list of metric-name strings only ([83b92d0](../../commit/83b92d0)) |
| `Input should be a valid dictionary [input_value='{"conditions":[...]'...]` | validation | NEVER JSON-stringify `alert_condition` — pass the structured dict ([e313bf5](../../commit/e313bf5)) |
| `Fields are only allowed on the right side for date and timestamp fields, or when using the 'in' operator` / `'not a number (NaN)' does not support fields of type 'string'` | validation | New "Semantic gotchas" subsection covering predicate/field-type compatibility + right-side-FIELD rules ([a96a40d](../../commit/a96a40d)) |

## Out of scope / follow-ups

- **MCP server bug:** `'coroutine' object has no attribute 'get'` — 6 prod events across all tools. Not skill-fixable. Needs a separate ticket.
- **Local MCP-server schema drift:** 190 dev events rejecting `domainUuids: Unknown field`. Either stale local MCP server or a camelCase→snake_case translation gap. Separate ticket.
- **Smoke-test bugs:** dev-only clusters (`threshold_value required for comparison_delta`, `TABLE_OR_VIEW_NOT_FOUND smoke_tests.fmm_testing_table`) — file against the mc-chat-agent smoke suite.
- **Transport/auth:** 18 events of 502/503 to dev backend. Infra, not skill.

## Verification

No automated eval cases exist for `create_*_monitor_mac` yet (existing `monitoring-advisor` live-evals cover discovery only). Verification plan:

- [ ] Human spot-check of each changed reference file for readability and tier discipline.
- [ ] 7-day and 30-day post-merge re-run of the DataDog query from \`.work/monitor-creator-error-analysis/queries.md\`; per-category deltas recorded back in \`analysis.md\`.
- [ ] Consider adding one live-eval case per top-5 category in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)