### PR TITLE
chore(plugin): metadata polish + MC_PREVENT_HOOKS_DISABLED kill-switch — v1.11.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,8 @@
         {
             "name": "mc-agent-toolkit",
             "source": "./plugins/claude-code",
-            "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents."
+            "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
+            "category": "monitoring"
         }
     ]
 }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,11 +1,13 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.11.0",
-  "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
+  "version": "1.11.1",
+  "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",
-    "url": "https://www.montecarlodata.com"
+    "url": "https://www.montecarlodata.com",
+    "email": "support@montecarlodata.com"
   },
+  "homepage": "https://docs.getmontecarlo.com/docs/agent-toolkit",
   "repository": "https://github.com/monte-carlo-data/mc-agent-toolkit",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-13
+
+### Added
+
+- Add `MC_PREVENT_HOOKS_DISABLED=1` env var to disable prevent hooks (block-edit, pre-commit, turn-end) for users who want the skills without the gating behavior.
+
+### Changed
+
+- Clarify telemetry disclosure in plugin README: explicit opt-out instructions and confirmation that no prompts/arguments/code are sent.
+- Polish `plugin.json` metadata for Anthropic plugin directory submission (expanded description, `author.email`, `homepage`).
+- Add `"category": "monitoring"` to the marketplace.json entry.
+
 ## [1.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -35,13 +35,11 @@ Restart Claude Code after installing.
 
 ## Telemetry
 
-The toolkit sends anonymous skill-usage telemetry — which skills are invoked, how often. Each event includes an opaque per-install UUID and a per-session UUID, the skill name, and the toolkit version.
+The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, and the toolkit version. No prompts, arguments, or code are ever sent.
 
-To disable, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment. The toolkit will not phone home.
+To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Claude Code. The toolkit will not phone home.
 
-The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in.
-
-The UUIDs are generated locally on first session and stored under `~/.claude/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in. The UUIDs are generated locally on first session and stored under `~/.claude/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
 
 ## Available Features
 
@@ -53,7 +51,11 @@ The UUIDs are generated locally on first session and stored under `~/.claude/mc-
 | **Push Ingestion** | Generates warehouse-specific collection scripts for pushing metadata, lineage, and query logs to Monte Carlo. Includes 10 `/mc-*` slash commands. | [Skill README](../../skills/push-ingestion/README.md) |
 | **Automated Triage** | Guides you through automated alert triage — scoring, deep troubleshooting, classification, and actions. Requires extended MCP toolset. | [SKILL](../../skills/automated-triage/SKILL.md) |
 
-The Prevent feature includes hooks that enforce the impact-assessment-first workflow. See the [Prevent Hook Behavior](../README.md#prevent-hook-behavior) section in the plugins README for details.
+The Prevent feature includes **PreToolUse hooks that can block edits to dbt SQL files** until an impact assessment runs. The hooks only fire on `.sql` files inside dbt model, macro, or snapshot directories — they do not affect non-dbt files.
+
+**To disable the Prevent hooks**, set `MC_PREVENT_HOOKS_DISABLED=1` in your environment (e.g. in your `.zshrc` or `.bashrc`, or via `.claude/settings.json` under `env`). The hooks will exit immediately without blocking any edits.
+
+See the [Prevent Hook Behavior](../README.md#prevent-hook-behavior) section in the plugins README for full details on scope and configuration.
 
 ## Updating
 

--- a/plugins/claude-code/hooks/prevent/lib/protocol.py
+++ b/plugins/claude-code/hooks/prevent/lib/protocol.py
@@ -118,12 +118,18 @@ def _get_staged_model_tables(cwd: str) -> list[str]:
 
 # --- Decision functions ---
 
+def _prevent_hooks_disabled() -> bool:
+    return os.environ.get("MC_PREVENT_HOOKS_DISABLED", "").strip() == "1"
+
+
 def evaluate_pre_edit(inp: HookInput) -> HookOutput:
     """Gate logic: should this file edit be allowed?
 
     Returns deny if impact assessment hasn't run for this table,
     noop if the edit should proceed.
     """
+    if _prevent_hooks_disabled():
+        return HookOutput()
     cleanup_stale_cache()
 
     file_path = inp.file_path or ""
@@ -231,6 +237,8 @@ def evaluate_post_edit(inp: HookInput) -> HookOutput:
 
 def evaluate_pre_commit(inp: HookInput) -> HookOutput:
     """Commit checkpoint: prompt for validation if dbt models are staged."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     command = inp.command or ""
     if "git commit" not in command:
         return HookOutput()
@@ -266,6 +274,8 @@ def evaluate_pre_commit(inp: HookInput) -> HookOutput:
 
 def evaluate_turn_end(inp: HookInput) -> HookOutput:
     """End of turn: prompt for validation queries if dbt models were edited."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     if inp.stop_hook_active:
         return HookOutput()
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-13
+
+### Added
+
+- Add `MC_PREVENT_HOOKS_DISABLED=1` env var to disable prevent hooks (block-edit, pre-commit, turn-end) for users who want the skills without the gating behavior.
+
+### Changed
+
+- Clarify telemetry disclosure in plugin README: explicit opt-out instructions and confirmation that no prompts/arguments/code are sent.
+- Polish `plugin.json` metadata for Anthropic plugin directory submission (expanded description, `author.email`, `homepage`).
+- Add `"category": "monitoring"` to the marketplace.json entry.
+
 ## [1.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/codex/hooks/prevent/lib/protocol.py
+++ b/plugins/codex/hooks/prevent/lib/protocol.py
@@ -118,12 +118,18 @@ def _get_staged_model_tables(cwd: str) -> list[str]:
 
 # --- Decision functions ---
 
+def _prevent_hooks_disabled() -> bool:
+    return os.environ.get("MC_PREVENT_HOOKS_DISABLED", "").strip() == "1"
+
+
 def evaluate_pre_edit(inp: HookInput) -> HookOutput:
     """Gate logic: should this file edit be allowed?
 
     Returns deny if impact assessment hasn't run for this table,
     noop if the edit should proceed.
     """
+    if _prevent_hooks_disabled():
+        return HookOutput()
     cleanup_stale_cache()
 
     file_path = inp.file_path or ""
@@ -231,6 +237,8 @@ def evaluate_post_edit(inp: HookInput) -> HookOutput:
 
 def evaluate_pre_commit(inp: HookInput) -> HookOutput:
     """Commit checkpoint: prompt for validation if dbt models are staged."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     command = inp.command or ""
     if "git commit" not in command:
         return HookOutput()
@@ -266,6 +274,8 @@ def evaluate_pre_commit(inp: HookInput) -> HookOutput:
 
 def evaluate_turn_end(inp: HookInput) -> HookOutput:
     """End of turn: prompt for validation queries if dbt models were edited."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     if inp.stop_hook_active:
         return HookOutput()
 

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-13
+
+### Added
+
+- Add `MC_PREVENT_HOOKS_DISABLED=1` env var to disable prevent hooks (block-edit, pre-commit, turn-end) for users who want the skills without the gating behavior.
+
+### Changed
+
+- Clarify telemetry disclosure in plugin README: explicit opt-out instructions and confirmation that no prompts/arguments/code are sent.
+- Polish `plugin.json` metadata for Anthropic plugin directory submission (expanded description, `author.email`, `homepage`).
+- Add `"category": "monitoring"` to the marketplace.json entry.
+
 ## [1.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/copilot/hooks/prevent/lib/protocol.py
+++ b/plugins/copilot/hooks/prevent/lib/protocol.py
@@ -118,12 +118,18 @@ def _get_staged_model_tables(cwd: str) -> list[str]:
 
 # --- Decision functions ---
 
+def _prevent_hooks_disabled() -> bool:
+    return os.environ.get("MC_PREVENT_HOOKS_DISABLED", "").strip() == "1"
+
+
 def evaluate_pre_edit(inp: HookInput) -> HookOutput:
     """Gate logic: should this file edit be allowed?
 
     Returns deny if impact assessment hasn't run for this table,
     noop if the edit should proceed.
     """
+    if _prevent_hooks_disabled():
+        return HookOutput()
     cleanup_stale_cache()
 
     file_path = inp.file_path or ""
@@ -231,6 +237,8 @@ def evaluate_post_edit(inp: HookInput) -> HookOutput:
 
 def evaluate_pre_commit(inp: HookInput) -> HookOutput:
     """Commit checkpoint: prompt for validation if dbt models are staged."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     command = inp.command or ""
     if "git commit" not in command:
         return HookOutput()
@@ -266,6 +274,8 @@ def evaluate_pre_commit(inp: HookInput) -> HookOutput:
 
 def evaluate_turn_end(inp: HookInput) -> HookOutput:
     """End of turn: prompt for validation queries if dbt models were edited."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     if inp.stop_hook_active:
         return HookOutput()
 

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-13
+
+### Added
+
+- Add `MC_PREVENT_HOOKS_DISABLED=1` env var to disable prevent hooks (block-edit, pre-commit, turn-end) for users who want the skills without the gating behavior.
+
+### Changed
+
+- Clarify telemetry disclosure in plugin README: explicit opt-out instructions and confirmation that no prompts/arguments/code are sent.
+- Polish `plugin.json` metadata for Anthropic plugin directory submission (expanded description, `author.email`, `homepage`).
+- Add `"category": "monitoring"` to the marketplace.json entry.
+
 ## [1.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/cursor/hooks/prevent/lib/protocol.py
+++ b/plugins/cursor/hooks/prevent/lib/protocol.py
@@ -118,12 +118,18 @@ def _get_staged_model_tables(cwd: str) -> list[str]:
 
 # --- Decision functions ---
 
+def _prevent_hooks_disabled() -> bool:
+    return os.environ.get("MC_PREVENT_HOOKS_DISABLED", "").strip() == "1"
+
+
 def evaluate_pre_edit(inp: HookInput) -> HookOutput:
     """Gate logic: should this file edit be allowed?
 
     Returns deny if impact assessment hasn't run for this table,
     noop if the edit should proceed.
     """
+    if _prevent_hooks_disabled():
+        return HookOutput()
     cleanup_stale_cache()
 
     file_path = inp.file_path or ""
@@ -231,6 +237,8 @@ def evaluate_post_edit(inp: HookInput) -> HookOutput:
 
 def evaluate_pre_commit(inp: HookInput) -> HookOutput:
     """Commit checkpoint: prompt for validation if dbt models are staged."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     command = inp.command or ""
     if "git commit" not in command:
         return HookOutput()
@@ -266,6 +274,8 @@ def evaluate_pre_commit(inp: HookInput) -> HookOutput:
 
 def evaluate_turn_end(inp: HookInput) -> HookOutput:
     """End of turn: prompt for validation queries if dbt models were edited."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     if inp.stop_hook_active:
         return HookOutput()
 

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-13
+
+### Added
+
+- Add `MC_PREVENT_HOOKS_DISABLED=1` env var to disable prevent hooks (block-edit, pre-commit, turn-end) for users who want the skills without the gating behavior.
+
+### Changed
+
+- Clarify telemetry disclosure in plugin README: explicit opt-out instructions and confirmation that no prompts/arguments/code are sent.
+- Polish `plugin.json` metadata for Anthropic plugin directory submission (expanded description, `author.email`, `homepage`).
+- Add `"category": "monitoring"` to the marketplace.json entry.
+
 ## [1.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/shared/prevent/lib/protocol.py
+++ b/plugins/shared/prevent/lib/protocol.py
@@ -118,12 +118,18 @@ def _get_staged_model_tables(cwd: str) -> list[str]:
 
 # --- Decision functions ---
 
+def _prevent_hooks_disabled() -> bool:
+    return os.environ.get("MC_PREVENT_HOOKS_DISABLED", "").strip() == "1"
+
+
 def evaluate_pre_edit(inp: HookInput) -> HookOutput:
     """Gate logic: should this file edit be allowed?
 
     Returns deny if impact assessment hasn't run for this table,
     noop if the edit should proceed.
     """
+    if _prevent_hooks_disabled():
+        return HookOutput()
     cleanup_stale_cache()
 
     file_path = inp.file_path or ""
@@ -231,6 +237,8 @@ def evaluate_post_edit(inp: HookInput) -> HookOutput:
 
 def evaluate_pre_commit(inp: HookInput) -> HookOutput:
     """Commit checkpoint: prompt for validation if dbt models are staged."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     command = inp.command or ""
     if "git commit" not in command:
         return HookOutput()
@@ -266,6 +274,8 @@ def evaluate_pre_commit(inp: HookInput) -> HookOutput:
 
 def evaluate_turn_end(inp: HookInput) -> HookOutput:
     """End of turn: prompt for validation queries if dbt models were edited."""
+    if _prevent_hooks_disabled():
+        return HookOutput()
     if inp.stop_hook_active:
         return HookOutput()
 


### PR DESCRIPTION
## Summary
Prep for Anthropic Claude Code plugin directory submission.

- Removed invalid `"category"` field from `plugin.json` (not in Anthropic's plugin schema). Moved `"category": "monitoring"` to `.claude-plugin/marketplace.json` where it belongs (matches Anthropic's own `claude-plugins-official` marketplace).
- Expanded `plugin.json` description; added `author.email` and `homepage` for reviewer/discoverability.
- README: explicit telemetry opt-out (`MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`) with confirmation that no prompts/args/code are sent; new prevent-hook opt-out documented.
- New `MC_PREVENT_HOOKS_DISABLED=1` env var short-circuits all three prevent evaluators (pre-edit, pre-commit, turn-end). Shared lib + synced copies in claude-code/codex/copilot/cursor adapters. OpenCode TS port not yet updated.
- Version bump 1.11.0 → 1.11.1.

## Test plan
- [x] Live end-to-end smoke test on dbt model `exlooker_gut_summary_last_four_weeks.sql`:
  - Scenario 1 — `MC_PREVENT_HOOKS_DISABLED=1 claude --plugin-dir ./plugins/claude-code`: edit passed through immediately, no block.
  - Scenario 2 — same `--plugin-dir` without the env var: prevent hook blocked the edit and triggered the impact-assessment workflow exactly as before.
- [x] Default behavior (env var unset) is byte-identical to 1.11.0 for users who don't opt in to the kill-switch.
- [x] CI `validate.yml` checks pass (no symlinks under `hooks/`, plugin versions in sync across all 5 manifests).