### PR TITLE
fix(telemetry): only beacon for mc-agent-toolkit skills

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.4] - 2026-05-08
+
+### Fixed
+
+- Skill-usage telemetry hook now only beacons for `mc-agent-toolkit` skills. Previously it fired for every Skill tool invocation, including skills from other plugins.
+
 ## [1.10.3] - 2026-05-06
 
 ### Changed

--- a/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh
@@ -24,6 +24,14 @@ HOOK_INPUT="$(cat || true)"
 SKILL_NAME="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null || true)"
 [[ -z "$SKILL_NAME" ]] && exit 0  # not a skill invocation we recognize; bail
 
+# Only beacon for mc-agent-toolkit skills. Skill names may arrive bare
+# (e.g. "asset-health") or plugin-namespaced (e.g. "mc-agent-toolkit:asset-health");
+# strip any "<plugin>:" prefix before checking against this plugin's skills/ dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$SCRIPT_DIR/../../../skills"
+SKILL_BASENAME="${SKILL_NAME##*:}"
+[[ -d "$SKILLS_DIR/$SKILL_BASENAME" ]] || exit 0
+
 ARGS_PRESENT="$(printf '%s' "$HOOK_INPUT" | jq -r '((.tool_input.args // "") | length) > 0' 2>/dev/null || echo false)"
 
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
@@ -32,7 +40,6 @@ BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/
 
 # Resolve plugin version from plugin.json relative to this script's location.
 # Script path: <plugin_root>/hooks/telemetry/scripts/skill-beacon.sh
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_JSON="$SCRIPT_DIR/../../../.claude-plugin/plugin.json"
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 

--- a/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats
@@ -35,38 +35,59 @@ wait_for_log() {
 }
 
 @test "fires beacon with correct skill name" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"start-work","args":""}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health","args":""}}' | bash "$SCRIPT"
   wait_for_log
   payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
   [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Skill Invoked" ]
-  [ "$(echo "$payload" | jq -r '.skill')" = "start-work" ]
+  [ "$(echo "$payload" | jq -r '.skill')" = "asset-health" ]
   [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
   [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
 }
 
+@test "no beacon for skills outside mc-agent-toolkit" {
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"some-other-plugin-skill\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "no beacon for namespaced skills from other plugins" {
+  run bash -c 'echo "{\"tool_name\":\"Skill\",\"tool_input\":{\"skill\":\"superpowers:brainstorming\"}}" | bash "$0"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  sleep 0.2
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "fires beacon for plugin-namespaced toolkit skill" {
+  echo '{"tool_name":"Skill","tool_input":{"skill":"mc-agent-toolkit:asset-health"}}' | bash "$SCRIPT"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.skill')" = "mc-agent-toolkit:asset-health" ]
+}
+
 @test "skill_args_present is true when args non-empty" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":"phase 2"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health","args":"phase 2"}}' | bash "$SCRIPT"
   wait_for_log
   payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
   [ "$(echo "$payload" | jq -r '.skill_args_present')" = "true" ]
 }
 
 @test "skill_args_present is false when args empty or missing" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"hack"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health"}}' | bash "$SCRIPT"
   wait_for_log
   payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
   [ "$(echo "$payload" | jq -r '.skill_args_present')" = "false" ]
 }
 
 @test "skill_args_present is false when args is empty string" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":""}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health","args":""}}' | bash "$SCRIPT"
   wait_for_log
   payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
   [ "$(echo "$payload" | jq -r '.skill_args_present')" = "false" ]
 }
 
 @test "payload never contains args content" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"hack","args":"SECRET-PROMPT-TEXT"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health","args":"SECRET-PROMPT-TEXT"}}' | bash "$SCRIPT"
   wait_for_log
   # Search the raw log (covers argv, headers, body — every field mock_curl captured),
   # not just .data, so any future leak path is caught.
@@ -112,7 +133,7 @@ wait_for_log() {
 }
 
 @test "payload includes toolkit_version from plugin.json" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health"}}' | bash "$SCRIPT"
   wait_for_log
   payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
   version="$(echo "$payload" | jq -r '.toolkit_version')"
@@ -121,7 +142,7 @@ wait_for_log() {
 }
 
 @test "curl is called with -m 2 and the prod beacon URL by default" {
-  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health"}}' | bash "$SCRIPT"
   wait_for_log
   argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
   echo "$argv" | grep -q '"-m"'
@@ -131,7 +152,7 @@ wait_for_log() {
 
 @test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
   export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
-  echo '{"tool_name":"Skill","tool_input":{"skill":"x"}}' | bash "$SCRIPT"
+  echo '{"tool_name":"Skill","tool_input":{"skill":"asset-health"}}' | bash "$SCRIPT"
   wait_for_log
   argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'


### PR DESCRIPTION
## Summary

The `PreToolUse:Skill` telemetry hook added in [#74](https://github.com/monte-carlo-data/mc-agent-toolkit/pull/74) fires on every Skill tool invocation, regardless of which plugin owns the skill — so beacons were being sent for skills from `superpowers`, `anthropic-skills`, etc.

This change filters in [skill-beacon.sh](plugins/claude-code/hooks/telemetry/scripts/skill-beacon.sh) to only beacon for skills present under the toolkit's own `skills/` directory:

- Strips any `<plugin>:` namespace prefix from the incoming skill name.
- Checks that a directory by that name exists under `<plugin_root>/skills/`. If not, exits 0 silently (fail-closed, no beacon).
- Filesystem-based allowlist stays in sync automatically as toolkit skills are added/removed.
- Both bare (`asset-health`) and namespaced (`mc-agent-toolkit:asset-health`) forms are accepted.

## Test plan

- [x] All 16 bats tests pass (`bats plugins/claude-code/hooks/telemetry/tests/test_skill_beacon.bats`) — 13 existing + 3 new:
  - non-toolkit bare-name skill → no beacon
  - other-plugin namespaced skill (`superpowers:brainstorming`) → no beacon
  - toolkit skill in namespaced form (`mc-agent-toolkit:asset-health`) → fires
- [ ] Deferred until beacon endpoint is live in dev: confirm in a real Claude Code session that invoking a toolkit skill fires a beacon while invoking e.g. `/brainstorming` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)