### PR TITLE
docs(automated-triage): update alert_assessment fields for alert_description/triage_summary split

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-05
+
+### Changed
+
+- Correct `alert_assessment` output field descriptions in automated-triage skill: replace the stale "natural-language summary" reference with explicit `alert_description` (what happened) and `triage_summary` (scoring reasoning) fields, and clarify that `alert_description` is used in triage comments for untroubleshot alerts.
+
+
 ## [1.10.1] - 2026-04-30
 
 ### Removed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-05
+
+### Changed
+
+- Correct `alert_assessment` output field descriptions in automated-triage skill: replace the stale "natural-language summary" reference with explicit `alert_description` (what happened) and `triage_summary` (scoring reasoning) fields, and clarify that `alert_description` is used in triage comments for untroubleshot alerts.
+
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-05
+
+### Changed
+
+- Correct `alert_assessment` output field descriptions in automated-triage skill: replace the stale "natural-language summary" reference with explicit `alert_description` (what happened) and `triage_summary` (scoring reasoning) fields, and clarify that `alert_description` is used in triage comments for untroubleshot alerts.
+
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-05
+
+### Changed
+
+- Correct `alert_assessment` output field descriptions in automated-triage skill: replace the stale "natural-language summary" reference with explicit `alert_description` (what happened) and `triage_summary` (scoring reasoning) fields, and clarify that `alert_description` is used in triage comments for untroubleshot alerts.
+
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-05-05
+
+### Changed
+
+- Correct `alert_assessment` output field descriptions in automated-triage skill: replace the stale "natural-language summary" reference with explicit `alert_description` (what happened) and `triage_summary` (scoring reasoning) fields, and clarify that `alert_description` is used in triage comments for untroubleshot alerts.
+
+
 ## [1.10.1] - 2026-04-30
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/automated-triage/references/triage-example.md
+++ b/skills/automated-triage/references/triage-example.md
@@ -38,7 +38,7 @@ If no alerts are returned, report: "No alerts in the last 3 hours." and stop.
 
 ### Step 3: Score each alert
 
-Call `alert_assessment` in parallel for every alert from step 2, in batches of up to 10 at a time. Each result includes `alert_confidence`, `alert_impact` (HIGH/MEDIUM/LOW each), and a natural-language summary — the summary is used for the triage comment in step 4 for alerts that don't go through troubleshooting.
+Call `alert_assessment` in parallel for every alert from step 2, in batches of up to 10 at a time. Each result includes `alert_confidence`, `alert_impact` (HIGH/MEDIUM/LOW each), `alert_description` (plain-language description of what happened in the incident), and `triage_summary` (the key reasoning behind the confidence and impact scores). Use `alert_description` and `triage_summary` to inform the triage comment in step 4 for alerts that don't go through troubleshooting.
 
 ### Step 4: Troubleshoot and classify high-signal alerts
 

--- a/skills/automated-triage/references/triage-stages.md
+++ b/skills/automated-triage/references/triage-stages.md
@@ -41,7 +41,8 @@ This stage replicates what a knowledgeable engineer does when scanning the alert
 It returns:
 - **`alert_confidence`** (HIGH/MEDIUM/LOW) — how likely the alert represents a real issue. Affected by: number of events, presence of concerning root causes (query changes, failures), how much thresholds were exceeded, and how noisy the monitor typically is.
 - **`alert_impact`** (HIGH/MEDIUM/LOW) — how significant the potential downstream impact is.  Use cases impacted.  Dashboards affected etc.
-- A natural-language summary of the alert.
+- **`alert_description`** — plain-language description of what happened in the incident.
+- **`triage_summary`** — the key reasoning behind the confidence and impact scores.
 
 **Run `alert_assessment` in parallel**, in batches of up to 10 at a time.
 


### PR DESCRIPTION
## What this changes

The `alert_assessment` tool now returns two named fields instead of a single generic summary (split in AI-199). This PR updates the automated-triage skill's reference docs to reflect that:

- **`alert_description`** — plain-language description of what happened in the incident
- **`triage_summary`** — the key reasoning behind the confidence and impact scores

Both fields can inform the triage comment for alerts that don't go through troubleshooting. Previously the docs referenced a single "natural-language summary" field that no longer exists, leaving it ambiguous which field to use where.

Also bumps the plugin version to **1.10.2** so editor clients pick up the update.

## Testing

Ran the automated-triage skill in recommendation mode (no writes) against 5 unacknowledged alerts in the Andes audience before and after the change. Before: docs were ambiguous — `alert_assessment` already returned both named fields at the API level but skill docs gave no guidance on how to use them. After: skill correctly names both fields and clarifies they can both inform triage comments. Results documented in `.work/ai-200-alert-desc-triage-summary/triage-behavior.md`.

## Checklist

- [x] Docs updated
- [na] Tests added (markdown-only change)
- [x] Version bumped (1.10.2, patch)
- [na] Migration notes