### PR TITLE
docs(performance-diagnosis): document bucket="1h" override

### DIFF
--- a/skills/performance-diagnosis/SKILL.md
+++ b/skills/performance-diagnosis/SKILL.md
@@ -116,6 +116,7 @@ Now drill into root causes using the MCONs from discovery or the bridge:
 4. **Is latency degrading?** Call `get_query_latency_distribution` to see the trend:
    - Compare p50 vs p95 -- if p95 >> p50 (>5x), the problem is outlier queries
    - Look for step-changes in latency (sudden increase = regression)
+   - For step-change / regression-time-localization use cases, pass `bucket="1h"`. The default downsamples to daily on windows ≥ 3 days, which hides hour-level steps.
 
 5. **Trace impact**: Call `get_asset_lineage` with `direction="DOWNSTREAM"` to see what's affected by a slow table, or `direction="UPSTREAM"` to find what feeds it.
 

--- a/skills/performance-diagnosis/references/investigation-tiers.md
+++ b/skills/performance-diagnosis/references/investigation-tiers.md
@@ -93,6 +93,9 @@ Latency trend over time.
 - p95 >> p50 (>5x) means outlier queries are the problem, not the average case
 - Gradual upward trend means growing data volume or inefficient queries
 
+**Key parameters:**
+- `bucket` (optional): defaults to `1d` for windows ≥ 3 days, `1h` otherwise. Pass `bucket="1h"` explicitly when localizing a step change to a specific hour, or when investigating intermittent outlier patterns that vary by time of day.
+
 ### `get_asset_lineage`
 
 Trace upstream/downstream impact.

--- a/skills/performance-diagnosis/references/query-analysis.md
+++ b/skills/performance-diagnosis/references/query-analysis.md
@@ -19,11 +19,11 @@ When presenting runtime data to the user, always cite the exact numbers from the
 
 ### Common performance patterns
 
-**Sudden spike**: Query changed (new JOIN, removed filter, different plan). Use `get_change_timeline` to find the change.
+**Sudden spike**: Query changed (new JOIN, removed filter, different plan). Use `get_change_timeline` to find the change. When using `get_query_latency_distribution` to confirm timing, pass `bucket="1h"` to localize the step to a specific hour.
 
 **Gradual degradation**: Data volume growing or query becoming less efficient over time. Use `get_query_latency_distribution` to confirm the trend.
 
-**Intermittent slowness**: Outlier executions (p95 >> p50). Often caused by: resource contention, cold warehouse startup, large partition scans on specific date ranges.
+**Intermittent slowness**: Outlier executions (p95 >> p50). Often caused by: resource contention, cold warehouse startup, large partition scans on specific date ranges. Pass `bucket="1h"` to `get_query_latency_distribution` to identify which hours are outlier-heavy.
 
 **Failed/futile patterns**: Use `get_query_rca` to group failures by cause. Common causes:
 - **Timeout**: Query takes too long -- needs optimization or larger warehouse


### PR DESCRIPTION
## Summary

- Adds three single-line doc updates to the performance-diagnosis skill teaching the agent to pass `bucket="1h"` to `get_query_latency_distribution` when it needs hour-level granularity.
- Background: ai-agent [#953](https://github.com/monte-carlo-data/ai-agent/pull/953) shrunk the tool's default response ~150x by auto-downsampling to daily on windows ≥ 3 days. Right default for gradual-degradation use cases; wrong for the two cases the skill explicitly calls out (step-change localization, intermittent slowness by hour).
- No tool/code changes — docs only.

## Changes

- `skills/performance-diagnosis/SKILL.md` — step 4 bullet about bucket override
- `skills/performance-diagnosis/references/investigation-tiers.md` — adds **Key parameters** subsection under `get_query_latency_distribution`, matching the pattern used by other tools in the file
- `skills/performance-diagnosis/references/query-analysis.md` — extends "Sudden spike" and "Intermittent slowness" patterns with the override

## Test plan

- [ ] Sanity-check by running the skill against a synthetic prompt like "did latency step up at any point in the last 7 days?" and confirm the tool call includes `bucket="1h"`
- [ ] Sanity-check that the gradual-degradation prompts still use the default (no `bucket` override)

Closes [K2-503](https://linear.app/montecarlodata/issue/K2-503/document-bucket1h-override-in-performance-diagnosis-skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)