### PR TITLE
chore(plugins): post-1.10.5 follow-ups — symlink guard, codex install fix, --sync-only

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  no-symlinks-under-hooks:
+    name: No symlinks under plugins/<editor>/hooks/
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find symlinks under hooks/
+        run: |
+          set -euo pipefail
+          symlinks=$(find plugins/claude-code plugins/cursor plugins/copilot plugins/codex \
+            -path '*/hooks/*' -type l 2>/dev/null || true)
+          if [[ -n "$symlinks" ]]; then
+            echo "::error::Symlinks under plugins/<editor>/hooks/ break marketplace installation."
+            echo "::error::The plugin cache materializes <editor>/ but not sibling plugins/shared/,"
+            echo "::error::so relative symlinks pointing outside the editor's subtree become dangling."
+            echo "::error::Use real file copies; edit plugins/shared/<skill>/lib/ and run"
+            echo "::error::./scripts/bump-version.sh --sync-only to propagate."
+            echo ""
+            echo "Offending symlinks:"
+            echo "$symlinks"
+            exit 1
+          fi
+          echo "OK: no symlinks under plugins/<editor>/hooks/"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ mc-agent-toolkit/
 └── SECURITY.md
 ```
 
-Plugins reference skills via symlinks so that skills are authored once and shared across all editor plugins. Shared hook logic lives in `plugins/shared/<skill>/lib/` as the canonical source and is **copied** (not symlinked) into each editor plugin's `hooks/<skill>/lib/` directory. The `bump-version.sh` script syncs these copies automatically at release time. If you edit shared hook logic, edit it in `plugins/shared/` and run `./scripts/bump-version.sh` to propagate.
+Plugins reference skills via symlinks so that skills are authored once and shared across all editor plugins. Shared hook logic lives in `plugins/shared/<skill>/lib/` as the canonical source and is **copied** (not symlinked) into each editor plugin's `hooks/<skill>/lib/` directory — symlinks under `hooks/` don't survive marketplace install, so a CI check (`.github/workflows/validate.yml`) blocks them. The `bump-version.sh` script syncs these copies automatically at release time. If you edit shared hook logic, edit it in `plugins/shared/` and run `./scripts/bump-version.sh --sync-only` to propagate without bumping the version.
 
 ## Adding a new skill
 
@@ -193,7 +193,7 @@ Setup and agent-routing skills are exempt from this rule. Setup skills are invok
 - For new skills: include example prompts that should trigger the skill.
 - For bug fixes: describe the incorrect behavior and how to reproduce.
 - Ensure skill symlinks are relative and resolve correctly (CI will verify this).
-- If you changed files in `plugins/shared/prevent/lib/`, run `./scripts/bump-version.sh` to sync copies to all editor plugins.
+- If you changed files in `plugins/shared/prevent/lib/`, run `./scripts/bump-version.sh --sync-only` to sync copies to all editor plugins without bumping the version. Symlinks under `plugins/<editor>/hooks/` are rejected by CI — see `.github/workflows/validate.yml`.
 - Run `git log --follow` on any moved files to confirm history is preserved.
 
 ## Version bumping

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -13,7 +13,6 @@ set -e
 PLUGIN_NAME="mc-agent-toolkit"
 REPO_URL="https://github.com/monte-carlo-data/mc-agent-toolkit.git"
 PLUGIN_SRC="plugins/codex"
-SHARED_LIB="plugins/codex/hooks/prevent/lib"
 SHARED_SKILLS=("skills/prevent" "skills/generate-validation-notebook" "skills/push-ingestion")
 
 CONFIG_DIR="$HOME/.codex"
@@ -84,13 +83,15 @@ if [ -d "$TARGET" ]; then
 fi
 
 # --- Copy plugin files (excluding symlinks) ---
+# hooks/prevent/lib is a real directory and is copied by the find/cpio pass.
+# Skills are symlinks pointing outside PLUGIN_SRC, so they're filtered here
+# and materialized as real directories in the loop below.
 mkdir -p "$TARGET"
 cd "$REPO_ROOT/$PLUGIN_SRC"
 find . -not -type l -not -path './__pycache__/*' -not -path './.pytest_cache/*' \
        -not -path './tests/*' -not -name '*.pyc' | cpio -pdm "$TARGET" 2>/dev/null
 
-# --- Copy symlink targets as real directories ---
-cp -R "$REPO_ROOT/$SHARED_LIB" "$TARGET/hooks/prevent/lib"
+# --- Materialize skills (symlinks were filtered above) ---
 mkdir -p "$TARGET/skills"
 for skill in "${SHARED_SKILLS[@]}"; do
   skill_name="$(basename "$skill")"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,12 +7,15 @@
 #
 # Usage:
 #   ./scripts/bump-version.sh <patch|minor|major|X.Y.Z> [--dry-run]
+#   ./scripts/bump-version.sh --sync-only [--dry-run]
 #
 # Examples:
-#   ./scripts/bump-version.sh patch          # 1.0.0 → 1.0.1
-#   ./scripts/bump-version.sh minor          # 1.0.0 → 1.1.0
-#   ./scripts/bump-version.sh 2.0.0          # Set explicit version
-#   ./scripts/bump-version.sh patch --dry-run  # Preview without changes
+#   ./scripts/bump-version.sh patch              # 1.0.0 → 1.0.1
+#   ./scripts/bump-version.sh minor              # 1.0.0 → 1.1.0
+#   ./scripts/bump-version.sh 2.0.0              # Set explicit version
+#   ./scripts/bump-version.sh patch --dry-run    # Preview without changes
+#   ./scripts/bump-version.sh --sync-only        # Re-sync plugins/shared/prevent/lib/
+#                                                # into all editor plugins (no version bump)
 #
 set -euo pipefail
 
@@ -47,22 +50,62 @@ CHANGELOG_FILES=(
 # ── Defaults ────────────────────────────────────────────────────────────────
 DRY_RUN=false
 BUMP_TYPE=""
+SYNC_ONLY=false
 
 # ── Parse arguments ─────────────────────────────────────────────────────────
 usage() {
   echo "Usage: $0 <patch|minor|major|X.Y.Z> [--dry-run]"
+  echo "       $0 --sync-only [--dry-run]"
   exit 1
 }
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
+    --sync-only) SYNC_ONLY=true ;;
     patch|minor|major) BUMP_TYPE="$arg" ;;
     [0-9]*.[0-9]*.[0-9]*)  BUMP_TYPE="explicit"; EXPLICIT_VERSION="$arg" ;;
     -h|--help) usage ;;
     *) echo "Unknown argument: $arg"; usage ;;
   esac
 done
+
+# ── Sync shared hook lib into all editor plugins ────────────────────────────
+# Run unconditionally as part of bump (after version is known) and as a
+# standalone op via --sync-only.
+sync_shared_lib() {
+  local SHARED_LIB_DIR="$REPO_ROOT/plugins/shared/prevent/lib"
+  local EDITOR_PLUGINS=(claude-code cursor copilot codex)
+  echo ""
+  if [[ ! -d "$SHARED_LIB_DIR" ]]; then
+    echo "Warning: $SHARED_LIB_DIR does not exist; skipping shared lib sync."
+    return
+  fi
+  for editor in "${EDITOR_PLUGINS[@]}"; do
+    local target="$REPO_ROOT/plugins/$editor/hooks/prevent/lib"
+    if [[ ! -d "$(dirname "$target")" ]]; then
+      continue
+    fi
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "[dry-run] Would sync shared lib → plugins/$editor/hooks/prevent/lib"
+    else
+      rm -rf "$target"
+      cp -R "$SHARED_LIB_DIR" "$target"
+      rm -rf "$target/__pycache__" "$target/tests"
+      find "$target" -name "*.pyc" -delete 2>/dev/null || true
+      echo "Synced shared lib → plugins/$editor/hooks/prevent/lib"
+    fi
+  done
+}
+
+if [[ "$SYNC_ONLY" == true ]]; then
+  if [[ -n "$BUMP_TYPE" ]]; then
+    echo "Error: --sync-only is incompatible with a version bump argument."
+    exit 1
+  fi
+  sync_shared_lib
+  exit 0
+fi
 
 [[ -z "$BUMP_TYPE" ]] && usage
 
@@ -141,27 +184,7 @@ fi
 
 rm -f "$TMPFILE"
 
-# ── Sync shared hook lib into all editor plugins ─────────────────────────
-SHARED_LIB_DIR="$REPO_ROOT/plugins/shared/prevent/lib"
-EDITOR_PLUGINS=(claude-code cursor copilot codex)
-
-echo ""
-if [[ -d "$SHARED_LIB_DIR" ]]; then
-  for editor in "${EDITOR_PLUGINS[@]}"; do
-    target="$REPO_ROOT/plugins/$editor/hooks/prevent/lib"
-    if [[ -d "$(dirname "$target")" ]]; then
-      if [[ "$DRY_RUN" == true ]]; then
-        echo "[dry-run] Would sync shared lib → plugins/$editor/hooks/prevent/lib"
-      else
-        rm -rf "$target"
-        cp -R "$SHARED_LIB_DIR" "$target"
-        rm -rf "$target/__pycache__" "$target/tests"
-        find "$target" -name "*.pyc" -delete 2>/dev/null || true
-        echo "Synced shared lib → plugins/$editor/hooks/prevent/lib"
-      fi
-    fi
-  done
-fi
+sync_shared_lib
 
 # ── Update version files ───────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Three follow-ups from the review of #82 (which fixed the 1.10.4 `ModuleNotFoundError: No module named 'lib'`), bundled in one PR.

- **CI symlink guard** (`.github/workflows/validate.yml`) — fails any PR that adds a symlink under `plugins/{claude-code,cursor,copilot,codex}/**/hooks/**`. Prevents a recurrence of the 1.10.4 class of bug.
- **Codex install fix** (`plugins/codex/scripts/install.sh`) — after #82 made `hooks/prevent/lib` a real directory, the cpio pass copies it normally, and the subsequent `cp -R "$SHARED_LIB" "$TARGET/.../lib"` nested the dir inside itself (BSD `cp -R` semantics produce `lib/lib/`). Drop the redundant `cp` and the now-unused `SHARED_LIB` variable.
- **`bump-version.sh --sync-only`** — refactor the sync block into a function and add a `--sync-only` flag so contributors editing `plugins/shared/prevent/lib/` can propagate changes without bumping a version. The existing release flow continues to call the same function inline.
- **CONTRIBUTING.md** — point contributors at `--sync-only` and the new CI guard.

No version bump needed; this is repo plumbing only.

## Test plan

- [x] `find plugins/{claude-code,cursor,copilot,codex} -path '*/hooks/*' -type l` is empty on main; a sentinel symlink is detected by the same find. Validate workflow will run on this PR.
- [x] `./scripts/bump-version.sh --sync-only --dry-run` lists the four sync targets and exits 0.
- [x] `./scripts/bump-version.sh --sync-only` rewrites `plugins/<editor>/hooks/prevent/lib/*.py` byte-for-byte from `plugins/shared/prevent/lib/`. No git diff after the run (the canonical state is already in sync).
- [x] `./scripts/bump-version.sh --sync-only patch` exits 1 with `--sync-only is incompatible with a version bump argument.`
- [x] `./scripts/bump-version.sh patch --dry-run` still previews both the sync and the version-bump phases — no regression to the existing release flow.
- [x] `bash plugins/codex/scripts/install.sh --local "$(pwd)" ~/codex-install-test` produces a single `hooks/prevent/lib/` (no nested `lib/lib/`); `python3 -c "from lib.safe_run import safe_run; from lib.protocol import HookInput, evaluate_turn_end"` succeeds against the installed tree.
- [na] No user-facing skill changes — no skill telemetry, prompts, or docs updated.
- [na] No version bump.