### PR TITLE
docs(monitoring-advisor): align coverage + monitor-creation guidance with the coverage agent

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- monitoring-advisor: align coverage and data-monitor-creation guidance with the internal Monte Carlo coverage agent — default to HIGH+MEDIUM scope (don't ask) with action-bias batching, "create a use case" handling, importance-score-is-not-business-criticality caveat, dedup + no-fabricated-credit-cost guidance, description(title)/notes(reasoning) split, a profiling-before-thresholds matrix, the field-monitor-requires-a-live-table-monitor prerequisite, and view fixed-schedule rule.
+
 ## [1.12.0] - 2026-05-20
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- monitoring-advisor: align coverage and data-monitor-creation guidance with the internal Monte Carlo coverage agent — default to HIGH+MEDIUM scope (don't ask) with action-bias batching, "create a use case" handling, importance-score-is-not-business-criticality caveat, dedup + no-fabricated-credit-cost guidance, description(title)/notes(reasoning) split, a profiling-before-thresholds matrix, the field-monitor-requires-a-live-table-monitor prerequisite, and view fixed-schedule rule.
+
 ## [1.12.0] - 2026-05-20
 
 ### Added

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- monitoring-advisor: align coverage and data-monitor-creation guidance with the internal Monte Carlo coverage agent — default to HIGH+MEDIUM scope (don't ask) with action-bias batching, "create a use case" handling, importance-score-is-not-business-criticality caveat, dedup + no-fabricated-credit-cost guidance, description(title)/notes(reasoning) split, a profiling-before-thresholds matrix, the field-monitor-requires-a-live-table-monitor prerequisite, and view fixed-schedule rule.
+
 ## [1.12.0] - 2026-05-20
 
 ### Added

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- monitoring-advisor: align coverage and data-monitor-creation guidance with the internal Monte Carlo coverage agent — default to HIGH+MEDIUM scope (don't ask) with action-bias batching, "create a use case" handling, importance-score-is-not-business-criticality caveat, dedup + no-fabricated-credit-cost guidance, description(title)/notes(reasoning) split, a profiling-before-thresholds matrix, the field-monitor-requires-a-live-table-monitor prerequisite, and view fixed-schedule rule.
+
 ## [1.12.0] - 2026-05-20
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- monitoring-advisor: align coverage and data-monitor-creation guidance with the internal Monte Carlo coverage agent — default to HIGH+MEDIUM scope (don't ask) with action-bias batching, "create a use case" handling, importance-score-is-not-business-criticality caveat, dedup + no-fabricated-credit-cost guidance, description(title)/notes(reasoning) split, a profiling-before-thresholds matrix, the field-monitor-requires-a-live-table-monitor prerequisite, and view fixed-schedule rule.
+
 ## [1.12.0] - 2026-05-20
 
 ### Added

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -156,15 +156,17 @@ This is the primary flow when use cases are defined.
 - Call `get_use_case_tables` with `golden_tables_only=true` and mention specific golden-table names as concrete examples. Golden tables are the last layer in the warehouse -- they feed ML models, dashboards, and reports. Explain this when relevant.
 - Use `get_asset_lineage` to explain how tables in a use case are connected and why certain tables are important (e.g. a golden table with many upstream dependencies).
 
+### "Create a use case" requests
+
+You **cannot** create use cases -- they are generated automatically by Monte Carlo (along with their criticality), and there is no tool to author one. When the user asks to "create", "set up", or "define" a use case: briefly say so, and do NOT silently substitute monitor deployment. Then offer what you *can* do for the table(s) they named -- look up the existing use case / criticality, recommend field monitors, generate monitor previews, or analyze coverage gaps -- and act on the do-able part without expanding to sibling tables.
+
 ### Analyze coverage
 
 1. Call `get_use_case_table_summary` to show how many tables exist at each criticality level (HIGH / MEDIUM / LOW) for the use case.
 2. Call `get_use_case_tables` to obtain table MCONs, then call `get_monitors(mcons=[...])` to report how many are already monitored vs. not.
-3. Ask the user which criticality scope they prefer:
-   - **HIGH only** -- monitor only the most critical tables
-   - **MEDIUM + HIGH** -- broader coverage
-   - **ALL** -- full coverage including LOW-criticality tables
+3. **Default to HIGH + MEDIUM criticality scope.** This covers the most important tables without overwhelming the user. Do NOT ask the user which scope to use -- just proceed. If they want LOW-criticality tables included, they'll ask.
 4. You may suggest covering **multiple** use cases in one session.
+5. **Bias toward action, not questions.** When the scope is clear (HIGH + MEDIUM for the selected use case), proceed directly to generating monitor previews for all recommended monitors. Frame it as opt-out, not opt-in: "I'll generate previews for all N monitors -- tell me if you want to skip any." Do NOT ask "which would you like me to create?" one at a time -- batch them.
 
 ### Identify coverage gaps with anomaly data
 
@@ -185,8 +187,14 @@ When no use cases are defined, fall back to importance-based table discovery.
 1. **Find unmonitored tables:** Use `search(query="", is_monitored=false)` to find unmonitored tables sorted by importance.
 2. **Find tables with anomalies:** Use `get_unmonitored_tables_with_anomalies` with a recent time window (last 14-30 days) to find tables with recent anomalies but no monitors.
 3. **Inspect top candidates:** Use `get_table` to check table details, fields, and stats for the most important unmonitored tables.
-4. **Understand criticality via lineage:** Use `get_asset_lineage` to understand which tables are most connected -- tables with many downstream dependencies are higher priority.
+4. **Understand criticality via lineage:** Use `get_asset_lineage` with `direction="DOWNSTREAM"` to understand which tables are most connected -- a table with many downstream dependents is a stronger candidate for monitoring.
 5. **Prioritize:** Rank candidates by importance score and anomaly activity. Present the top candidates to the user with reasoning.
+
+### Important
+
+- **Do NOT present importance scores as business criticality.** Always explain that the importance score is a *computed* metric (query frequency, downstream dependencies, usage patterns), not business-defined criticality.
+- Tell the user their account doesn't have use-case data **yet** -- use cases are generated automatically by Monte Carlo from warehouse metadata and exposed as asset tags; they are not manually configured through a UI.
+- You can still create metric, validation, and custom SQL monitors for individual tables in this mode -- you just won't use tag-based table monitors, since there are no use-case tags.
 
 ---
 
@@ -206,9 +214,10 @@ If no database MCP is available, skip this step entirely. Do not ask the user to
 
 When coverage analysis leads to monitor creation, gather this context before reading the creation reference file:
 
-1. Call `get_audiences` to list available notification audiences. Ask the user which audience they want notifications sent to.
-2. Ask whether the monitor should be created as a **DRAFT** or active.
-3. When passing `audiences` or `failure_audiences`, use the audience **name/label** (not UUID).
+1. **Dedup first.** Before generating a use-case tag monitor, call `get_monitors` with the same tag pair (and `monitor_types=["TABLE"]`) you'd put in the monitor's `asset_selection.filters`. If a monitor already covers that `(tag, domain)` scope, surface it (description, uuid) and ask whether to update it (pass its `monitor_uuid`), add one with a distinct scope, or skip -- do NOT silently re-create. The backend upserts a table monitor on its `(description, domain)`, so a same-description definition silently overwrites the prior monitor's settings.
+2. Call `get_audiences` to list notification audiences. Suggest one or more relevant audiences (match by team or use-case context) and ask the user which they want -- they can pick **one or several**. This is the **one** question to ask before generating; do NOT also ask about draft/active or schedule. Default to **draft** (`is_draft=True`); the user can flip to active after seeing the preview.
+3. When passing `audiences` or `failure_audiences`, use the audience **name/label** (not UUID), as a list -- one entry per selected audience.
+4. **Never fabricate credit costs.** Do not give a generic per-monitor or per-field MC credit rate -- cost scales with the specific spec (segmentation, schedule, field count). If a preview response includes a backend estimate (e.g. `estimated_credits.credits_per_day`), report that; otherwise decline and offer to preview a specific monitor or use case to get the real estimate.
 
 ### Use-case tag monitors
 
@@ -236,14 +245,18 @@ Rules:
 - To monitor MEDIUM + HIGH: `["tag_name:high", "tag_name:medium"]`
 - To monitor ALL: `["tag_name:high", "tag_name:medium", "tag_name:low"]`
 
-### Monitor description guidelines
+### Monitor title (`description`) and reasoning (`notes`)
 
-Write a clear, meaningful `description` that explains what the monitor covers and why. The backend auto-generates the monitor `name` -- you cannot control it, but the description is what users see.
+Keep these distinct -- both are accepted by the creation tools. The backend auto-generates the monitor `name` slug; `description` is the title users see.
 
-- **Bad:** `"Data Quality Monitoring - HIGH criticality table monitor"`
-- **Good:** `"Monitor HIGH criticality tables in the Revenue Reporting use case to catch issues before they affect dashboards and financial reports."`
+- **`description` -- the title.** Short and scannable (≤ ~80 chars), plain English, naming the asset/use case and criticality scope. Do NOT cram reasoning here.
+- **`notes` -- the reasoning.** 1-3 sentences answering "why this monitor?", grounded in criticality, scope, and downstream impact.
 
-The description should mention the criticality scope, the use case name, and a brief reason why this monitoring matters.
+Example for a use-case tag monitor:
+
+- **Bad description** (this is reasoning, not a title): `"Monitor HIGH criticality tables in the Revenue Reporting use case to catch issues before they affect dashboards and financial reports."`
+- **Good description:** `"Revenue Reporting coverage -- HIGH + MEDIUM criticality tables"`
+- **Good notes** (paired): `"Covers HIGH/MEDIUM-criticality tables in the Revenue Reporting use case. Catches freshness, volume, and schema issues before they reach dashboards and financial reports."`
 
 ---
 

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -66,6 +66,23 @@ Use the `domains` list on the `get_table` response (each entry has `uuid` and `n
 
 Do NOT present all account domains as options when the table already has domains listed -- prefer domains that contain the table.
 
+### Step 3b: Ground thresholds and predicates in real data (profiling)
+
+Verified column names are not enough. Schema alone does not tell you whether a column is mostly-null, whether a status code is truly a closed set, or whether a numeric range is stable enough to alert on. Profiling once up front is the difference between a useful monitor and a noisy one the user mutes the next day.
+
+| Monitor / config | Profiling | How to ground it |
+| --- | --- | --- |
+| Metric monitor, **auto / ML threshold** | **Not required** | The backend learns the baseline from history -- you don't pick a number. |
+| Metric monitor, **manual `min`/`max`** | **Required** (unless the user pre-opts-out) | Sample the metric over a recent window and pick a threshold outside normal variation but tight enough to catch regressions. |
+| **Validation** monitor (any predicate) | **Required** | Membership predicates (`in_set`/`not_in_set`/equality): sample distinct values. Range/regex/cross-field: sample the actual distribution. |
+| **Custom SQL** monitor | **Required** | Run the proposed SQL once first -- confirm it parses, returns the expected shape, and produces values consistent with the threshold. |
+
+How to profile depends on the environment: use `get_table` field stats where they suffice, or an optional database MCP (`snowflake_query`, `bigquery_query`, etc.) for distributions and distinct values. **If you cannot profile** (no query access, permission denied, user declines): do NOT invent values. Fall back to **auto / ML thresholds** where the monitor supports them, propose a metadata-only sketch for the user to refine, or pause -- and say which. A user instruction like "use my number directly", "skip profiling", or "just give me the dry-run" is a valid pre-opt-out; honor it without re-prompting.
+
+### Step 3c: Field monitors require a live table monitor (prerequisite)
+
+A metric or validation monitor on a table only runs if that table has an active **user-deployed table monitor** -- not the auto-applied out-of-the-box freshness/volume. A field monitor on an OOTB-only table is silently inert. Before proposing a metric/validation monitor, check the table's monitors (`get_monitors` for the MCON); if there is no user table monitor, tell the user the field monitor would not actually run, and offer to create a table monitor first. (Custom SQL monitors are exempt.)
+
 ---
 
 ## Creation Phase (Steps 4-8)
@@ -105,6 +122,8 @@ Valid arguments:
 - Fixed: `schedule_type="fixed"`, `interval_minutes=<N>` (any integer, e.g. 30, 60, 90, 360, 720, 1440)
 - Dynamic: `schedule_type="dynamic"` (omit `interval_minutes`)
 - Manual: `schedule_type="manual"` (omit `interval_minutes`)
+
+**Views require a fixed schedule.** A view has no independent "last update" timestamp, so dynamic scheduling never triggers correctly. When the target is a view, always use a fixed schedule and surface that in the preview so the user sees the correct config.
 
 ### Step 6: Confirm with the user
 


### PR DESCRIPTION
## What

Aligns the public **monitoring-advisor** skill with the internal Monte Carlo **coverage agent**, so the hands-on skill recommends and creates monitors the same way the autonomous agent does. The behavioral rules are ported from the agent's interactive prompt (`coverage_system_prompt`) and its `table-deep-dive` guide — the canonical, most-maintained source.

### `skills/monitoring-advisor/SKILL.md`
- **Scope default (was a direct contradiction):** default to HIGH+MEDIUM and proceed — don't ask the user to pick a scope — plus action-bias batching of previews (opt-out, not opt-in, one at a time).
- **"Create a use case" handling:** use cases are auto-generated; say so and don't silently substitute a monitor deploy.
- **Importance ≠ criticality:** importance score is a computed metric, not business-defined criticality.
- **Dedup-before-create** (with the upsert-on-`(description, domain)` overwrite hazard), **no fabricated credit costs**, ask audience once, default to draft.
- **`description` (title) vs `notes` (reasoning) split** — the old "good" example was actually the anti-pattern (reasoning crammed into the title).

### `skills/monitoring-advisor/references/data-monitor-creation.md`
- **Profiling-before-thresholds matrix** — when ML-auto is safe vs when manual / validation / custom-SQL thresholds must be grounded in real data (and the fall-back when you can't profile).
- **Field monitors require a live user table monitor** — OOTB-only tables make field monitors silently inert.
- **Views require a fixed schedule.**

Version bumped to **1.12.1** via `scripts/bump-version.sh` (all 5 plugin configs + changelogs).

## Notes
- Adapted to the public MCP surface: only references tools the skill already documents (`get_monitors`, `get_audiences`, `get_table`, `get_asset_lineage`, the `create_or_update_*_monitor` tools) plus the optional database MCP the skill already mentions. The `notes` field was confirmed against the per-type references before relying on it.
- The earlier camelCase/`Mac` tool naming and the separate `monitor-creation` skill no longer exist on `main` (already migrated to snake_case + merged) — this PR targets the current v2.1.x structure.

## Testing
- `lint-skill.py monitoring-advisor` passes (pre-existing `when_to_use`/`version` warnings only).
- Markdown-only + generated version bump; no symlink/hook changes (the only thing `validate.yml` checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)