### PR TITLE
feat(tune-monitor): add validation monitor support

### DIFF
--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune-monitor
-description: Analyze a Monte Carlo monitor and recommend configuration changes to reduce alert noise. Supports metric monitors and custom SQL monitors. Fetches the report, identifies patterns, and suggests tuning.
+description: Analyze a Monte Carlo monitor and recommend configuration changes to reduce alert noise. Supports metric, custom SQL, and validation monitors. Fetches the report, identifies patterns, and suggests tuning.
 version: 1.0.0
 ---
 
@@ -17,6 +17,7 @@ them:
 
 - Metric monitor tuning: `references/metric-monitor.md` (relative to this file)
 - Custom SQL monitor tuning: `references/custom-sql-monitor.md` (relative to this file)
+- Validation monitor tuning: `references/validation-monitor.md` (relative to this file)
 
 ---
 
@@ -34,6 +35,7 @@ them:
 | `get_monitors` | Fetch monitor configuration (type, thresholds, schedule, segments) |
 | `create_metric_monitor` | Update a metric monitor's configuration (used in Phase 5) |
 | `create_custom_sql_monitor` | Update a custom SQL monitor's configuration (used in Phase 5) |
+| `create_validation_monitor` | Update a validation monitor's configuration (used in Phase 5) |
 
 ---
 
@@ -80,15 +82,16 @@ From the `get_monitors` config response, determine the monitor type:
 |---|---|---|
 | Monitor type is a metric monitor variant (e.g., metric, field health) | Metric | `references/metric-monitor.md` |
 | Monitor type is a custom SQL rule / custom monitor | Custom SQL | `references/custom-sql-monitor.md` |
+| Monitor type is a validation rule / validation monitor | Validation | `references/validation-monitor.md` |
 
 **Read** the appropriate reference file using the Read tool with the path relative to this skill
 file. The reference contains type-specific config fields to extract, recommendation guidance, and
 apply-changes instructions.
 
-If the monitor type is not metric or custom SQL, stop and tell the user:
+If the monitor type is not metric, custom SQL, or validation, stop and tell the user:
 
-> This skill supports tuning metric monitors and custom SQL monitors. This monitor is a {type}
-> monitor, which is not supported.
+> This skill supports tuning metric monitors, custom SQL monitors, and validation monitors.
+> This monitor is a {type} monitor, which is not supported.
 
 ---
 
@@ -106,6 +109,7 @@ Analyze the monitor report and config together. Focus on:
 - Are anomalies consistently marginal (just above threshold) or severe?
 - Are any anomalies from sparse/bursty event types that naturally spike?
 - Are anomalies caused by known operational events (deployments, batch jobs, bulk user actions)?
+- For validation monitors: how many invalid rows per incident? Is the count stable or growing?
 
 ### 2c. Current configuration
 Extract the current configuration. The specific fields to look for are documented in the per-type
@@ -134,8 +138,9 @@ Based on the analysis, produce a prioritized list of recommendations. For each r
 
 #### Sensitivity tuning (ML thresholds only)
 This applies to any monitor that uses ML thresholds — both metric monitors and custom SQL monitors.
-If the monitor uses explicit thresholds, skip this section (for custom SQL monitors, see threshold
-adjustment in the per-type reference instead).
+Skip this section for validation monitors (they don't use ML thresholds) and for monitors with
+explicit thresholds (for custom SQL monitors, see threshold adjustment in the per-type reference
+instead).
 
 - If anomalies are consistently marginal (observed value just barely above threshold) AND assessed
   as normal variation → recommend lowering sensitivity one step:
@@ -159,8 +164,8 @@ adjustment in the per-type reference instead).
 ### Type-specific recommendations
 
 For type-specific recommendations (WHERE conditions, segment exclusion, aggregation changes,
-threshold adjustment, SQL modifications), follow the guidance in the per-type reference loaded
-in Phase 1.5.
+threshold adjustment, SQL modifications, alert condition modifications), follow the guidance in
+the per-type reference loaded in Phase 1.5.
 
 ---
 
@@ -172,16 +177,16 @@ Output a structured analysis. **This is the primary output — include it in ful
 ## Monitor Tune Report: {monitor_uuid}
 
 **Monitor:** {display_name or mac_name}
-**Type:** {monitor type — metric or custom SQL}
+**Type:** {monitor type — metric, custom SQL, or validation}
 **Table:** {table}
-**What it monitors:** {metric and segments, or SQL query summary}
+**What it monitors:** {metric and segments, SQL query summary, or validation condition summary}
 **Current sensitivity:** {sensitivity or "AUTO (default)" or "N/A (explicit thresholds)"}
 **Schedule:** every {interval_minutes / 60}h
 
 ### Alert Summary (last 30 days)
 - Total alerts: {count}
 - Firing frequency: {e.g., "~twice daily", "daily", "sporadic"}
-- Most noisy segments: {top 2-3 segment values by alert count, or N/A for custom SQL}
+- Most noisy segments: {top 2-3 segment values by alert count, or N/A for custom SQL and validation}
 
 ### Root Cause Pattern
 {1-3 sentence summary of what the alerts represent — operational events, bursty data, model

--- a/skills/tune-monitor/references/validation-monitor.md
+++ b/skills/tune-monitor/references/validation-monitor.md
@@ -1,0 +1,114 @@
+# Tuning Validation Monitors
+
+This reference covers type-specific tuning guidance for validation monitors. Read this file after
+determining the monitor type in Phase 1.5.
+
+## Config fields to extract
+
+Extract these from the `get_monitors` config response for your Phase 2 analysis:
+
+- Alert condition tree (`alert_condition`) — a FilterGroup with UNARY, BINARY, SQL, and/or
+  nested GROUP nodes
+- Table being validated
+- Schedule interval
+- Whether conditions use simple predicates or SQL expressions
+
+---
+
+## Key constraint: limited incident detail
+
+Validation incidents only report **invalid row counts** — not what the rows contained. This
+fundamentally limits what you can recommend without troubleshooting analysis (TSA).
+
+**Without TSA:** You cannot determine _why_ rows are invalid or whether the alert condition
+itself is too broad. Only schedule changes are safe to recommend.
+
+**With TSA:** If troubleshooting analysis identifies specific values, patterns, or root causes
+for the invalid rows, you can recommend alert condition modifications.
+
+---
+
+## Schedule tuning (always safe)
+
+- If the monitor fires repeatedly for the same underlying issue (e.g., the same batch of invalid
+  rows detected on every run) → increase the schedule interval to reduce duplicate alerts.
+- If invalid rows appear only after specific ETL jobs → align the schedule to run after those
+  jobs complete.
+
+---
+
+## Alert condition modifications (requires troubleshooting analysis)
+
+**IMPORTANT:** Do NOT recommend alert condition changes unless TSA is present and identifies the
+root cause of the invalid rows. Without knowing _what_ the invalid data looks like, condition
+changes risk masking real issues.
+
+The alert condition is a FilterGroup tree. When tuning:
+
+### Add exclusions
+
+Add SQL conditions or additional predicates to exclude known-valid edge cases that trigger
+false positives:
+
+```json
+{
+  "type": "GROUP",
+  "operator": "AND",
+  "conditions": [
+    // ... existing conditions ...
+    {
+      "type": "SQL",
+      "sql": "category != 'legacy_import'"
+    }
+  ]
+}
+```
+
+### Tighten or loosen existing predicates
+
+- If a BINARY condition threshold is too tight (e.g., `greater_than 0` but 1-3 invalid rows
+  is normal) → loosen the threshold based on observed values from TSA.
+- If a UNARY null check fires on a column that is legitimately nullable for certain record
+  types → add an exclusion condition rather than removing the null check.
+
+### Produce the full FilterGroup tree
+
+When recommending changes, always output the **complete** `alert_condition` tree — not just the
+modified node. The tool replaces the full condition, not individual nodes.
+
+**NEVER** simplify or restructure the condition tree beyond the targeted change. Preserve the
+existing structure and only modify what's needed.
+
+---
+
+## What NOT to recommend without TSA
+
+- Removing conditions from the alert condition tree
+- Changing predicate logic (e.g., `null` to `not_null`, `in_set` to different values)
+- Adding new conditions based on speculation about what the invalid data might look like
+
+If TSA is absent and the monitor is noisy, say so explicitly:
+
+> This validation monitor is firing frequently, but without troubleshooting analysis I cannot
+> determine what the invalid rows contain. I can only recommend schedule changes. To enable
+> deeper tuning, run troubleshooting on recent incidents to identify the root cause.
+
+---
+
+## Applying changes
+
+Use `create_validation_monitor` to update the monitor.
+
+1. **Always pass the existing identifier** to update rather than create a new monitor.
+2. **Always preview first** — show the user the full updated `alert_condition` tree and ask
+   for confirmation before applying.
+3. **On confirmation**, apply the change.
+
+### Common mistakes
+
+- **NEVER** apply changes without showing the preview first.
+- **CRITICAL:** The `alert_condition` must be a dict (JSON object), never a JSON-encoded string.
+- **IMPORTANT:** Always produce the full `alert_condition` tree, not just the changed node.
+  The tool replaces the entire condition tree.
+- **NEVER** recommend condition changes without TSA evidence — schedule changes are the only
+  safe lever without it.


### PR DESCRIPTION
## Summary
- Add `references/validation-monitor.md` with tuning guidance for validation monitors (TSA-gated condition changes, always-safe schedule tuning, full FilterGroup tree output)
- Update `SKILL.md` to route validation monitors, add `create_validation_monitor` tool, and extend analysis/report phases

## Test plan
- [x] Run `/tune-monitor` against a validation monitor UUID and verify it loads the new reference
- [x] Verify noisy validation monitor without TSA only gets schedule recommendations
- [ ] Verify validation monitor with TSA gets alert condition recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)