### PR TITLE
AI-360: tune-monitor — migrate TABLE flow to create_or_update_table_monitor_asset_rule

### DIFF
--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -41,9 +41,7 @@ them:
 | `create_or_update_metric_monitor` | Update a metric monitor in place (pass `monitor_uuid`; used in Phase 5) |
 | `create_or_update_sql_monitor` | Update a custom SQL monitor in place (pass `monitor_uuid`; used in Phase 5) |
 | `create_or_update_validation_monitor` | Update a validation monitor in place (pass `monitor_uuid`; used in Phase 5) |
-| `tune_freshness_table_monitor` | Tune freshness sensitivity/threshold for a table (used in Phase 5) |
-| `tune_volume_change_table_monitor` | Tune volume change sensitivity/threshold for a table (used in Phase 5) |
-| `tune_unchanged_size_table_monitor` | Tune unchanged size sensitivity/threshold for a table (used in Phase 5) |
+| `create_or_update_table_monitor_asset_rule` | Tune freshness / volume change / unchanged size for a single table; pick the per-metric variant via `rule_type` (`last_updated_on` / `total_row_count` / `total_row_count_last_changed_on`). One call per `(table, metric)` pair (used in Phase 5). |
 
 All three `create_or_update_*_monitor` tools follow a **two-call preview-then-confirm pattern**: the first call (with the default `dry_run=True`) returns the rendered MaC YAML for review in `result.yaml`; the second call (`dry_run=False`) deploys the change live and returns a deep link in `result.instructions`. **Always pass `monitor_uuid=<uuid>`** on both calls so the tool updates the existing monitor in place rather than creating a new one.
 

--- a/skills/tune-monitor/references/table-monitor.md
+++ b/skills/tune-monitor/references/table-monitor.md
@@ -79,7 +79,9 @@ anomalies alone is not enough — the pattern must clearly indicate noise.
 ### Schema anomalies
 
 **Do NOT recommend changes for schema anomalies** — they are not tunable via the
-`tune_*_table_monitor` tools.
+asset-rule tool. (Schema change is a separate per-table on/off flag via
+`create_or_update_table_monitor_asset_rule` with `rule_type="schema_monitor"`,
+but that's a different intent from tuning detector sensitivity.)
 
 ---
 
@@ -94,26 +96,43 @@ switch to explicit thresholds if:
 
 ## Applying changes
 
-Table monitor tuning uses per-metric tools — **not** `create_or_update_table_monitor`:
+Table monitor tuning uses **`create_or_update_table_monitor_asset_rule`** — **not**
+`create_or_update_table_monitor`. The single tool covers all three OOTB detectors;
+pick the per-metric variant via `rule_type`:
 
-| Metric | Tool |
+| Metric | `rule_type` arg |
 |---|---|
-| Freshness (`last_updated_on`) | `tune_freshness_table_monitor` |
-| Volume change (`total_row_count`) | `tune_volume_change_table_monitor` |
-| Unchanged size (`total_row_count_last_changed_on`) | `tune_unchanged_size_table_monitor` |
+| Freshness (`last_updated_on`) | `last_updated_on` |
+| Volume change (`total_row_count`) | `total_row_count` |
+| Unchanged size (`total_row_count_last_changed_on`) | `total_row_count_last_changed_on` |
 
-Each tool call targets one (MCON, metric) pair:
-- For sensitivity changes: pass `mcon` and `sensitivity`.
-- For explicit thresholds: pass `mcon` and the threshold parameters.
+Each tool call targets one `(table, rule_type)` pair. Pass the MCON in the `table`
+arg (the warehouse is parsed from it). For each `rule_type`, pick **one of two
+paths**:
 
-1. **Always preview first** — show the user the planned changes per (table, metric) pair and
-   ask for confirmation before applying.
+- **AUTO sensitivity** (default lever):
+  - `rule_type="last_updated_on"`: pass `threshold_sensitivity` (`low` / `medium` / `high`).
+  - `rule_type="total_row_count"` (volume): pass `alert_conditions=[{"type": "lookback", "operator": "AUTO", "thresholdSensitivity": "low"|"medium"|"high"}]`.
+  - `rule_type="total_row_count_last_changed_on"` (UCS): pass `alert_conditions=[{"type": "threshold", "operator": "AUTO", "thresholdSensitivity": "low"|"medium"|"high"}]`.
+  - Omit `schedule_type` — the platform's existing schedule is preserved.
+- **Explicit threshold + fixed cadence**:
+  - `rule_type="last_updated_on"`: pass `freshness_threshold_minutes=<int>` (single duration).
+  - `rule_type="total_row_count"`: pass `alert_conditions=[{"type": "lookback", "operator": "OUTSIDE_RANGE", "lowerThreshold": <pct>, "upperThreshold": <pct>, "thresholdLookbackMinutes": <minutes>}]` — thresholds are relative percentages (e.g. -50 / 50 = ±50 %).
+  - `rule_type="total_row_count_last_changed_on"`: pass `alert_conditions=[{"type": "threshold", "operator": "GT", "thresholdValue": <minutes>, "thresholdLookbackMinutes": <minutes>}]` — `thresholdValue` is duration in minutes.
+  - **Must** also pass `schedule_type="fixed"` plus an `interval_minutes` (or `interval_crontab`) cadence — the threshold's meaning depends on how often the check runs.
+
+1. **Always preview first** — show the user the planned changes per `(table, rule_type)` pair
+   and ask for confirmation before applying.
 2. **On confirmation**, make one tool call per recommendation.
 
 ### Common mistakes
 
 - **NEVER** apply changes without showing the preview first.
-- **NEVER** group multiple tables into one recommendation — one tool call per (MCON, metric).
+- **NEVER** group multiple tables into one recommendation — one tool call per
+  `(table, rule_type)`.
 - **NEVER** recommend tuning schema anomalies — they are not supported.
-- **IMPORTANT:** These mutations are full replacements. Pass `tags` if the current config has
-  any — omitting tags clears them.
+- **NEVER** combine AUTO sensitivity with `schedule_type="fixed"` or explicit cadence
+  args — AUTO preserves the platform schedule. Conversely, **always** pass
+  `schedule_type="fixed"` + a cadence when setting an explicit threshold.
+- **IMPORTANT:** These mutations are full replacements. Pass `tags` if the current
+  config has any — omitting tags clears them.


### PR DESCRIPTION
## Summary

The three legacy `tune_*_table_monitor` MCP tools were removed in [ai-agent#1161](https://github.com/monte-carlo-data/ai-agent/pull/1161) (AI-360). The asset-rule tool `create_or_update_table_monitor_asset_rule` replaces them — it covers all three OOTB detectors via `rule_type` and supports `dry_run` end-to-end, matching the contract of the sibling `create_or_update_*_monitor` tools the skill already uses.

The asset-rule tool was previously in the `EXTENDED_ONLY_TOOLS` set; ai-agent#1161 also promotes it to the default toolset so the public toolkit can call it (visibility-wise this is unchanged — the legacy `tune_*` tools were also extended-only, so the toolkit's TABLE flow has always relied on extended-toolset clients).

### Changes

- **`SKILL.md`**: replace the three `tune_*_table_monitor` rows in the Available MCP tools table with a single `create_or_update_table_monitor_asset_rule` row that notes the `rule_type` selector.
- **`references/table-monitor.md`**: rewrite the "Applying changes" section around the **two-paths-or-nothing** decision the analyze step makes:
  - **AUTO sensitivity** (default lever) — per-`rule_type` `alert_conditions` shapes; omit `schedule_type` so the platform schedule is preserved.
  - **Explicit threshold + fixed schedule cadence** — per-`rule_type` shapes (single duration for freshness/UCS; relative `lowerThreshold` / `upperThreshold` % for volume change); requires `schedule_type="fixed"` + a cadence.
  - Update the schema-anomaly note to point at the asset-rule's `rule_type="schema_monitor"` variant.
  - Tighten the "common mistakes" list with the AUTO-vs-explicit path constraint.

## Test plan

- [x] No code in this repo — docs only.
- [x] Confirmed no stale `tune_*_table_monitor` references remain in `skills/`.
- [ ] Manual smoke: invoke `/tune-monitor <table-monitor-uuid>` after the ai-agent PR lands and verify the skill emits correct `create_or_update_table_monitor_asset_rule` calls per the new guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)