### PR TITLE
fix(catalog): correct skill names in /mc listing

### DIFF
--- a/plugins/claude-code/commands/catalog/mc.md
+++ b/plugins/claude-code/commands/catalog/mc.md
@@ -15,7 +15,8 @@ List all available Monte Carlo skills and workflows. Present them grouped by cat
 
 | Command | Description |
 |---------|-------------|
-| `/mc-triage` | Triage Monte Carlo alerts — score, classify, and investigate interactively or build an automated workflow |
+| `/automated-triage` | Triage Monte Carlo alerts — score, classify, and investigate interactively or build an automated workflow |
+| `/tune-monitor` | Analyze a Monte Carlo monitor and recommend config changes to reduce alert noise |
 | `/monitoring-advisor` | Analyze data coverage, identify gaps, and create monitors for warehouse tables and AI agents |
 | `/mc-validate` | Generate and run validation queries for dbt model changes |
 | `/mc-build-*` | Push ingestion commands — build metadata, lineage, and query log collectors |

--- a/plugins/claude-code/commands/catalog/mc.md
+++ b/plugins/claude-code/commands/catalog/mc.md
@@ -29,6 +29,7 @@ These skills don't have dedicated commands but activate automatically when you a
 |-------|------------|
 | Asset Health | "check health of table X", "how is X doing?", "status of X" |
 | Root Cause Analysis | "why is this table stale?", "investigate this alert", "debug this incident" |
+| Automated Triage | "triage my alerts", "what alerts are firing?", "score and troubleshoot my open alerts" |
 | Remediation | "fix this alert", "remediate this issue", "handle this incident" |
 | Storage Cost Analysis | "unused tables", "storage costs", "zombie tables" |
 | Performance Diagnosis | "slow pipeline", "expensive queries", "query performance" |


### PR DESCRIPTION
## Summary
- Renamed `/mc-triage` → `/automated-triage` to match the actual skill name (the old command file was removed in #75)
- Added missing `/tune-monitor` skill to the catalog

## Test plan
- [x] Verified `/automated-triage` matches the skill name in `skills/automated-triage/SKILL.md`
- [x] Verified `/tune-monitor` matches the skill name in `skills/tune-monitor/SKILL.md`
- [na] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)