### PR TITLE
docs(skills): adopt create_or_update_*_monitor tools and preview-then-confirm flow

### DIFF
--- a/plugins/claude-code/evals/README.md
+++ b/plugins/claude-code/evals/README.md
@@ -99,7 +99,7 @@ Edit `<skill>/live-evals-<env>.yaml`. All cases use the `turns` format:
     - prompt: "Your prompt here"
       criteria:
         must_call: [get_warehouses]
-        must_not_call: [create_table_monitor_mac]
+        must_not_call: [create_or_update_table_monitor]
         output_must_not_contain: ["MCON++"]
   criteria:
     judge_rubric: |

--- a/plugins/claude-code/evals/monitoring-advisor/live-evals-dev.yaml
+++ b/plugins/claude-code/evals/monitoring-advisor/live-evals-dev.yaml
@@ -4,7 +4,7 @@ cases:
       - prompt: "What warehouses do I have access to?"
         criteria:
           must_call: [get_warehouses]
-          must_not_call: [create_table_monitor_mac, create_metric_monitor_mac]
+          must_not_call: [create_or_update_table_monitor, create_or_update_metric_monitor]
           output_must_not_contain: ["MCON++"]
     criteria:
       judge_rubric: |

--- a/plugins/claude-code/evals/monitoring-advisor/live-evals-prod.yaml
+++ b/plugins/claude-code/evals/monitoring-advisor/live-evals-prod.yaml
@@ -4,7 +4,7 @@ cases:
       - prompt: "What warehouses do I have access to?"
         criteria:
           must_call: [get_warehouses]
-          must_not_call: [create_table_monitor_mac, create_metric_monitor_mac]
+          must_not_call: [create_or_update_table_monitor, create_or_update_metric_monitor]
           output_must_not_contain: ["MCON++"]
     criteria:
       judge_rubric: |

--- a/plugins/claude-code/evals/prevent/live-evals-dev.yaml
+++ b/plugins/claude-code/evals/prevent/live-evals-dev.yaml
@@ -74,9 +74,9 @@ cases:
         monitor generation to the monitoring-advisor skill — not generate
         monitor YAML inline as part of prevent. The handoff is observable
         via the monitoring-advisor's MCP calls (one of:
-        get_validation_predicates, create_validation_monitor_mac,
-        create_metric_monitor_mac, create_comparison_monitor_mac,
-        create_custom_sql_monitor_mac) appearing in the turn 2 trace.
+        get_validation_predicates, create_or_update_validation_monitor,
+        create_or_update_metric_monitor, create_or_update_comparison_monitor,
+        create_or_update_sql_monitor) appearing in the turn 2 trace.
 
         The output should include monitor YAML (or describe the YAML) that
         targets the is_active column specifically — for example a validation

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -2,7 +2,7 @@
 name: monte-carlo-monitoring-advisor
 description: Analyze data coverage, create monitors for warehouse tables and AI agents. Covers coverage gaps, use-case analysis, data monitor creation, and agent observability.
 bucket: Monitoring
-version: 2.1.0
+version: 2.1.1
 ---
 
 # Monte Carlo Monitoring Advisor Skill

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -2,7 +2,7 @@
 name: monte-carlo-monitoring-advisor
 description: Analyze data coverage, create monitors for warehouse tables and AI agents. Covers coverage gaps, use-case analysis, data monitor creation, and agent observability.
 bucket: Monitoring
-version: 2.0.0
+version: 2.1.0
 ---
 
 # Monte Carlo Monitoring Advisor Skill
@@ -82,13 +82,15 @@ All tools are available via the `monte-carlo` MCP server.
 
 ### Data monitor creation tools
 
+All five tools follow a **two-call preview-then-confirm pattern**: the first call (with the default `dry_run=True`) returns rendered MaC YAML for review; the second call (`dry_run=False`) deploys the monitor live and returns a deep link to it. Pass `monitor_uuid` on either call to update an existing monitor in place instead of creating a new one. See `references/data-monitor-creation.md` for the full flow.
+
 | Tool | Purpose |
 | --- | --- |
-| `create_table_monitor_mac` | Generate table monitor YAML (dry-run) |
-| `create_metric_monitor_mac` | Generate metric monitor YAML (dry-run) |
-| `create_validation_monitor_mac` | Generate validation monitor YAML (dry-run) |
-| `create_custom_sql_monitor_mac` | Generate custom SQL monitor YAML (dry-run) |
-| `create_comparison_monitor_mac` | Generate comparison monitor YAML (dry-run) |
+| `create_or_update_table_monitor` | Create or update a table monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_metric_monitor` | Create or update a metric monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_validation_monitor` | Create or update a validation monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_sql_monitor` | Create or update a custom SQL monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_comparison_monitor` | Create or update a comparison monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 
 ### Agent monitoring tools
 
@@ -210,7 +212,7 @@ When coverage analysis leads to monitor creation, gather this context before rea
 
 ### Use-case tag monitors
 
-The most common output of coverage analysis is a **table monitor scoped by use-case tags** via `create_table_monitor_mac`. The `asset_selection` parameter uses this structure:
+The most common output of coverage analysis is a **table monitor scoped by use-case tags** via `create_or_update_table_monitor`. The `asset_selection` parameter uses this structure:
 
 ```json
 {

--- a/skills/monitoring-advisor/references/data-comparison-monitor.md
+++ b/skills/monitoring-advisor/references/data-comparison-monitor.md
@@ -1,6 +1,6 @@
 # Comparison Monitor Reference
 
-Detailed reference for building `create_comparison_monitor_mac` tool calls.
+Detailed reference for building `create_or_update_comparison_monitor` tool calls. The tool follows the **two-call preview-then-confirm pattern** — see `data-monitor-creation.md` for the full flow.
 
 ## Critical Constraints
 
@@ -49,6 +49,16 @@ Before constructing alert conditions, you MUST verify that both tables exist and
 | `target_warehouse` | string | Warehouse name or UUID for the target table. Required if `target_table` is not an MCON. |
 | `segment_fields` | array of string | Fields to segment the comparison by. Must exist in BOTH tables with the same name. |
 | `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
+| `schedule_type` | string | Schedule type: `"fixed"` (default), `"dynamic"`, `"manual"`. |
+| `interval_minutes` | int | Schedule interval in minutes (only for `schedule_type="fixed"`). |
+| `audiences` | array of string | Notification audience **names** (not UUIDs) to alert when the monitor triggers. |
+| `failure_audiences` | array of string | Notification audience names to alert on query execution failures. |
+| `notes` | string | Free-text notes shown in the UI (separate from `description`). |
+| `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
+| `tags` | array of `{name, value}` | Key-value tags to attach. |
+| `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-comparison-monitor.md
+++ b/skills/monitoring-advisor/references/data-comparison-monitor.md
@@ -57,7 +57,7 @@ Before constructing alert conditions, you MUST verify that both tables exist and
 | `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
 | `tags` | array of `{name, value}` | Key-value tags to attach. |
 | `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
-| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. **PUT semantics:** the call fully replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT left untouched. Before editing, read the current config with `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` and re-pass every field you want to keep. See `data-monitor-creation.md` (Step 7) for the safe-edit workflow. |
 | `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -1,6 +1,6 @@
 # Custom SQL Monitor Reference
 
-Detailed reference for building `create_custom_sql_monitor_mac` tool calls.
+Detailed reference for building `create_or_update_sql_monitor` tool calls. The tool follows the **two-call preview-then-confirm pattern** — see `data-monitor-creation.md` for the full flow.
 
 ## Critical Constraints
 
@@ -48,6 +48,19 @@ If you find yourself contorting another monitor type to fit the user's intent, s
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
+| `query_result_type` | string | What the SQL query returns — see the tool's enum for accepted values (single numeric is the most common). |
+| `custom_sampling_sql` | string | Optional SQL used to sample rows that contributed to the result (shown in alert detail). |
+| `variable_definitions` | object | Named variables that can be referenced in `sql` / `custom_sampling_sql`. |
+| `schedule_type` | string | Schedule type: `"fixed"` (default), `"dynamic"`, `"manual"`. |
+| `interval_minutes` | int | Schedule interval in minutes (only for `schedule_type="fixed"`). |
+| `audiences` | array of string | Notification audience **names** (not UUIDs) to alert when the monitor triggers. |
+| `failure_audiences` | array of string | Notification audience names to alert on query execution failures. |
+| `notes` | string | Free-text notes shown in the UI (separate from `description`). |
+| `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
+| `tags` | array of `{name, value}` | Key-value tags to attach. |
+| `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -59,7 +59,7 @@ If you find yourself contorting another monitor type to fit the user's intent, s
 | `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
 | `tags` | array of `{name, value}` | Key-value tags to attach. |
 | `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
-| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. **PUT semantics:** the call fully replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT left untouched. Before editing, read the current config with `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` and re-pass every field you want to keep. See `data-monitor-creation.md` (Step 7) for the safe-edit workflow. |
 | `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -1,6 +1,6 @@
 # Metric Monitor Reference
 
-Detailed reference for building `create_metric_monitor_mac` tool calls.
+Detailed reference for building `create_or_update_metric_monitor` tool calls. The tool follows the **two-call preview-then-confirm pattern** — see `data-monitor-creation.md` for the full flow.
 
 ## Critical Constraints
 
@@ -35,12 +35,25 @@ Use a metric monitor when the user wants to:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `aggregate_time_field` | string | none | Timestamp/datetime column for time-windowed aggregation. **When provided, MUST be a real column from the table — NEVER guess this value.** When omitted, the monitor queries all rows on each run (whole-table scan). Omit for tables without a suitable timestamp column. |
+| `aggregate_time_sql` | string | none | SQL expression that produces the timestamp for bucketing (e.g. `CAST(payload:event_time AS TIMESTAMP)`). Use when the timestamp is embedded in a variant/object column or needs transformation. Mutually exclusive with `aggregate_time_field`. |
 | `warehouse` | string | auto-resolved | Warehouse name or UUID. Required if `table` is not an MCON. |
 | `segment_fields` | array of string | none | Fields to group/segment metrics by (e.g., `["country", "status"]`). |
+| `segment_sql` | array of string | none | SQL expressions to segment by (e.g. `["CASE WHEN amount > 100 THEN 'high' ELSE 'low' END"]`). |
 | `aggregate_by` | string | `"day"` | Time interval: `"hour"`, `"day"`, `"week"`, `"month"`. |
 | `where_condition` | string | none | SQL WHERE clause (without `WHERE` keyword) to filter rows before computing metrics. |
+| `sensitivity` | string | none | Anomaly detection sensitivity for AUTO operators: `"low"`, `"medium"`, `"high"`. |
+| `collection_lag_hours` | int | none | Hours to wait after expected data arrival before running the monitor. |
+| `schedule_type` | string | `"fixed"` | Schedule type: `"fixed"`, `"dynamic"`, `"manual"`. |
 | `interval_minutes` | int | auto | Schedule interval in minutes. Must be compatible with `aggregate_by` (see note below). If not specified, the tool defaults to the minimum valid interval for the chosen `aggregate_by`. |
 | `domain_uuids` | array of string (uuid) | none | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
+| `audiences` | array of string | none | Notification audience **names** (not UUIDs) to alert when the monitor triggers. |
+| `failure_audiences` | array of string | none | Notification audience names to alert on query execution failures. |
+| `notes` | string | none | Free-text notes shown in the UI (separate from `description`). |
+| `priority` | string | none | Monitor priority (e.g. `"P1"`, `"P2"`). |
+| `tags` | array of `{name, value}` | none | Key-value tags to attach. |
+| `is_draft` | bool | `False` | When `True`, saves the monitor as a draft (not active). |
+| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `dry_run` | bool | `True` | Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -52,7 +52,7 @@ Use a metric monitor when the user wants to:
 | `priority` | string | none | Monitor priority (e.g. `"P1"`, `"P2"`). |
 | `tags` | array of `{name, value}` | none | Key-value tags to attach. |
 | `is_draft` | bool | `False` | When `True`, saves the monitor as a draft (not active). |
-| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. **PUT semantics:** the call fully replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT left untouched. Before editing, read the current config with `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` and re-pass every field you want to keep. See `data-monitor-creation.md` (Step 7) for the safe-edit workflow. |
 | `dry_run` | bool | `True` | Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -1,8 +1,15 @@
 # Data Monitor Creation Procedure
 
-This is the data monitor creation procedure for Monte Carlo warehouse tables. Use this reference when a user wants to create monitors for their data warehouse tables -- it walks through the full workflow from understanding the request through generating monitors-as-code (MaC) YAML.
+This is the data monitor creation procedure for Monte Carlo warehouse tables. Use this reference when a user wants to create monitors for their data warehouse tables -- it walks through the full workflow from understanding the request through generating monitors-as-code (MaC) YAML and (optionally) deploying the monitor.
 
-All creation tools run in **dry-run mode** and return MaC YAML. No monitors are created directly -- the user applies the YAML via the Monte Carlo CLI or CI/CD.
+All five `create_or_update_*_monitor` tools follow a **two-call preview-then-confirm pattern**:
+
+1. **First call -- preview.** Invoke with `dry_run=True` (this is the default -- you can omit the argument). The tool returns rendered MaC YAML in `result.yaml` and a DRY RUN notice in `result.instructions`. Show the YAML to the user and confirm.
+2. **Second call -- live create/update.** After the user confirms, invoke the same tool again with `dry_run=False` and the same other parameters. The tool actually creates or updates the monitor and returns `result.monitor_uuid` plus a `result.instructions` string containing a deep link `<webapp_url>/monitors/<monitor_uuid>` to the live monitor. `result.yaml` is intentionally `None` on this call -- the monitor is already deployed.
+
+To **update an existing monitor** instead of creating a new one, pass its `monitor_uuid`. This works on both the preview and live calls. To save the monitor as a draft (not active), pass `is_draft=True`.
+
+The user may also choose to skip the live call and take the preview YAML themselves and apply it via the Monte Carlo CLI or CI/CD. Always present the YAML on the preview call regardless.
 
 ---
 
@@ -89,12 +96,15 @@ For all other monitor types, the creation tools default to a fixed schedule runn
 
 1. **Fixed interval** -- any integer for `interval_minutes` (30, 60, 90, 120, 360, 720, 1440, etc.)
 2. **Dynamic** -- MC auto-determines when to run based on table update patterns.
-3. **Loose** -- runs once per day.
+3. **Manual** -- runs only on demand.
 
-Schedule format in MaC YAML:
-- Fixed: `schedule: { type: fixed, interval_minutes: <N> }`
-- Dynamic: `schedule: { type: dynamic }`
-- Loose: `schedule: { type: loose, start_time: "00:00" }`
+Pass the user's choice to the creation tool as `schedule_type` and (for fixed schedules) `interval_minutes`. **Both the preview (`dry_run=True`) and the live (`dry_run=False`) call must use the same schedule arguments** -- the tool re-renders the schedule from these parameters when it deploys, so editing the `schedule` section of the preview YAML by hand does NOT change what the live call creates. Without explicit arguments the backend falls back to fixed/60 regardless of what the YAML displayed to the user.
+
+Valid arguments:
+
+- Fixed: `schedule_type="fixed"`, `interval_minutes=<N>` (any integer, e.g. 30, 60, 90, 360, 720, 1440)
+- Dynamic: `schedule_type="dynamic"` (omit `interval_minutes`)
+- Manual: `schedule_type="manual"` (omit `interval_minutes`)
 
 ### Step 6: Confirm with the user
 
@@ -106,35 +116,51 @@ Before calling the creation tool, present the monitor configuration in plain lan
 - What it checks / what triggers an alert
 - Domain assignment
 - Schedule
+- Whether this is a new monitor or an in-place update (i.e. is `monitor_uuid` set?)
+- Whether to save as draft (`is_draft=True`) or active
 
 Ask: "Does this look correct? I'll generate the monitor configuration."
 
 ### Step 7: Create the monitor
 
-Call the appropriate creation tool with the parameters built in previous steps. Always pass an MCON when possible. If only table name is available, also pass warehouse.
+This step is a **two-call sequence**. Do NOT skip the preview call.
+
+1. **Preview call.** Call the appropriate creation tool with the parameters built in previous steps. Omit `dry_run` (it defaults to `True`) or pass `dry_run=True` explicitly. Always pass an MCON when possible. If only a table name is available, also pass `warehouse`. The tool returns rendered YAML in `result.yaml` and a DRY RUN notice in `result.instructions`. Present the YAML per Step 8 and ask the user to confirm before proceeding.
+2. **Live call.** After the user confirms and explicitly opts in to deploying directly, call the same tool again with **the same parameters** plus `dry_run=False`. The tool actually creates (or updates) the monitor; the response carries the new `monitor_uuid` and a deep link in `result.instructions`. On this call `result.yaml` is `None` by design -- the monitor is already deployed.
+
+**Updating an existing monitor.** If the user wants to edit a monitor they (or a previous call) already created, pass `monitor_uuid=<uuid>` on both the preview and live calls. The tool will update that monitor in place rather than creating a new one. Use a previously returned `monitor_uuid`, or look one up via `get_monitors`. If the underlying monitor was deleted between read and write, the tool will raise a clear error instructing you to retry without `monitor_uuid` (turning the intent from "update" into "create").
+
+**Drafts.** Pass `is_draft=True` to save the monitor in draft state (not active). Omit it to create the monitor as active.
 
 ### Step 8: Present results
 
-**CRITICAL: Always include the YAML in your response.** The user needs copy-pasteable YAML.
+Handle both response shapes.
 
-1. If a non-default schedule was chosen, modify the schedule section in the YAML before presenting.
-2. Wrap the YAML in the full MaC structure (see MaC YAML format below).
-3. ALWAYS present the full YAML in a ```yaml code block.
-4. Explain where to put it and how to apply it (see below).
-5. ALWAYS use ISO 8601 format for datetime values.
-6. **NEVER reformat YAML values returned by creation tools.**
+**Preview response (`dry_run=True`)** -- `result.yaml` is set; `result.monitor_uuid` is `None`; `result.instructions` includes a DRY RUN notice. You MUST include the YAML in your reply -- the user needs copy-pasteable YAML in the **same** message where you ask for confirmation. Do NOT refer back to "the YAML I showed you" or give deployment instructions without the actual YAML.
+
+1. The YAML comes verbatim from `result.yaml` -- the tool has already rendered the schedule from the `schedule_type` / `interval_minutes` you passed in. Do NOT post-edit the `schedule` section to change values; if the schedule is wrong, re-call the preview with corrected arguments.
+2. ALWAYS present the full YAML in a ```yaml code block. Present ALL YAML values exactly as returned by the tool. Do NOT reformat, convert, or "humanize" any values -- especially dates, timestamps, UUIDs, and identifiers.
+3. Wrap the YAML in the standard MaC structure before presenting it (see MaC YAML Format below).
+4. ALWAYS use ISO 8601 format for any datetime values you author (e.g. `start_time: '2026-03-25T09:00:00+00:00'`).
+5. **NEVER reformat YAML values returned by creation tools.**
+6. Explain the user's two options once they confirm: (a) let you re-call the tool with `dry_run=False` to deploy it directly in Monte Carlo, or (b) take the YAML and apply it themselves via Monte Carlo CLI or CI/CD.
+
+**Live response (`dry_run=False`)** -- `result.yaml` is `None`; `result.monitor_uuid` is the new (or updated) monitor's UUID; `result.instructions` contains a deep link of the form `<webapp_url>/monitors/<monitor_uuid>`.
+
+1. Confirm to the user that the monitor was created (or updated) and surface the deep link from `result.instructions` so they can click through to it in the Monte Carlo web app.
+2. Do NOT try to re-render or invent YAML -- it is intentionally not returned for live calls.
 
 ---
 
 ## Monitor Type Selection
 
-| Type           | Creation tool                  | Use when                                                                                                                               |
-| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Metric**     | `create_metric_monitor_mac`     | Track statistical metrics on fields (null rates, unique counts, numeric stats) or row count changes over time. Requires a timestamp field for aggregation. |
-| **Validation** | `create_validation_monitor_mac` | Row-level data quality checks with conditions (e.g. "field X is never null", "status is in allowed set"). Alerts on INVALID data.      |
-| **Custom SQL** | `create_custom_sql_monitor_mac` | Run arbitrary SQL returning a single number and alert on thresholds. Most flexible; use when other types don't fit.                    |
-| **Comparison** | `create_comparison_monitor_mac` | Compare metrics between two tables (e.g. dev vs prod, source vs target).                                                              |
-| **Table**      | `create_table_monitor_mac`      | Monitor groups of tables for freshness, schema changes, and volume. Uses asset selection at database/schema level.                     |
+| Type           | Creation tool                         | Use when                                                                                                                               |
+| -------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Metric**     | `create_or_update_metric_monitor`     | Track statistical metrics on fields (null rates, unique counts, numeric stats) or row count changes over time. Requires a timestamp field for aggregation. |
+| **Validation** | `create_or_update_validation_monitor` | Row-level data quality checks with conditions (e.g. "field X is never null", "status is in allowed set"). Alerts on INVALID data.      |
+| **Custom SQL** | `create_or_update_sql_monitor`        | Run arbitrary SQL returning a single number and alert on thresholds. Most flexible; use when other types don't fit.                    |
+| **Comparison** | `create_or_update_comparison_monitor` | Compare metrics between two tables (e.g. dev vs prod, source vs target).                                                              |
+| **Table**      | `create_or_update_table_monitor`      | Monitor groups of tables for freshness, schema changes, and volume. Uses asset selection at database/schema level.                     |
 
 Per-type reference files with detailed parameter guidance, constraints, and examples:
 - `data-metric-monitor.md`
@@ -147,7 +173,7 @@ Per-type reference files with detailed parameter guidance, constraints, and exam
 
 ## MaC YAML Format
 
-The YAML returned by creation tools is the monitor definition. It must be wrapped in the standard MaC structure to be applied:
+The YAML returned on the preview call (`dry_run=True`) is the monitor definition. It must be wrapped in the standard MaC structure to be applied:
 
 ```yaml
 montecarlo:
@@ -160,12 +186,12 @@ For example, a metric monitor would look like:
 ```yaml
 montecarlo:
   metric:
-    - <yaml returned by create_metric_monitor_mac>
+    - <yaml returned by create_or_update_metric_monitor>
 ```
 
 **Important:** `montecarlo.yml` (without a directory path) is a separate Monte Carlo project configuration file -- it is NOT the same as a monitor definition file. Monitor definitions go in their own `.yml` files, typically in a `monitors/` directory or alongside dbt model schema files.
 
-Tell the user:
+If the user prefers to deploy via CLI/CI rather than the live tool call:
 - Save the YAML to a `.yml` file (e.g. `monitors/<table_name>.yml` or in their dbt schema)
 - Apply via the Monte Carlo CLI: `montecarlo monitors apply --namespace <namespace>`
 - Or integrate into CI/CD for automatic deployment on merge
@@ -183,9 +209,10 @@ All tools are available via the `monte-carlo` MCP server.
 | `get_table`                     | Schema, stats, metadata, domain membership, capabilities     |
 | `get_validation_predicates`     | List available validation rule types for a warehouse         |
 | `get_domains`                   | List MC domains (only needed if table has no domain info)    |
-| `get_warehouses`                | Resolve warehouse UUIDs from names; needed when a name is the only identifier |
-| `create_metric_monitor_mac`     | Generate metric monitor YAML (dry-run)                       |
-| `create_validation_monitor_mac` | Generate validation monitor YAML (dry-run)                   |
-| `create_comparison_monitor_mac` | Generate comparison monitor YAML (dry-run)                   |
-| `create_custom_sql_monitor_mac` | Generate custom SQL monitor YAML (dry-run)                   |
-| `create_table_monitor_mac`      | Generate table monitor YAML (dry-run)                        |
+| `get_warehouses`                          | Resolve warehouse UUIDs from names; needed when a name is the only identifier |
+| `get_monitors`                            | Look up an existing monitor's UUID for in-place updates via `monitor_uuid` |
+| `create_or_update_metric_monitor`         | Create or update a metric monitor (preview on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_validation_monitor`     | Create or update a validation monitor (preview on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_comparison_monitor`     | Create or update a comparison monitor (preview on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_sql_monitor`            | Create or update a custom SQL monitor (preview on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_table_monitor`          | Create or update a table monitor (preview on `dry_run=True`, deploy on `dry_run=False`) |

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -7,7 +7,7 @@ All five `create_or_update_*_monitor` tools follow a **two-call preview-then-con
 1. **First call -- preview.** Invoke with `dry_run=True` (this is the default -- you can omit the argument). The tool returns rendered MaC YAML in `result.yaml` and a DRY RUN notice in `result.instructions`. Show the YAML to the user and confirm.
 2. **Second call -- live create/update.** After the user confirms, invoke the same tool again with `dry_run=False` and the same other parameters. The tool actually creates or updates the monitor and returns `result.monitor_uuid` plus a `result.instructions` string containing a deep link `<webapp_url>/monitors/<monitor_uuid>` to the live monitor. `result.yaml` is intentionally `None` on this call -- the monitor is already deployed.
 
-To **update an existing monitor** instead of creating a new one, pass its `monitor_uuid`. This works on both the preview and live calls. To save the monitor as a draft (not active), pass `is_draft=True`.
+To **update an existing monitor** instead of creating a new one, pass its `monitor_uuid`. This works on both the preview and live calls. **Important:** `create_or_update_*_monitor` with `monitor_uuid` has **PUT semantics** -- the call fully replaces the monitor's configuration. Fields you omit revert to the tool's defaults; they are NOT left untouched. See Step 7 ("Updating an existing monitor") for the safe-edit workflow. To save the monitor as a draft (not active), pass `is_draft=True`.
 
 The user may also choose to skip the live call and take the preview YAML themselves and apply it via the Monte Carlo CLI or CI/CD. Always present the YAML on the preview call regardless.
 
@@ -129,6 +129,12 @@ This step is a **two-call sequence**. Do NOT skip the preview call.
 2. **Live call.** After the user confirms and explicitly opts in to deploying directly, call the same tool again with **the same parameters** plus `dry_run=False`. The tool actually creates (or updates) the monitor; the response carries the new `monitor_uuid` and a deep link in `result.instructions`. On this call `result.yaml` is `None` by design -- the monitor is already deployed.
 
 **Updating an existing monitor.** If the user wants to edit a monitor they (or a previous call) already created, pass `monitor_uuid=<uuid>` on both the preview and live calls. The tool will update that monitor in place rather than creating a new one. Use a previously returned `monitor_uuid`, or look one up via `get_monitors`. If the underlying monitor was deleted between read and write, the tool will raise a clear error instructing you to retry without `monitor_uuid` (turning the intent from "update" into "create").
+
+**PUT semantics -- do not skip this step.** `create_or_update_*_monitor` with `monitor_uuid` replaces the monitor configuration in full. Every parameter you omit reverts to the tool's default (e.g. schedule resets to fixed/60 minutes); it is NOT left untouched. To edit safely:
+
+1. **Read the current config first.** Call `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` to get the full monitor configuration. `config` is excluded by default for performance -- you must request it explicitly.
+2. **Carry over every value you want to keep**, in addition to the ones you're changing. Do not pass only the changed fields -- anything you leave out is overwritten with the tool default.
+3. **Preview with `dry_run=True` and diff** the rendered YAML against the original config. If anything you meant to preserve is missing or changed, fix the call before running `dry_run=False`.
 
 **Drafts.** Pass `is_draft=True` to save the monitor in draft state (not active). Omit it to create the monitor as active.
 

--- a/skills/monitoring-advisor/references/data-table-monitor.md
+++ b/skills/monitoring-advisor/references/data-table-monitor.md
@@ -48,7 +48,7 @@ Use a table monitor when the user wants to:
 | `priority` | string | none | Monitor priority (e.g. `"P1"`, `"P2"`). |
 | `tags` | array of `{name, value}` | none | Key-value tags to attach. |
 | `is_draft` | bool | `False` | When `True`, saves the monitor as a draft (not active). |
-| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. **PUT semantics:** the call fully replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT left untouched. Before editing, read the current config with `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` and re-pass every field you want to keep. See `data-monitor-creation.md` (Step 7) for the safe-edit workflow. |
 | `dry_run` | bool | `True` | Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---

--- a/skills/monitoring-advisor/references/data-table-monitor.md
+++ b/skills/monitoring-advisor/references/data-table-monitor.md
@@ -1,6 +1,6 @@
 # Table Monitor Reference
 
-Detailed reference for building `create_table_monitor_mac` tool calls.
+Detailed reference for building `create_or_update_table_monitor` tool calls. The tool follows the **two-call preview-then-confirm pattern** — see `data-monitor-creation.md` for the full flow.
 
 ## Critical Constraints
 
@@ -42,6 +42,14 @@ Use a table monitor when the user wants to:
 |-----------|------|---------|-------------|
 | `alert_conditions` | array of strings | `["last_updated_on", "schema", "total_row_count", "total_row_count_last_changed_on"]` | Metric names to monitor (see Alert Conditions below). |
 | `domain_uuids` | array of string (uuid) | none | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
+| `audiences` | array of string | none | Notification audience **names** (not UUIDs) to alert when the monitor triggers. |
+| `failure_audiences` | array of string | none | Notification audience names to alert on query execution failures. |
+| `notes` | string | none | Free-text notes shown in the UI (separate from `description`). |
+| `priority` | string | none | Monitor priority (e.g. `"P1"`, `"P2"`). |
+| `tags` | array of `{name, value}` | none | Key-value tags to attach. |
+| `is_draft` | bool | `False` | When `True`, saves the monitor as a draft (not active). |
+| `monitor_uuid` | string (uuid) | none | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `dry_run` | bool | `True` | Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---
 

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -75,7 +75,7 @@ Before constructing the `alert_condition`, verify that every field name you plan
 | `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
 | `tags` | array of `{name, value}` | Key-value tags to attach. |
 | `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
-| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. **PUT semantics:** the call fully replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT left untouched. Before editing, read the current config with `get_monitors(monitor_ids=[<uuid>], include_fields=["config"])` and re-pass every field you want to keep. See `data-monitor-creation.md` (Step 7) for the safe-edit workflow. |
 | `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---

--- a/skills/monitoring-advisor/references/data-validation-monitor.md
+++ b/skills/monitoring-advisor/references/data-validation-monitor.md
@@ -1,6 +1,6 @@
 # Validation Monitor Reference
 
-Detailed reference for building `create_validation_monitor_mac` tool calls.
+Detailed reference for building `create_or_update_validation_monitor` tool calls. The tool follows the **two-call preview-then-confirm pattern** — see `data-monitor-creation.md` for the full flow.
 
 ## Critical Constraints
 
@@ -67,6 +67,16 @@ Before constructing the `alert_condition`, verify that every field name you plan
 |-----------|------|-------------|
 | `warehouse` | string | Warehouse name or UUID. Required if `table` is not an MCON. |
 | `domain_uuids` | array of string (uuid) | Domain UUIDs (use `get_domains` to list). Data monitors accept exactly one UUID in the list. |
+| `schedule_type` | string | Schedule type: `"fixed"` (default), `"dynamic"`, `"manual"`. |
+| `interval_minutes` | int | Schedule interval in minutes (only for `schedule_type="fixed"`). |
+| `audiences` | array of string | Notification audience **names** (not UUIDs) to alert when the monitor triggers. |
+| `failure_audiences` | array of string | Notification audience names to alert on query execution failures. |
+| `notes` | string | Free-text notes shown in the UI (separate from `description`). |
+| `priority` | string | Monitor priority (e.g. `"P1"`, `"P2"`). |
+| `tags` | array of `{name, value}` | Key-value tags to attach. |
+| `is_draft` | bool | When `True`, saves the monitor as a draft (not active). Default `False`. |
+| `monitor_uuid` | string (uuid) | UUID of an existing monitor to update in place. Omit to create a new monitor. Look up via `get_monitors` or use the UUID returned by a previous `dry_run=False` call. |
+| `dry_run` | bool | Default `True`. Preview mode. When omitted or `True`, returns YAML preview in `result.yaml`. When `False`, actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions`. See `data-monitor-creation.md`. |
 
 ---
 
@@ -410,7 +420,7 @@ Verify that `email` and `phone` exist in the table schema from `get_table` befor
 
 ## Fallback: Custom SQL Monitor
 
-If `create_validation_monitor_mac` fails -- for example because a referenced column does not exist yet in the live table, or the warehouse does not support a particular predicate -- fall back to `create_custom_sql_monitor_mac` with an explicit SQL query instead.
+If `create_or_update_validation_monitor` fails -- for example because a referenced column does not exist yet in the live table, or the warehouse does not support a particular predicate -- fall back to `create_or_update_sql_monitor` with an explicit SQL query instead.
 
 A custom SQL monitor lets you express any validation logic as a SQL query that returns rows or a count. This is always available as a backup when the structured validation condition tree cannot express what you need or encounters an API error.
 
@@ -418,5 +428,5 @@ When falling back:
 
 1. Translate the intended validation logic into a SQL query.
 2. The SQL should select rows that violate the rule (matching the same "conditions match INVALID data" principle).
-3. Use `create_custom_sql_monitor_mac` with the translated query.
+3. Use `create_or_update_sql_monitor` with the translated query.
 4. Inform the user that you used a custom SQL monitor as a fallback and explain why.

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: |
   Invoke when the user wants to tune, reduce noise on, or adjust sensitivity for a Monte Carlo monitor.
   Example triggers: "tune monitor <uuid>", "this monitor is too noisy", "reduce alerts on this monitor", "adjust sensitivity for <uuid>".
 bucket: Monitoring
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Tune Monitor: Noise Reduction Analysis
@@ -38,12 +38,14 @@ them:
 |---|---|
 | `get_monitor_report` | Fetch a monitor's alert history, incident details, and troubleshooting summaries |
 | `get_monitors` | Fetch monitor configuration (type, thresholds, schedule, segments) |
-| `create_metric_monitor` | Update a metric monitor's configuration (used in Phase 5) |
-| `create_custom_sql_monitor` | Update a custom SQL monitor's configuration (used in Phase 5) |
-| `create_validation_monitor` | Update a validation monitor's configuration (used in Phase 5) |
+| `create_or_update_metric_monitor` | Update a metric monitor in place (pass `monitor_uuid`; used in Phase 5) |
+| `create_or_update_sql_monitor` | Update a custom SQL monitor in place (pass `monitor_uuid`; used in Phase 5) |
+| `create_or_update_validation_monitor` | Update a validation monitor in place (pass `monitor_uuid`; used in Phase 5) |
 | `tune_freshness_table_monitor` | Tune freshness sensitivity/threshold for a table (used in Phase 5) |
 | `tune_volume_change_table_monitor` | Tune volume change sensitivity/threshold for a table (used in Phase 5) |
 | `tune_unchanged_size_table_monitor` | Tune unchanged size sensitivity/threshold for a table (used in Phase 5) |
+
+All three `create_or_update_*_monitor` tools follow a **two-call preview-then-confirm pattern**: the first call (with the default `dry_run=True`) returns the rendered MaC YAML for review in `result.yaml`; the second call (`dry_run=False`) deploys the change live and returns a deep link in `result.instructions`. **Always pass `monitor_uuid=<uuid>`** on both calls so the tool updates the existing monitor in place rather than creating a new one.
 
 ---
 

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: |
   Invoke when the user wants to tune, reduce noise on, or adjust sensitivity for a Monte Carlo monitor.
   Example triggers: "tune monitor <uuid>", "this monitor is too noisy", "reduce alerts on this monitor", "adjust sensitivity for <uuid>".
 bucket: Monitoring
-version: 1.1.0
+version: 1.1.1
 ---
 
 # Tune Monitor: Noise Reduction Analysis

--- a/skills/tune-monitor/references/custom-sql-monitor.md
+++ b/skills/tune-monitor/references/custom-sql-monitor.md
@@ -99,7 +99,14 @@ Use `create_or_update_sql_monitor` to update the monitor in place.
 
 - **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
 - **NEVER** apply changes without showing the dry-run preview first.
+- **CRITICAL: PUT semantics.** `create_or_update_sql_monitor` with `monitor_uuid` fully replaces
+  the monitor's configuration — fields you omit revert to tool defaults, they are NOT left
+  untouched. The full config from Phase 1's `get_monitors(monitor_ids=[<uuid>],
+  include_fields=["config"])` call is your source of truth: re-pass every field you want to
+  keep (sql, all alert_conditions, schedule, warehouse, audiences, notes, priority, tags, etc.)
+  alongside the ones you're changing.
+- **Diff the preview against the original.** Before running `dry_run=False`, compare the
+  rendered YAML returned in `result.yaml` against the original config — if anything you meant to
+  preserve is missing or changed, fix the call before committing.
 - **CRITICAL:** When modifying the SQL query, ensure the query still returns a single numeric
   value. A query that returns multiple rows or non-numeric data will break the monitor.
-- **IMPORTANT:** If the monitor has multiple alert conditions, ensure all conditions are included
-  in the update — the tool replaces the full config, not individual conditions.

--- a/skills/tune-monitor/references/custom-sql-monitor.md
+++ b/skills/tune-monitor/references/custom-sql-monitor.md
@@ -81,15 +81,24 @@ dialect:
 
 ## Applying changes
 
-Use `create_custom_sql_monitor` to update the monitor.
+Use `create_or_update_sql_monitor` to update the monitor in place.
 
-1. **Always pass the existing identifier** to update rather than create a new monitor.
-2. **Always dry-run first** — show the user the preview and ask for confirmation before applying.
-3. **On confirmation**, apply the change.
+1. **Always pass `monitor_uuid=<uuid>`** so the tool updates the existing monitor rather than
+   creating a new one. Use the monitor UUID from Phase 1.
+2. **Always dry-run first** (`dry_run=True`, the default) — show the user the YAML preview
+   returned in `result.yaml` and ask for confirmation before applying.
+3. **On confirmation**, call again with `dry_run=False` (and the same `monitor_uuid` plus the
+   same other parameters). The response carries the monitor's UUID in `result.monitor_uuid` and
+   a deep link in `result.instructions` — surface that to the user. `result.yaml` is `None` on
+   the live call by design.
+4. **Stale-uuid handling.** If the monitor was deleted between read and write, the tool raises a
+   clear error instructing you to retry without `monitor_uuid` (turning the intent from "update"
+   into "create"). Confirm with the user before recreating.
 
 ### Common mistakes
 
-- **NEVER** apply changes without showing the preview first.
+- **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
+- **NEVER** apply changes without showing the dry-run preview first.
 - **CRITICAL:** When modifying the SQL query, ensure the query still returns a single numeric
   value. A query that returns multiple rows or non-numeric data will break the monitor.
 - **IMPORTANT:** If the monitor has multiple alert conditions, ensure all conditions are included

--- a/skills/tune-monitor/references/metric-monitor.md
+++ b/skills/tune-monitor/references/metric-monitor.md
@@ -89,18 +89,23 @@ Recommend reviewing whether the metric and field combination is the right approa
 
 ## Applying changes
 
-Use `create_metric_monitor` to update the monitor.
+Use `create_or_update_metric_monitor` to update the monitor in place.
 
-1. **Always pass the existing `uuid`** to update rather than create a new monitor.
-2. **Always dry-run first** (`dry_run=True`, the default) — show the user the YAML preview and
-   ask for confirmation before applying.
-3. **On confirmation**, call again with `dry_run=False`.
-4. **Check the returned UUID** — if it differs from the one you passed, tell the user the old
-   monitor was replaced with a new one.
+1. **Always pass `monitor_uuid=<uuid>`** so the tool updates the existing monitor rather than
+   creating a new one. Use the monitor UUID from Phase 1.
+2. **Always dry-run first** (`dry_run=True`, the default) — show the user the YAML preview
+   returned in `result.yaml` and ask for confirmation before applying.
+3. **On confirmation**, call again with `dry_run=False` (and the same `monitor_uuid` plus the
+   same other parameters). The response carries the monitor's UUID in `result.monitor_uuid` and
+   a deep link in `result.instructions` — surface that to the user. `result.yaml` is `None` on
+   the live call by design.
+4. **Stale-uuid handling.** If the monitor was deleted between read and write, the tool raises a
+   clear error instructing you to retry without `monitor_uuid` (turning the intent from "update"
+   into "create"). Confirm with the user before recreating.
 
 ### Common mistakes
 
-- **NEVER** omit the `uuid` field — this creates a duplicate monitor instead of updating.
+- **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
 - **NEVER** apply changes without showing the dry-run preview first.
 - **IMPORTANT:** When updating a single field (e.g., `where_condition`), you must still pass all
   required parameters. The tool replaces the full config, not individual fields.

--- a/skills/tune-monitor/references/metric-monitor.md
+++ b/skills/tune-monitor/references/metric-monitor.md
@@ -107,5 +107,12 @@ Use `create_or_update_metric_monitor` to update the monitor in place.
 
 - **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
 - **NEVER** apply changes without showing the dry-run preview first.
-- **IMPORTANT:** When updating a single field (e.g., `where_condition`), you must still pass all
-  required parameters. The tool replaces the full config, not individual fields.
+- **CRITICAL: PUT semantics.** `create_or_update_metric_monitor` with `monitor_uuid` fully
+  replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT
+  left untouched. The full config from Phase 1's `get_monitors(monitor_ids=[<uuid>],
+  include_fields=["config"])` call is your source of truth: re-pass every field you want to
+  keep (schedule, audiences, segment_fields, where_condition, sensitivity, collection_lag_hours,
+  notes, priority, tags, etc.) alongside the ones you're changing.
+- **Diff the preview against the original.** Before running `dry_run=False`, compare the
+  rendered YAML returned in `result.yaml` against the original config — if anything you meant to
+  preserve is missing or changed, fix the call before committing.

--- a/skills/tune-monitor/references/table-monitor.md
+++ b/skills/tune-monitor/references/table-monitor.md
@@ -94,7 +94,7 @@ switch to explicit thresholds if:
 
 ## Applying changes
 
-Table monitor tuning uses per-metric tools — **not** `create_table_monitor`:
+Table monitor tuning uses per-metric tools — **not** `create_or_update_table_monitor`:
 
 | Metric | Tool |
 |---|---|

--- a/skills/tune-monitor/references/validation-monitor.md
+++ b/skills/tune-monitor/references/validation-monitor.md
@@ -97,16 +97,25 @@ If TSA is absent and the monitor is noisy, say so explicitly:
 
 ## Applying changes
 
-Use `create_validation_monitor` to update the monitor.
+Use `create_or_update_validation_monitor` to update the monitor in place.
 
-1. **Always pass the existing identifier** to update rather than create a new monitor.
-2. **Always preview first** — show the user the full updated `alert_condition` tree and ask
-   for confirmation before applying.
-3. **On confirmation**, apply the change.
+1. **Always pass `monitor_uuid=<uuid>`** so the tool updates the existing monitor rather than
+   creating a new one. Use the monitor UUID from Phase 1.
+2. **Always dry-run first** (`dry_run=True`, the default) — show the user the YAML preview
+   returned in `result.yaml`, including the full updated `alert_condition` tree, and ask for
+   confirmation before applying.
+3. **On confirmation**, call again with `dry_run=False` (and the same `monitor_uuid` plus the
+   same other parameters). The response carries the monitor's UUID in `result.monitor_uuid` and
+   a deep link in `result.instructions` — surface that to the user. `result.yaml` is `None` on
+   the live call by design.
+4. **Stale-uuid handling.** If the monitor was deleted between read and write, the tool raises a
+   clear error instructing you to retry without `monitor_uuid` (turning the intent from "update"
+   into "create"). Confirm with the user before recreating.
 
 ### Common mistakes
 
-- **NEVER** apply changes without showing the preview first.
+- **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
+- **NEVER** apply changes without showing the dry-run preview first.
 - **CRITICAL:** The `alert_condition` must be a dict (JSON object), never a JSON-encoded string.
 - **IMPORTANT:** Always produce the full `alert_condition` tree, not just the changed node.
   The tool replaces the entire condition tree.

--- a/skills/tune-monitor/references/validation-monitor.md
+++ b/skills/tune-monitor/references/validation-monitor.md
@@ -116,6 +116,15 @@ Use `create_or_update_validation_monitor` to update the monitor in place.
 
 - **NEVER** omit `monitor_uuid` — this creates a duplicate monitor instead of updating.
 - **NEVER** apply changes without showing the dry-run preview first.
+- **CRITICAL: PUT semantics.** `create_or_update_validation_monitor` with `monitor_uuid` fully
+  replaces the monitor's configuration — fields you omit revert to tool defaults, they are NOT
+  left untouched. The full config from Phase 1's `get_monitors(monitor_ids=[<uuid>],
+  include_fields=["config"])` call is your source of truth: re-pass every field you want to
+  keep (the full alert_condition tree, schedule, table, audiences, notes, priority, tags, etc.)
+  alongside the ones you're changing.
+- **Diff the preview against the original.** Before running `dry_run=False`, compare the
+  rendered YAML returned in `result.yaml` against the original config — if anything you meant to
+  preserve is missing or changed, fix the call before committing.
 - **CRITICAL:** The `alert_condition` must be a dict (JSON object), never a JSON-encoded string.
 - **IMPORTANT:** Always produce the full `alert_condition` tree, not just the changed node.
   The tool replaces the entire condition tree.


### PR DESCRIPTION
## Summary

- Renames every `create_*_monitor_mac` reference in skill docs to the new `create_or_update_{table,metric,validation,sql,comparison}_monitor` tools introduced in [ai-agent#998](https://github.com/monte-carlo-data/ai-agent/pull/998).
- Documents the **two-call preview-then-confirm flow** that those tools enforce: `dry_run=True` (the default) returns rendered MaC YAML in `result.yaml`; `dry_run=False` actually creates/updates the monitor and returns `result.monitor_uuid` + a deep link in `result.instructions` (with `result.yaml=None` by design).
- Documents `monitor_uuid` for **update-in-place**, `is_draft` for draft mode, and the parity params (`schedule_type`, `interval_minutes`, `audiences`, `failure_audiences`, `notes`, `priority`, `tags`, plus per-type extras like `aggregate_time_sql`/`segment_sql`/`sensitivity`/`collection_lag_hours` on metric, `query_result_type`/`custom_sampling_sql`/`variable_definitions` on SQL).
- Migrates the **tune-monitor** skill off the now-extended-only direct-GraphQL `create_metric_monitor` / `create_custom_sql_monitor` / `create_validation_monitor` tools (hidden from the public default toolset) onto `create_or_update_*_monitor` with `monitor_uuid` for in-place updates.
- Updates `plugins/claude-code/evals/{monitoring-advisor,prevent}/live-evals-*.yaml` and the eval README example to assert the new tool names in `must_call` / `must_not_call`.
- Bumps `monitoring-advisor` to **2.1.0** and `tune-monitor` to **1.1.0**.

Plugin-level CHANGELOGs are left for the next release cut (no Unreleased section convention in this repo).

## Test plan

- [ ] Spot-check the rendered skill docs to confirm tool names + preview/confirm flow read coherently end-to-end.
- [ ] Run the `monitoring-advisor` live evals (`plugins/claude-code/evals/monitoring-advisor/live-evals-{dev,prod}.yaml`) against the updated dev MCP server — confirms the new tool names match what the server actually exposes in the default toolset.
- [ ] Run the `prevent` live eval (`live-04-monitor-delegation`) and confirm the turn-2 trace shows one of the new `create_or_update_*_monitor` calls.
- [ ] Manually exercise the tune-monitor apply step against a sandbox monitor: `dry_run=True` returns YAML, `dry_run=False` updates in place and returns the deep link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)