### PR TITLE
DOL-8649: Skill telemetry — anonymous beacon hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See the [skills directory](skills/) for the full list and individual READMEs.
 
 ## Telemetry
 
-The Claude Code plugin sends anonymous skill-usage telemetry. No prompts or skill arguments are sent. To disable, set `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. See [the plugin README](plugins/claude-code/README.md#telemetry) for details.
+The Claude Code plugin sends anonymous skill-usage telemetry. No prompts or skill arguments are sent. To disable, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See [the plugin README](plugins/claude-code/README.md#telemetry) for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ cp -r skills/prevent ~/.claude/skills/prevent
 
 See the [skills directory](skills/) for the full list and individual READMEs.
 
+## Telemetry
+
+The Claude Code plugin sends anonymous skill-usage telemetry. No prompts or skill arguments are sent. To disable, set `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. See [the plugin README](plugins/claude-code/README.md#telemetry) for details.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding skills, creating plugins, and submitting pull requests. It also covers [plugin architecture](docs/plugin-architecture-guide.md) and [releasing new versions](CONTRIBUTING.md#releasing).

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.11.0",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",
@@ -29,5 +29,5 @@
     "./commands/incident-response/",
     "./commands/proactive-monitoring/"
   ],
-  "hooks": ["./hooks/prevent/hooks.json"]
+  "hooks": ["./hooks/prevent/hooks.json", "./hooks/telemetry/hooks.json"]
 }

--- a/plugins/claude-code/.mcp.json
+++ b/plugins/claude-code/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   }
 }

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-05-04
+
+### Added
+
+- **Anonymous skill-usage telemetry.** A new `SessionStart` hook generates a per-install and per-session UUID under `~/.claude/mc-agent-toolkit/`. A new `PreToolUse:Skill` hook fires a fire-and-forget beacon to `https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon` on each skill activation, sending only the skill name, toolkit version, UUIDs, and a boolean indicating whether arguments were present. **No prompts, args, or file paths are sent.** Disable with `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. See the plugin README for details.
+
 ## [1.10.1] - 2026-04-30
 
 ### Removed

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.11.0] - 2026-05-04
+## [1.10.2] - 2026-05-04
 
-### Added
+### Changed
 
-- **Anonymous skill-usage telemetry.** A new `SessionStart` hook generates a per-install and per-session UUID under `~/.claude/mc-agent-toolkit/`. A new `PreToolUse:Skill` hook fires a fire-and-forget beacon to `https://mcp.getmontecarlo.com/mcp/toolkit/beacon` on each skill activation, sending only the skill name, toolkit version, UUIDs, and a boolean indicating whether arguments were present. **No prompts, args, or file paths are sent.** Disable with `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. MC engineers can override the endpoint with `MCD_TOOLKIT_BEACON_URL` (e.g. to target the dev environment for verification). See the plugin README for details.
+- Internal tracking only: anonymous skill-usage telemetry and MCP route updated to `/mcp/toolkit`. No prompts, args, or file paths sent. Disable telemetry with `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See the plugin README for details.
 
 ## [1.10.1] - 2026-04-30
 

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Anonymous skill-usage telemetry.** A new `SessionStart` hook generates a per-install and per-session UUID under `~/.claude/mc-agent-toolkit/`. A new `PreToolUse:Skill` hook fires a fire-and-forget beacon to `https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon` on each skill activation, sending only the skill name, toolkit version, UUIDs, and a boolean indicating whether arguments were present. **No prompts, args, or file paths are sent.** Disable with `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. See the plugin README for details.
+- **Anonymous skill-usage telemetry.** A new `SessionStart` hook generates a per-install and per-session UUID under `~/.claude/mc-agent-toolkit/`. A new `PreToolUse:Skill` hook fires a fire-and-forget beacon to `https://mcp.getmontecarlo.com/mcp/toolkit/beacon` on each skill activation, sending only the skill name, toolkit version, UUIDs, and a boolean indicating whether arguments were present. **No prompts, args, or file paths are sent.** Disable with `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. MC engineers can override the endpoint with `MCD_TOOLKIT_BEACON_URL` (e.g. to target the dev environment for verification). See the plugin README for details.
 
 ## [1.10.1] - 2026-04-30
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -33,9 +33,9 @@ Restart Claude Code after installing.
 
 ## Telemetry
 
-The toolkit sends anonymous skill-usage telemetry — which skills are invoked, how often. Each event includes an opaque per-install UUID and a per-session UUID, the skill name, and the toolkit version. **No prompts, no skill arguments, no file paths, and no email or account info are sent.**
+The toolkit sends anonymous skill-usage telemetry — which skills are invoked, how often. Each event includes an opaque per-install UUID and a per-session UUID, the skill name, and the toolkit version.
 
-To disable, set `MCD_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment. The toolkit will not phone home.
+To disable, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment. The toolkit will not phone home.
 
 The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in.
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -31,6 +31,16 @@ Restart Claude Code after installing.
 1. **Authenticate with Monte Carlo** — run `/mcp` in Claude Code, select the Monte Carlo server, and complete the OAuth flow.
 2. **Verify** — ask Claude: "Test my Monte Carlo connection."
 
+## Telemetry
+
+The toolkit sends anonymous skill-usage telemetry — which skills are invoked, how often. Each event includes an opaque per-install UUID and a per-session UUID, the skill name, and the toolkit version. **No prompts, no skill arguments, no file paths, and no email or account info are sent.**
+
+To disable, set `MCD_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment. The toolkit will not phone home.
+
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in.
+
+The UUIDs are generated locally on first session and stored under `~/.claude/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+
 ## Available Features
 
 | Feature | Description | Details |

--- a/plugins/claude-code/hooks/telemetry/hooks.json
+++ b/plugins/claude-code/hooks/telemetry/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/telemetry/scripts/ensure-toolkit-ids.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/telemetry/scripts/skill-beacon.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Ensure stable install_id and fresh session_id for the current Claude Code session.
+# install_id is generated once and persisted; session_id is regenerated every session.
+set -euo pipefail
+
+DIR="$HOME/.claude/mc-agent-toolkit"
+mkdir -p "$DIR"
+
+if [[ ! -f "$DIR/install_id" ]]; then
+  uuidgen | tr '[:upper:]' '[:lower:]' > "$DIR/install_id"
+  chmod 600 "$DIR/install_id"
+fi
+
+uuidgen | tr '[:upper:]' '[:lower:]' > "$DIR/session_id"
+chmod 600 "$DIR/session_id"

--- a/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensure stable install_id and fresh session_id for the current Claude Code session.
-# install_id is generated once and persisted; session_id is regenerated every session.
+# Ensure stable install_id and fresh toolkit_session_id for the current Claude Code session.
+# install_id is generated once and persisted; toolkit_session_id is regenerated every session.
 # Fails closed (exit 0) on any error — telemetry must never break a Claude Code session.
 # If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
 set -uo pipefail
@@ -13,7 +13,7 @@ if [[ ! -f "$DIR/install_id" ]]; then
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
 fi
 
-uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/session_id" 2>/dev/null || exit 0
-chmod 600 "$DIR/session_id" 2>/dev/null || exit 0
+uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
 exit 0

--- a/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 # Ensure stable install_id and fresh session_id for the current Claude Code session.
 # install_id is generated once and persisted; session_id is regenerated every session.
-set -euo pipefail
+# Fails closed (exit 0) on any error — telemetry must never break a Claude Code session.
+# If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
+set -uo pipefail
 
 DIR="$HOME/.claude/mc-agent-toolkit"
-mkdir -p "$DIR"
+mkdir -p "$DIR" 2>/dev/null || exit 0
 
 if [[ ! -f "$DIR/install_id" ]]; then
-  uuidgen | tr '[:upper:]' '[:lower:]' > "$DIR/install_id"
-  chmod 600 "$DIR/install_id"
+  uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
+  chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
 fi
 
-uuidgen | tr '[:upper:]' '[:lower:]' > "$DIR/session_id"
-chmod 600 "$DIR/session_id"
+uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/session_id" 2>/dev/null || exit 0
+chmod 600 "$DIR/session_id" 2>/dev/null || exit 0
+
+exit 0

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -26,6 +26,10 @@ SKILL_NAME="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.skill // empty' 2>/
 
 ARGS_PRESENT="$(printf '%s' "$HOOK_INPUT" | jq -r '((.tool_input.args // "") | length) > 0' 2>/dev/null || echo false)"
 
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
 # Resolve plugin version from plugin.json relative to this script's location.
 # Script path: <plugin_root>/hooks/telemetry/scripts/skill-beacon.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,7 +50,7 @@ PAYLOAD="$(jq -nc \
 ( curl -fsS -m 2 -X POST \
     -H 'Content-Type: application/json' \
     -d "$PAYLOAD" \
-    "https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon" \
+    "$BEACON_URL" \
     >/dev/null 2>&1 || true ) &
 disown
 

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -5,7 +5,7 @@
 set -uo pipefail
 
 # Opt-out
-if [[ "${MCD_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
   exit 0
 fi
 

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -39,12 +39,12 @@ TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || e
 PAYLOAD="$(jq -nc \
   --arg event "Toolkit Skill Invoked" \
   --arg install_id "$INSTALL_ID" \
-  --arg toolkit_session_id "$TOOLKIT_SESSION_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
   --arg skill "$SKILL_NAME" \
   --argjson skill_args_present "$ARGS_PRESENT" \
   --arg toolkit_version "$TOOLKIT_VERSION" \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '{event: $event, install_id: $install_id, toolkit_session_id: $toolkit_session_id, skill: $skill, skill_args_present: $skill_args_present, toolkit_version: $toolkit_version, ts: $ts}')"
+  '{event: $event, install_id: $install_id, session_id: $session_id, skill: $skill, skill_args_present: $skill_args_present, toolkit_version: $toolkit_version, ts: $ts}')"
 
 # Fire-and-forget. 2s timeout so a slow server never delays a skill invocation.
 ( curl -fsS -m 2 -X POST \

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -11,10 +11,10 @@ fi
 
 DIR="$HOME/.claude/mc-agent-toolkit"
 INSTALL_ID="$(cat "$DIR/install_id" 2>/dev/null || echo "")"
-SESSION_ID="$(cat "$DIR/session_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 # If files are missing for any reason, don't beacon (better than sending null IDs)
-[[ -z "$INSTALL_ID" || -z "$SESSION_ID" ]] && exit 0
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
 # Capture stdin ONCE — stdin is a stream, consumed by first reader.
 # Hook stdin contract: {"tool_name":"Skill","tool_input":{"skill":"...","args":"..."},...}
@@ -39,12 +39,12 @@ TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || e
 PAYLOAD="$(jq -nc \
   --arg event "Toolkit Skill Invoked" \
   --arg install_id "$INSTALL_ID" \
-  --arg session_id "$SESSION_ID" \
+  --arg toolkit_session_id "$TOOLKIT_SESSION_ID" \
   --arg skill "$SKILL_NAME" \
   --argjson skill_args_present "$ARGS_PRESENT" \
   --arg toolkit_version "$TOOLKIT_VERSION" \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '{event: $event, install_id: $install_id, session_id: $session_id, skill: $skill, skill_args_present: $skill_args_present, toolkit_version: $toolkit_version, ts: $ts}')"
+  '{event: $event, install_id: $install_id, toolkit_session_id: $toolkit_session_id, skill: $skill, skill_args_present: $skill_args_present, toolkit_version: $toolkit_version, ts: $ts}')"
 
 # Fire-and-forget. 2s timeout so a slow server never delays a skill invocation.
 ( curl -fsS -m 2 -X POST \

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Fire a fire-and-forget beacon on Skill tool invocation.
+# Reads tool input JSON from stdin (Claude Code hook contract).
+# Fails closed (exit 0) on any error — telemetry must never break a skill invocation.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MCD_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+DIR="$HOME/.claude/mc-agent-toolkit"
+INSTALL_ID="$(cat "$DIR/install_id" 2>/dev/null || echo "")"
+SESSION_ID="$(cat "$DIR/session_id" 2>/dev/null || echo "")"
+
+# If files are missing for any reason, don't beacon (better than sending null IDs)
+[[ -z "$INSTALL_ID" || -z "$SESSION_ID" ]] && exit 0
+
+# Capture stdin ONCE — stdin is a stream, consumed by first reader.
+# Hook stdin contract: {"tool_name":"Skill","tool_input":{"skill":"...","args":"..."},...}
+HOOK_INPUT="$(cat || true)"
+[[ -z "$HOOK_INPUT" ]] && exit 0
+
+SKILL_NAME="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null || true)"
+[[ -z "$SKILL_NAME" ]] && exit 0  # not a skill invocation we recognize; bail
+
+ARGS_PRESENT="$(printf '%s' "$HOOK_INPUT" | jq -r '((.tool_input.args // "") | length) > 0' 2>/dev/null || echo false)"
+
+# Resolve plugin version from plugin.json relative to this script's location.
+# Script path: <plugin_root>/hooks/telemetry/scripts/skill-beacon.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_JSON="$SCRIPT_DIR/../../../.claude-plugin/plugin.json"
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Skill Invoked" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$SESSION_ID" \
+  --arg skill "$SKILL_NAME" \
+  --argjson skill_args_present "$ARGS_PRESENT" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, skill: $skill, skill_args_present: $skill_args_present, toolkit_version: $toolkit_version, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays a skill invocation.
+( curl -fsS -m 2 -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$PAYLOAD" \
+    "https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon" \
+    >/dev/null 2>&1 || true ) &
+disown
+
+exit 0

--- a/plugins/claude-code/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/claude-code/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
+# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# verify what would have been sent without making network calls.
+set -uo pipefail
+
+LOG="${MOCK_CURL_LOG:-/dev/null}"
+STDIN_PAYLOAD="$(cat || true)"
+
+# Pull the body from -d/--data when present; otherwise fall back to stdin.
+data=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -d|--data|--data-raw|--data-binary) data="$arg" ;;
+  esac
+  prev="$arg"
+done
+[[ -z "$data" ]] && data="$STDIN_PAYLOAD"
+
+# argv as a JSON array; data as a string. jq handles all escaping.
+jq -nc \
+  --argjson argv "$(printf '%s\n' "$@" | jq -R . | jq -sc .)" \
+  --arg data "$data" \
+  '{argv: $argv, data: $data}' >> "$LOG"
+
+exit 0

--- a/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -50,3 +50,11 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -d "$TEST_HOME/.claude/mc-agent-toolkit" ]
 }
+
+@test "exits 0 even when parent directory cannot be created" {
+  # Make $HOME a regular file so mkdir -p $HOME/.claude/... must fail.
+  rm -rf "$TEST_HOME"
+  touch "$TEST_HOME"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -10,36 +10,36 @@ teardown() {
   rm -rf "$TEST_HOME"
 }
 
-@test "creates install_id and session_id files" {
+@test "creates install_id and toolkit_session_id files" {
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
   [ -f "$TEST_HOME/.claude/mc-agent-toolkit/install_id" ]
-  [ -f "$TEST_HOME/.claude/mc-agent-toolkit/session_id" ]
+  [ -f "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id" ]
 }
 
 @test "files contain lowercase UUIDs" {
   bash "$SCRIPT"
   install_id="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
-  session_id="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  toolkit_session_id="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id")"
   [[ "$install_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
-  [[ "$session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+  [[ "$toolkit_session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
 }
 
 @test "files have mode 600" {
   bash "$SCRIPT"
   perms_install="$(stat -f '%Lp' "$TEST_HOME/.claude/mc-agent-toolkit/install_id" 2>/dev/null || stat -c '%a' "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
-  perms_session="$(stat -f '%Lp' "$TEST_HOME/.claude/mc-agent-toolkit/session_id" 2>/dev/null || stat -c '%a' "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  perms_session="$(stat -f '%Lp' "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id" 2>/dev/null || stat -c '%a' "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id")"
   [ "$perms_install" = "600" ]
   [ "$perms_session" = "600" ]
 }
 
-@test "install_id is stable across runs; session_id rotates" {
+@test "install_id is stable across runs; toolkit_session_id rotates" {
   bash "$SCRIPT"
   install_first="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
-  session_first="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  session_first="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id")"
   bash "$SCRIPT"
   install_second="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
-  session_second="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  session_second="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/toolkit_session_id")"
   [ "$install_first" = "$install_second" ]
   [ "$session_first" != "$session_second" ]
 }

--- a/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "creates install_id and session_id files" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/.claude/mc-agent-toolkit/install_id" ]
+  [ -f "$TEST_HOME/.claude/mc-agent-toolkit/session_id" ]
+}
+
+@test "files contain lowercase UUIDs" {
+  bash "$SCRIPT"
+  install_id="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
+  session_id="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  [[ "$install_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+  [[ "$session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+@test "files have mode 600" {
+  bash "$SCRIPT"
+  perms_install="$(stat -f '%Lp' "$TEST_HOME/.claude/mc-agent-toolkit/install_id" 2>/dev/null || stat -c '%a' "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
+  perms_session="$(stat -f '%Lp' "$TEST_HOME/.claude/mc-agent-toolkit/session_id" 2>/dev/null || stat -c '%a' "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  [ "$perms_install" = "600" ]
+  [ "$perms_session" = "600" ]
+}
+
+@test "install_id is stable across runs; session_id rotates" {
+  bash "$SCRIPT"
+  install_first="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
+  session_first="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  bash "$SCRIPT"
+  install_second="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/install_id")"
+  session_second="$(cat "$TEST_HOME/.claude/mc-agent-toolkit/session_id")"
+  [ "$install_first" = "$install_second" ]
+  [ "$session_first" != "$session_second" ]
+}
+
+@test "creates parent directory when absent" {
+  rm -rf "$TEST_HOME/.claude"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_HOME/.claude/mc-agent-toolkit" ]
+}

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -16,7 +16,7 @@ setup() {
   export MOCK_CURL_LOG="$(mktemp)"
 
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/skill-beacon.sh"
-  unset MCD_TOOLKIT_TELEMETRY_DISABLED
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
   unset MCD_TOOLKIT_BEACON_URL
 }
 
@@ -41,7 +41,7 @@ wait_for_log() {
   [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Skill Invoked" ]
   [ "$(echo "$payload" | jq -r '.skill')" = "start-work" ]
   [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
-  [ "$(echo "$payload" | jq -r '.toolkit_session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
 }
 
 @test "skill_args_present is true when args non-empty" {
@@ -74,7 +74,7 @@ wait_for_log() {
 }
 
 @test "opt-out env var suppresses beacon" {
-  export MCD_TOOLKIT_TELEMETRY_DISABLED=1
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
   run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
   [ "$status" -eq 0 ]
   sleep 0.2

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -6,7 +6,7 @@ setup() {
   IDS_DIR="$TEST_HOME/.claude/mc-agent-toolkit"
   mkdir -p "$IDS_DIR"
   echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
-  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/session_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
 
   # Mock curl on PATH
   MOCK_BIN="$(mktemp -d)"
@@ -41,7 +41,7 @@ wait_for_log() {
   [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Skill Invoked" ]
   [ "$(echo "$payload" | jq -r '.skill')" = "start-work" ]
   [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
-  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.toolkit_session_id')" = "22222222-2222-2222-2222-222222222222" ]
 }
 
 @test "skill_args_present is true when args non-empty" {
@@ -89,8 +89,8 @@ wait_for_log() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "missing session_id file results in no beacon, exit 0" {
-  rm "$IDS_DIR/session_id"
+@test "missing toolkit_session_id file results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
   run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
   [ "$status" -eq 0 ]
   sleep 0.2

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -17,6 +17,7 @@ setup() {
 
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/skill-beacon.sh"
   unset MCD_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
 }
 
 teardown() {
@@ -119,11 +120,20 @@ wait_for_log() {
   [ "$version" = "$expected" ]
 }
 
-@test "curl is called with -m 2 and the beacon URL" {
+@test "curl is called with -m 2 and the prod beacon URL by default" {
   echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
   wait_for_log
   argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
   echo "$argv" | grep -q '"-m"'
   echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -57,11 +57,19 @@ wait_for_log() {
   [ "$(echo "$payload" | jq -r '.skill_args_present')" = "false" ]
 }
 
+@test "skill_args_present is false when args is empty string" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":""}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.skill_args_present')" = "false" ]
+}
+
 @test "payload never contains args content" {
   echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":"SECRET-PROMPT-TEXT"}}' | bash "$SCRIPT"
   wait_for_log
-  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
-  ! echo "$payload" | grep -q "SECRET-PROMPT-TEXT"
+  # Search the raw log (covers argv, headers, body — every field mock_curl captured),
+  # not just .data, so any future leak path is caught.
+  ! grep -q "SECRET-PROMPT-TEXT" "$MOCK_CURL_LOG"
 }
 
 @test "opt-out env var suppresses beacon" {
@@ -74,6 +82,14 @@ wait_for_log() {
 
 @test "missing install_id file results in no beacon, exit 0" {
   rm "$IDS_DIR/install_id"
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing session_id file results in no beacon, exit 0" {
+  rm "$IDS_DIR/session_id"
   run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
   [ "$status" -eq 0 ]
   sleep 0.2

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.claude/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/skill-beacon.sh"
+  unset MCD_TOOLKIT_TELEMETRY_DISABLED
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+# Helper: wait briefly for the backgrounded curl to flush its log line.
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires beacon with correct skill name" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"start-work","args":""}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Skill Invoked" ]
+  [ "$(echo "$payload" | jq -r '.skill')" = "start-work" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+}
+
+@test "skill_args_present is true when args non-empty" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":"phase 2"}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.skill_args_present')" = "true" ]
+}
+
+@test "skill_args_present is false when args empty or missing" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"hack"}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.skill_args_present')" = "false" ]
+}
+
+@test "payload never contains args content" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":"SECRET-PROMPT-TEXT"}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  ! echo "$payload" | grep -q "SECRET-PROMPT-TEXT"
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MCD_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id file results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"x\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing tool_input.skill results in no beacon, exit 0" {
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "non-skill tool input results in no beacon, exit 0" {
+  run bash -c 'echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "payload includes toolkit_version from plugin.json" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$BATS_TEST_DIRNAME/../../../.claude-plugin/plugin.json")"
+  [ "$version" = "$expected" ]
+}
+
+@test "curl is called with -m 2 and the beacon URL" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/.mcp.json
+++ b/plugins/codex/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   }
 }

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-04
+
+### Changed
+
+- Internal tracking only: MCP route updated to `/mcp/toolkit`.
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -20,7 +20,7 @@ CONFIG_DIR="$HOME/.codex"
 CONFIG_FILE="$CONFIG_DIR/config.toml"
 HOOKS_FILE=""  # set after TARGET_REPO is resolved
 SERVER_NAME="monte-carlo-mcp"
-SERVER_URL="https://mcp.getmontecarlo.com/mcp"
+SERVER_URL="https://mcp.getmontecarlo.com/mcp/toolkit"
 
 # --- Parse arguments ---
 # Usage: install.sh [--local /path/to/mc-agent-toolkit] <target-repo>

--- a/plugins/copilot/.mcp.json
+++ b/plugins/copilot/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "monte-carlo-mcp": {
       "type": "http",
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   }
 }

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-04
+
+### Changed
+
+- Internal tracking only: MCP route updated to `/mcp/toolkit`.
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-04
+
+### Changed
+
+- Internal tracking only: MCP route updated to `/mcp/toolkit`.
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/cursor/mcp.json
+++ b/plugins/cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "monte-carlo-mcp": {
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   }
 }

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-04
+
+### Changed
+
+- Internal tracking only: MCP route updated to `/mcp/toolkit`.
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -76,7 +76,7 @@ cp plugins/opencode/commands/mc-validate.md .opencode/commands/
   "mcp": {
     "monte-carlo-mcp": {
       "type": "remote",
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   }
 }

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -89,7 +89,7 @@ if [ -f "$OPENCODE_JSON" ]; then
     echo "  ✓ MCP server already configured in opencode.json"
   else
     echo "  ⚠ monte-carlo-mcp MCP is not configured."
-    echo '    Add under "mcp": { "monte-carlo-mcp": { "type": "remote", "url": "https://mcp.getmontecarlo.com/mcp" } }'
+    echo '    Add under "mcp": { "monte-carlo-mcp": { "type": "remote", "url": "https://mcp.getmontecarlo.com/mcp/toolkit" } }'
     NEEDS_GUIDANCE=true
   fi
 

--- a/plugins/opencode/opencode.json
+++ b/plugins/opencode/opencode.json
@@ -4,7 +4,7 @@
   "mcp": {
     "monte-carlo-mcp": {
       "type": "remote",
-      "url": "https://mcp.getmontecarlo.com/mcp"
+      "url": "https://mcp.getmontecarlo.com/mcp/toolkit"
     }
   },
   "permission": {

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/prevent/references/TROUBLESHOOTING.md
+++ b/skills/prevent/references/TROUBLESHOOTING.md
@@ -3,7 +3,7 @@
 ### MCP connection fails:
 ```bash
 # Verify the server is reachable
-curl -s -o /dev/null -w "%{http_code}" https://mcp.getmontecarlo.com/mcp
+curl -s -o /dev/null -w "%{http_code}" https://mcp.getmontecarlo.com/mcp/toolkit
 ```
 
 **If using the plugin (OAuth):** Run `/mcp` in Claude Code, select the `monte-carlo` server, and re-authenticate. If the browser flow doesn't complete, copy the callback URL from your browser's address bar into the URL prompt that appears in Claude Code.


### PR DESCRIPTION
## Summary

Adds anonymous skill-usage telemetry hooks to the Claude Code plugin. Two new bash scripts wired via `hooks/telemetry/hooks.json`:

- **`SessionStart` hook** (`ensure-toolkit-ids.sh`) — idempotently writes `~/.claude/mc-agent-toolkit/install_id` (stable) and `session_id` (rotated each session), both lowercase UUIDs at mode 600. Fail-closed: exits 0 even if the home directory is unwritable or `uuidgen` is missing.
- **`PreToolUse:Skill` hook** (`skill-beacon.sh`) — fires a fire-and-forget `curl` (2s timeout, backgrounded + disowned, parent returns in ~80ms even when curl can't reach the host) to `POST https://mcp.getmontecarlo.com/mcp/toolkit/beacon` on each skill activation. Payload: skill name, install_id, session_id, toolkit version, and a boolean `skill_args_present` — never the args content itself.

Plugin version bumped 1.10.1 → 1.11.0. Telemetry section added to plugin README + root README.

## Privacy posture

- No prompts, no skill arguments, no file paths, no email/account info ever sent.
- Privacy canary test (`payload never contains args content`) injects `SECRET-PROMPT-TEXT` as args and `grep`s the entire mock-curl capture (argv + body + headers) to confirm zero leak surface.
- Both hook scripts fail-closed (exit 0 on every error path) — telemetry can never break a Claude Code session.
- Opt-out via `MCD_TOOLKIT_TELEMETRY_DISABLED=1`. MC engineers can override the endpoint via `MCD_TOOLKIT_BEACON_URL` (e.g. to target dev during verification).

## Companion work

The beacon endpoint at `mcp.getmontecarlo.com/mcp/toolkit/beacon` is implemented in a separate `ai-agent/mcp-server` change (parent ticket DOL-8646; sibling plan to be filed). Until that endpoint ships to prod, beacons fired from this plugin will silently fail (curl returns nonzero, parent exits 0, nothing observed). That's deliberate — the v1 design treats telemetry as best-effort.

## Test plan

- [x] All 19 bats tests pass (`bats plugins/claude-code/hooks/telemetry/tests/`)
  - 6 covering `ensure-toolkit-ids.sh`: file creation, lowercase UUID format, mode 600, install stability + session rotation, parent dir creation, fail-closed under unwritable home
  - 13 covering `skill-beacon.sh`: payload field correctness, `skill_args_present` true/false/empty-string, privacy canary, opt-out env var, missing install_id / missing session_id / missing skill / non-Skill input → no beacon, toolkit_version sourced from plugin.json, default prod URL, override URL via env var
- [x] Smoke-tested `ensure-toolkit-ids.sh` against a fresh `\$HOME` — generates lowercase UUIDs, mode 600
- [x] Smoke-tested `skill-beacon.sh` with real curl + unreachable host — parent returns in 79ms (curl backgrounded properly via `& disown`)
- [ ] **Deferred until beacon endpoint is live in dev:** real Claude Code session smoke test (per the plan's Step 8.2). When the companion `ai-agent` PR ships:
  - Confirm `~/.claude/mc-agent-toolkit/install_id` and `session_id` files appear after restart
  - Invoke a skill via the LLM → confirm Mixpanel event arrives with matching IDs and `skill: "<name>"`
  - Type `/<skill-name>` directly → record whether the same beacon fires (resolves the open question in the design about slash-command coverage; if it does NOT fire, file a follow-up to add a `UserPromptSubmit` backstop)
  - Set `MCD_TOOLKIT_TELEMETRY_DISABLED=1`, restart, invoke skill → confirm no event lands

## Checklist

- [x] Tests added/updated (19 bats tests covering happy paths, privacy invariants, fail-closed semantics)
- [x] Documentation updated (plugin README + root README + CHANGELOG)
- [x] Version bumped (1.10.1 → 1.11.0; minor bump because telemetry is a user-visible behavior change)
- [x] No secrets or credentials in changes
- [na] Database migration — none in this change
- [na] Backwards-compatibility considerations — net-new feature behind opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)