### PR TITLE
fix(docs): reference MCP server by its actual name `monte-carlo-mcp`

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -40,7 +40,7 @@ This installs all three components and creates the MCP server config:
 Then authenticate:
 
 ```bash
-opencode mcp auth monte-carlo
+opencode mcp auth monte-carlo-mcp
 ```
 
 ### Manual install
@@ -149,8 +149,8 @@ See [skills/prevent/references/TROUBLESHOOTING.md](../../../skills/prevent/refer
 
 ### MCP tools not appearing
 
-1. Run `opencode mcp auth monte-carlo` to authenticate
-2. Check that `opencode.json` has the `mcp.monte-carlo` configuration
+1. Run `opencode mcp auth monte-carlo-mcp` to authenticate
+2. Check that `opencode.json` has the `mcp.monte-carlo-mcp` configuration
 3. Verify connectivity: the `testConnection` tool should succeed
 
 ## Architecture

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -106,5 +106,5 @@ fi
 
 echo ""
 echo "Installation complete. Next steps:"
-echo "  1. Authenticate:  opencode mcp auth monte-carlo"
+echo "  1. Authenticate:  opencode mcp auth monte-carlo-mcp"
 echo "  2. Launch:        opencode"

--- a/skills/automated-triage/SKILL.md
+++ b/skills/automated-triage/SKILL.md
@@ -42,7 +42,7 @@ Do not activate when the user is:
 
 ## Available MCP tools
 
-All tools are available via the `monte-carlo` MCP server.
+All tools are available via the `monte-carlo-mcp` MCP server.
 
 | Tool                             | Toolset  | Purpose                                                         |
 | -------------------------------- | -------- | --------------------------------------------------------------- |

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -59,7 +59,7 @@ Do not activate when the user is:
 
 ## Available MCP tools
 
-All tools are available via the `monte-carlo` MCP server.
+All tools are available via the `monte-carlo-mcp` MCP server.
 
 ### Coverage and discovery tools
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -4,7 +4,7 @@ This is the agent monitor creation procedure for AI agent observability. Follow
 these steps in order when a user asks to monitor their AI agents — setting up
 alerts on agent behavior, investigating agent traces, or creating agent monitors.
 
-All tools are available via the `monte-carlo` MCP server.
+All tools are available via the `monte-carlo-mcp` MCP server.
 
 ---
 

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -233,7 +233,7 @@ Generated YAML must not include fields that don't appear in the schema for that 
 
 ## Available MCP Tools
 
-All tools are available via the `monte-carlo` MCP server.
+All tools are available via the `monte-carlo-mcp` MCP server.
 
 | Tool                            | Purpose                                                      |
 | ------------------------------- | ------------------------------------------------------------ |

--- a/skills/prevent/SKILL.md
+++ b/skills/prevent/SKILL.md
@@ -168,7 +168,7 @@ the change") — proceed but note the skipped assessment.
 
 ## Available MCP tools
 
-All tools are available via the `monte-carlo` MCP server.
+All tools are available via the `monte-carlo-mcp` MCP server.
 
 | Tool                         | Purpose                                                              |
 | ---------------------------- | -------------------------------------------------------------------- |

--- a/skills/prevent/references/TROUBLESHOOTING.md
+++ b/skills/prevent/references/TROUBLESHOOTING.md
@@ -6,7 +6,7 @@
 curl -s -o /dev/null -w "%{http_code}" https://mcp.getmontecarlo.com/mcp/toolkit
 ```
 
-**If using the plugin (OAuth):** Run `/mcp` in Claude Code, select the `monte-carlo` server, and re-authenticate. If the browser flow doesn't complete, copy the callback URL from your browser's address bar into the URL prompt that appears in Claude Code.
+**If using the plugin (OAuth):** Run `/mcp` in Claude Code, select the `monte-carlo-mcp` server, and re-authenticate. If the browser flow doesn't complete, copy the callback URL from your browser's address bar into the URL prompt that appears in Claude Code.
 
 **Legacy (header-based auth, for MCP clients without HTTP transport):** Check that `x-mcd-id` and `x-mcd-token` are set correctly in your MCP config. The key format is `<KEY_ID>:<KEY_SECRET>` — these are split across two separate headers.
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -42,7 +42,7 @@ Do not activate when the user is:
 
 ### Monte Carlo MCP server (investigation + post-remediation)
 
-The Monte Carlo MCP server (`monte-carlo`) provides the investigation tools used in the workflows below. The workflows reference key tools by name (e.g., `get_alerts`, `run_troubleshooting_agent`, `get_asset_lineage`), but **use any Monte Carlo tool that helps** — the server has additional tools beyond what the workflows explicitly call out. Explore what's available.
+The Monte Carlo MCP server (`monte-carlo-mcp`) provides the investigation tools used in the workflows below. The workflows reference key tools by name (e.g., `get_alerts`, `run_troubleshooting_agent`, `get_asset_lineage`), but **use any Monte Carlo tool that helps** — the server has additional tools beyond what the workflows explicitly call out. Explore what's available.
 
 > **Note on tool call examples:** The code blocks below show key parameters to guide you. Always check the tool's own description for the complete parameter list and exact parameter names — they are authoritative.
 


### PR DESCRIPTION
## Summary
- All plugin configs register the MCP server as `monte-carlo-mcp` (see `plugins/*/.mcp.json`, `plugins/cursor/mcp.json`, `plugins/opencode/opencode.json`, `plugins/codex/scripts/install.sh`), but several user-facing docs still pointed users at a bare `monte-carlo` name. Anyone following those instructions runs `opencode mcp auth monte-carlo` or selects a `monte-carlo` server in `/mcp` — neither exists.
- The opencode README/installer fix from the working tree is included here; this PR extends the same fix to the shared skill docs that had the same drift.

## Changes
- `plugins/opencode/README.md`, `plugins/opencode/install.sh` — auth command + troubleshooting references
- `skills/prevent/SKILL.md`, `skills/prevent/references/TROUBLESHOOTING.md`
- `skills/monitoring-advisor/SKILL.md`, `skills/monitoring-advisor/references/agent-monitor-creation.md`, `skills/monitoring-advisor/references/data-monitor-creation.md`
- `skills/automated-triage/SKILL.md`
- `skills/remediation/SKILL.md`

## Verified not affected
- `plugins/{claude-code,codex,copilot,cursor,mc-agent-toolkit}/scripts/install.sh` — either use `SERVER_NAME="monte-carlo-mcp"` correctly or never name the server in a command (generic "Monte Carlo MCP server" prose only).
- `plugin.json` / `package.json` `keywords` arrays — these are tags, not server names.
- `plugins/claude-code/evals/constants.py:MCP_SERVER_NAME` — internal eval config, self-contained; not user-facing.

## Test plan
- [ ] `grep -rn '\`monte-carlo\`' plugins/ skills/ README.md` returns no hits (verified locally).
- [ ] Sanity-check rendered docs in GitHub UI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)