### PR TITLE
docs(readme): link to Monte Carlo connector in the Claude directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monte Carlo's official toolkit for AI coding agents. Brings data observability — lineage, monitoring, validation, alerting, and metadata ingestion — directly into your development workflow. The toolkit bundles multiple skills into a single plugin that works across supported editors.
 
-> Using Claude.ai (web or desktop) instead of a coding agent? Install Monte Carlo as a [verified connector from the Claude directory](https://claude.ai/directory/connectors/monte-carlo).
+> Using Claude.ai (web or desktop) instead of a coding agent? Monte Carlo is a [verified connector](https://claude.com/connectors/monte-carlo) in the Claude directory — [install it directly](https://claude.ai/directory/connectors/monte-carlo).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Monte Carlo's official toolkit for AI coding agents. Brings data observability — lineage, monitoring, validation, alerting, and metadata ingestion — directly into your development workflow. The toolkit bundles multiple skills into a single plugin that works across supported editors.
 
+> Using Claude.ai (web or desktop) instead of a coding agent? Install Monte Carlo as a [verified connector from the Claude directory](https://claude.ai/directory/connectors/monte-carlo).
+
 ## Features
 
 The toolkit bundles the following capabilities as a single **mc-agent-toolkit** plugin. Each feature is a [skill](skills/) that can also be used standalone.


### PR DESCRIPTION
## Summary
- Adds a callout under the README intro pointing Claude.ai users to the verified Monte Carlo connector listing in the Claude directory.

Per [Mor's request](https://montecarloai.slack.com/archives/CP4L3KPTL/p1779294421828949?thread_ts=1778710497.120059&cid=CP4L3KPTL) in #product-releases.

## Test plan
- [x] Verified the link target (https://claude.ai/directory/connectors/monte-carlo) is the in-app install path.
- [ ] Spot-check rendering on GitHub once the PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)