### PR TITLE
feat(telemetry): one-shot install beacon across all six editor plugins (DOL-8692)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,26 +34,29 @@ jobs:
           echo "OK: no symlinks under plugins/<editor>/hooks/"
 
   lib-in-sync:
-    name: Synced prevent lib matches plugins/shared
+    name: Synced shared libs match plugins/shared
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Diff each plugin's prevent lib against the shared source
+      - name: Diff each plugin's shared lib against the shared source
         run: |
           set -euo pipefail
-          shared="plugins/shared/prevent/lib"
           rc=0
-          for libdir in plugins/*/hooks/prevent/lib; do
-            [ -d "$libdir" ] || continue
-            if ! diff -r -x '__pycache__' -x 'tests' -x '*.pyc' "$shared" "$libdir" >/dev/null; then
-              echo "::error::$libdir is out of sync with $shared."
-              echo "::error::Edit plugins/shared/prevent/lib/ and run ./scripts/bump-version.sh --sync-only."
-              echo "Drift:"
-              diff -r -x '__pycache__' -x 'tests' -x '*.pyc' "$shared" "$libdir" || true
-              rc=1
-            fi
+          for skill in prevent telemetry; do
+            shared="plugins/shared/$skill/lib"
+            [ -d "$shared" ] || continue
+            for libdir in plugins/*/hooks/$skill/lib; do
+              [ -d "$libdir" ] || continue
+              if ! diff -r -x '__pycache__' -x 'tests' -x '*.pyc' "$shared" "$libdir" >/dev/null; then
+                echo "::error::$libdir is out of sync with $shared."
+                echo "::error::Edit plugins/shared/$skill/lib/ and run ./scripts/bump-version.sh --sync-only."
+                echo "Drift:"
+                diff -r -x '__pycache__' -x 'tests' -x '*.pyc' "$shared" "$libdir" || true
+                rc=1
+              fi
+            done
           done
           if [[ "$rc" -eq 0 ]]; then
-            echo "OK: every plugin's prevent lib matches plugins/shared/prevent/lib"
+            echo "OK: every plugin's shared libs match plugins/shared"
           fi
           exit $rc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ mc-agent-toolkit/
 │
 ├── plugins/
 │   ├── shared/                          # Canonical hook logic (source of truth)
-│   │   └── prevent/lib/                 # Business logic (copied into each editor plugin's hooks/prevent/lib/)
+│   │   ├── prevent/lib/                 # Business logic (copied into each editor plugin's hooks/prevent/lib/)
+│   │   └── telemetry/lib/               # Install-beacon (copied into each editor plugin's hooks/telemetry/lib/)
 │   │
 │   ├── claude-code/                     # Unified mc-agent-toolkit plugin
 │   │   ├── .claude-plugin/plugin.json
@@ -205,7 +206,7 @@ Setup and agent-routing skills are exempt from this rule. Setup skills are invok
 - For new skills: include example prompts that should trigger the skill.
 - For bug fixes: describe the incorrect behavior and how to reproduce.
 - Ensure skill symlinks are relative and resolve correctly (CI will verify this).
-- If you changed files in `plugins/shared/prevent/lib/`, run `./scripts/bump-version.sh --sync-only` to sync copies to all editor plugins without bumping the version. Symlinks under `plugins/<editor>/hooks/` are rejected by CI — see `.github/workflows/validate.yml`.
+- If you changed files under `plugins/shared/<skill>/lib/` (e.g. `prevent/lib/` or `telemetry/lib/`), run `./scripts/bump-version.sh --sync-only` to sync copies to all editor plugins without bumping the version. Symlinks under `plugins/<editor>/hooks/` are rejected by CI — see `.github/workflows/validate.yml`.
 - Run `git log --follow` on any moved files to confirm history is preserved.
 
 ## Version bumping

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the [skills directory](skills/) for the full list and individual READMEs.
 
 ## Telemetry
 
-All six editor plugins send a one-shot anonymous **install beacon** at first session start — a `Toolkit Installed` event carrying an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor name — so we can count installations. The Claude Code and Cortex Code plugins additionally send anonymous **skill-usage** telemetry (which skills are invoked, how often). No prompts, skill arguments, or code are ever sent, and telemetry is fail-open and non-blocking. To disable all of it, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See each plugin's README (e.g. [Claude Code](plugins/claude-code/README.md#telemetry), [Cortex Code](plugins/cortex-code/README.md#telemetry)) for details.
+All six editor plugins send an anonymous **install beacon** — a `Toolkit Installed` event carrying an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor name — once per machine per toolkit version (first install and after each upgrade), so we can count installations and version adoption. The Claude Code and Cortex Code plugins additionally send anonymous **skill-usage** telemetry (which skills are invoked, how often). No prompts, skill arguments, or code are ever sent, and telemetry is fail-open and non-blocking. To disable all of it, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See each plugin's README (e.g. [Claude Code](plugins/claude-code/README.md#telemetry), [Cortex Code](plugins/cortex-code/README.md#telemetry)) for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the [skills directory](skills/) for the full list and individual READMEs.
 
 ## Telemetry
 
-The Claude Code and Cortex Code plugins send anonymous skill-usage telemetry. No prompts or skill arguments are sent. To disable, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See the [Claude Code](plugins/claude-code/README.md#telemetry) or [Cortex Code](plugins/cortex-code/README.md#telemetry) plugin README for details.
+All six editor plugins send a one-shot anonymous **install beacon** at first session start — a `Toolkit Installed` event carrying an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor name — so we can count installations. The Claude Code and Cortex Code plugins additionally send anonymous **skill-usage** telemetry (which skills are invoked, how often). No prompts, skill arguments, or code are ever sent, and telemetry is fail-open and non-blocking. To disable all of it, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See each plugin's README (e.g. [Claude Code](plugins/claude-code/README.md#telemetry), [Cortex Code](plugins/cortex-code/README.md#telemetry)) for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the [skills directory](skills/) for the full list and individual READMEs.
 
 ## Telemetry
 
-All six editor plugins send an anonymous **install beacon** — a `Toolkit Installed` event carrying an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor name — once per machine per toolkit version (first install and after each upgrade), so we can count installations and version adoption. The Claude Code and Cortex Code plugins additionally send anonymous **skill-usage** telemetry (which skills are invoked, how often). No prompts, skill arguments, or code are ever sent, and telemetry is fail-open and non-blocking. To disable all of it, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See each plugin's README (e.g. [Claude Code](plugins/claude-code/README.md#telemetry), [Cortex Code](plugins/cortex-code/README.md#telemetry)) for details.
+All six editor plugins send an anonymous **install beacon** — a `Toolkit Installed` event carrying an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor name — once per machine per toolkit version (first install and after each version change), so we can count installations and version adoption. The Claude Code and Cortex Code plugins additionally send anonymous **skill-usage** telemetry (which skills are invoked, how often). No prompts, skill arguments, or code are ever sent, and telemetry is fail-open and non-blocking. To disable all of it, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1`. See each plugin's README (e.g. [Claude Code](plugins/claude-code/README.md#telemetry), [Cortex Code](plugins/cortex-code/README.md#telemetry)) for details.
 
 ## Contributing
 

--- a/docs/plugin-architecture-guide.md
+++ b/docs/plugin-architecture-guide.md
@@ -95,6 +95,8 @@ mc-agent-toolkit/
 │   │   │   ├── cache.py                 # State management (mc_prevent_* prefixed)
 │   │   │   ├── detect.py                # dbt file detection
 │   │   │   └── safe_run.py              # Error safety decorator
+│   │   ├── telemetry/lib/               # Install-beacon (copied into each editor's hooks/telemetry/lib/)
+│   │   │   └── install-beacon.sh        # One-shot "Toolkit Installed" beacon (bash)
 │   │   └── <future-skill>/lib/
 │   │       ├── protocol.py              # Separate business logic
 │   │       └── cache.py                 # Separate cache (mc_<skill>_* prefixed)
@@ -105,7 +107,8 @@ mc-agent-toolkit/
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── .mcp.json
 │   │   ├── hooks/
-│   │   │   └── prevent/                 # Adapters + lib/ (copied from plugins/shared/prevent/lib/)
+│   │   │   ├── prevent/                 # Adapters + lib/ (copied from plugins/shared/prevent/lib/)
+│   │   │   └── telemetry/               # SessionStart id-mint + install + skill-usage beacons
 │   │   ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │   │   └── commands/
 │   │       ├── prevent/
@@ -147,7 +150,7 @@ mc-agent-toolkit/
 │       ├── .mcp.json
 │       ├── hooks/
 │       │   ├── prevent/                 # Adapters + lib/ (copied from plugins/shared/prevent/lib/)
-│       │   └── telemetry/               # SessionStart id-mint + skill-usage beacon
+│       │   └── telemetry/               # SessionStart id-mint + install + skill-usage beacons
 │       ├── skills/                      # One symlink per skill → ../../../skills/<name>
 │       ├── commands/
 │       └── scripts/install.sh           # cp -RL staging → cortex plugin install

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -15,7 +15,7 @@ For the user-facing feature list and installation instructions, see the [main RE
 | **Copilot CLI** | Preliminary | All 17 | OAuth | [Setup guide](copilot/README.md) |
 | **Codex** | Preliminary | All 17 | OAuth | [Setup guide](codex/README.md) |
 
-Currently, only the **Prevent** skill leverages hooks for enforcement. The other skills are instruction-only.
+Currently, only the **Prevent** skill leverages hooks for *enforcement*; the other skills are instruction-only. (Telemetry also uses a lightweight `SessionStart` hook to fire an anonymous install beacon — see each plugin's README and the Telemetry section in the root README.)
 
 ### Prevent Hook Behavior
 
@@ -46,8 +46,9 @@ Each editor plugin follows the **unified toolkit model** — one plugin per edit
 
 ```
 plugins/
-├── shared/              # Platform-agnostic hook logic (Python)
-│   └── prevent/lib/     # Business logic used by all editor adapters
+├── shared/              # Shared hook logic, synced into each editor plugin
+│   ├── prevent/lib/     # Business logic used by all editor adapters (Python)
+│   └── telemetry/lib/   # Canonical install-beacon (bash), synced into hooks/telemetry/lib/
 ├── claude-code/         # Claude Code plugin
 ├── cursor/              # Cursor plugin
 ├── opencode/            # OpenCode plugin (TypeScript port)

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -37,7 +37,7 @@ Restart Claude Code after installing.
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`claude-code`). No prompts, arguments, or code are ever sent.
 
-It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Claude Code after installing, and again after each upgrade — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`claude-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Claude Code after installing, and again after each version change — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`claude-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Claude Code. The toolkit will not phone home.
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -37,7 +37,7 @@ Restart Claude Code after installing.
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`claude-code`). No prompts, arguments, or code are ever sent.
 
-It also sends a one-shot `Toolkit Installed` beacon the first time you start Claude Code after installing — deduped by a local marker so it fires at most once per machine, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`claude-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Claude Code after installing, and again after each upgrade — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`claude-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Claude Code. The toolkit will not phone home.
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -37,6 +37,8 @@ Restart Claude Code after installing.
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`claude-code`). No prompts, arguments, or code are ever sent.
 
+It also sends a one-shot `Toolkit Installed` beacon the first time you start Claude Code after installing — deduped by a local marker so it fires at most once per machine, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`claude-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Claude Code. The toolkit will not phone home.
 
 The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in. The UUIDs are generated locally on first session and stored under `~/.claude/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.

--- a/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/claude-code/hooks/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -3,33 +3,29 @@
 # install_id is generated once and persisted; toolkit_session_id is regenerated every session.
 # Fails closed (exit 0) on any error — telemetry must never break a Claude Code session.
 # If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
-# On the first-ever run (when install_id is created) it also fires a one-shot
-# "Toolkit Installed" beacon — fail-open and non-blocking.
+# Every session it also invokes the install beacon, which fires once per toolkit
+# version (first install + upgrades) — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.claude/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
-install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
-  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
-# First-ever run for this editor: fire the one-shot install beacon now that both
-# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
-# fail-open — never let telemetry break a session, and never gate the id writes
-# above on the beacon's outcome.
-if [[ "$install_id_created" == "1" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
-    "$DIR" \
-    "$SCRIPT_DIR/../../../.claude-plugin/plugin.json" \
-    "claude-code" 2>/dev/null || true
-fi
+# Invoke the install beacon now that both ids exist (the sink requires both). It
+# self-dedups by toolkit version — firing once per version (first install plus
+# upgrades). Backgrounded, fail-open — never let telemetry break a session, and
+# never gate the id writes above on its outcome.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+  "$DIR" \
+  "$SCRIPT_DIR/../../../.claude-plugin/plugin.json" \
+  "claude-code" 2>/dev/null || true
 
 exit 0

--- a/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/claude-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -3,17 +3,33 @@
 # install_id is generated once and persisted; toolkit_session_id is regenerated every session.
 # Fails closed (exit 0) on any error — telemetry must never break a Claude Code session.
 # If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
+# On the first-ever run (when install_id is created) it also fires a one-shot
+# "Toolkit Installed" beacon — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.claude/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
+install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
+  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+
+# First-ever run for this editor: fire the one-shot install beacon now that both
+# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
+# fail-open — never let telemetry break a session, and never gate the id writes
+# above on the beacon's outcome.
+if [[ "$install_id_created" == "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+    "$DIR" \
+    "$SCRIPT_DIR/../../../.claude-plugin/plugin.json" \
+    "claude-code" 2>/dev/null || true
+fi
 
 exit 0

--- a/plugins/claude-code/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/claude-code/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
-# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# (one JSON line per invocation) and exits 0. Used by install-beacon and skill-beacon tests to
 # verify what would have been sent without making network calls.
 set -uo pipefail
 

--- a/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -4,10 +4,23 @@ setup() {
   TEST_HOME="$(mktemp -d)"
   export HOME="$TEST_HOME"
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+  IDS_DIR="$TEST_HOME/.claude/mc-agent-toolkit"
+
+  # First run now fires the install beacon — mock curl so no real network calls
+  # happen during tests, and run it synchronously for deterministic assertions.
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+  export MC_BEACON_SYNC=1
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
 }
 
 teardown() {
-  rm -rf "$TEST_HOME"
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
 }
 
 @test "creates install_id and toolkit_session_id files" {
@@ -57,4 +70,40 @@ teardown() {
   touch "$TEST_HOME"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
+}
+
+@test "first run fires exactly one Toolkit Installed beacon" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(wc -l < "$MOCK_CURL_LOG" | tr -d ' ')" = "1" ]
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "claude-code" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "$(cat "$IDS_DIR/install_id")" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
+}
+
+@test "second run does not fire the install beacon (install_id already exists)" {
+  bash "$SCRIPT"
+  : > "$MOCK_CURL_LOG"   # clear the first-run beacon
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+  bash "$SCRIPT"
+  rm "$IDS_DIR/install_id"
+  : > "$MOCK_CURL_LOG"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson.event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}
+
+@test "toolkit_session_id is written even on the first (beacon-firing) run" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
 }

--- a/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -84,7 +84,7 @@ teardown() {
   [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
 }
 
-@test "second run does not fire the install beacon (install_id already exists)" {
+@test "second run does not fire the install beacon (same version)" {
   bash "$SCRIPT"
   : > "$MOCK_CURL_LOG"   # clear the first-run beacon
   run bash "$SCRIPT"
@@ -92,9 +92,9 @@ teardown() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+@test "re-fires the install beacon after a toolkit version change" {
   bash "$SCRIPT"
-  rm "$IDS_DIR/install_id"
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"   # simulate an older recorded version
   : > "$MOCK_CURL_LOG"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -105,3 +105,12 @@ wait_for_log() {
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
   ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }
+
+@test "backgrounded beacon (no MC_BEACON_SYNC) still fires" {
+  # Exercise the production default path: ( curl ... ) & disown.
+  unset MC_BEACON_SYNC
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}

--- a/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -130,3 +130,10 @@ wait_for_log() {
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
   [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
 }
+
+@test "does not fire (or write marker) when the toolkit version is unknown" {
+  run bash "$SCRIPT" "$IDS_DIR" "/nonexistent/plugin.json" "claude-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+  [ ! -f "$IDS_DIR/beacon_sent_version" ]
+}

--- a/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# The install beacon fires once, at first-ever session start, carrying the
+# "Toolkit Installed" event. It is editor-agnostic shared code synced from
+# plugins/shared/telemetry/lib/; these tests exercise the Claude Code copy.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.claude/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../lib/install-beacon.sh"
+  MANIFEST="$BATS_TEST_DIRNAME/../../../.claude-plugin/plugin.json"
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+  # Run curl synchronously so "no beacon" assertions are deterministic.
+  export MC_BEACON_SYNC=1
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires Toolkit Installed beacon with ids and claude-code harness" {
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  [ "$status" -eq 0 ]
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "claude-code" ]
+}
+
+@test "install payload carries no skill fields" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r 'has("skill")')" = "false" ]
+  [ "$(echo "$payload" | jq -r 'has("skill_args_present")')" = "false" ]
+}
+
+@test "payload includes toolkit_version from .claude-plugin/plugin.json" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$MANIFEST")"
+  [ "$version" = "$expected" ]
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing toolkit_session_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "curl is called with -m 2 and the prod beacon URL by default" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/claude-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -114,3 +114,19 @@ wait_for_log() {
   [ -s "$MOCK_CURL_LOG" ]
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
 }
+
+@test "does not fire when beacon_sent_version matches the current version" {
+  echo "$(jq -r '.version' "$MANIFEST")" > "$IDS_DIR/beacon_sent_version"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires and updates the marker when beacon_sent_version differs" {
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "claude-code"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+  [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
+}

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -63,6 +63,14 @@ Codex hook coverage is incomplete, which may cause hooks to not fire consistentl
 
 The skill-based impact assessment (via `SKILL.md`) works reliably regardless of these hook limitations.
 
+## Telemetry
+
+The toolkit sends a single anonymous install beacon the first time you start Codex after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`codex`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+
+To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Codex. The toolkit will not phone home.
+
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions. The UUIDs are generated locally on first session and stored under `~/.codex/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+
 ## Architecture
 
 This plugin uses the shared core library at `hooks/prevent/lib/` (symlinked). All business logic lives in the shared library; the hooks in this plugin are thin adapters (~20 lines each) that translate Codex JSON to/from the platform-agnostic interface.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -65,7 +65,7 @@ The skill-based impact assessment (via `SKILL.md`) works reliably regardless of 
 
 ## Telemetry
 
-The toolkit sends a single anonymous install beacon the first time you start Codex after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`codex`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`codex`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Codex after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Codex. The toolkit will not phone home.
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -65,7 +65,7 @@ The skill-based impact assessment (via `SKILL.md`) works reliably regardless of 
 
 ## Telemetry
 
-The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`codex`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Codex after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`codex`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Codex after installing, and again after each version change (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Codex. The toolkit will not phone home.
 

--- a/plugins/codex/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/codex/hooks/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/codex/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/codex/hooks/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/codex/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/codex/hooks/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/codex/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/codex/hooks/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/plugins/codex/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/codex/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -5,33 +5,29 @@
 # Codex is a distinct installation from one in Claude Code or Cortex Code (separate plugin
 # registries, separate install flows), so each editor keeps its own install/session identity.
 # Fails closed (exit 0) on any error — telemetry must never break a Codex session.
-# On the first-ever run (when install_id is created) it also fires a one-shot
-# "Toolkit Installed" beacon — fail-open and non-blocking.
+# Every session it also invokes the install beacon, which fires once per toolkit
+# version (first install + upgrades) — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.codex/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
-install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
-  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
-# First-ever run for this editor: fire the one-shot install beacon now that both
-# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
-# fail-open — never let telemetry break a session, and never gate the id writes
-# above on the beacon's outcome.
-if [[ "$install_id_created" == "1" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
-    "$DIR" \
-    "$SCRIPT_DIR/../../../.codex-plugin/plugin.json" \
-    "codex" 2>/dev/null || true
-fi
+# Invoke the install beacon now that both ids exist (the sink requires both). It
+# self-dedups by toolkit version — firing once per version (first install plus
+# upgrades). Backgrounded, fail-open — never let telemetry break a session, and
+# never gate the id writes above on its outcome.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+  "$DIR" \
+  "$SCRIPT_DIR/../../../.codex-plugin/plugin.json" \
+  "codex" 2>/dev/null || true
 
 exit 0

--- a/plugins/codex/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/codex/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Ensure stable install_id and fresh toolkit_session_id for the current Codex session.
+# install_id is generated once and persisted; toolkit_session_id is regenerated every session.
+# IDs live under Codex's own config home (~/.codex), NOT ~/.claude: a toolkit install in
+# Codex is a distinct installation from one in Claude Code or Cortex Code (separate plugin
+# registries, separate install flows), so each editor keeps its own install/session identity.
+# Fails closed (exit 0) on any error — telemetry must never break a Codex session.
+# On the first-ever run (when install_id is created) it also fires a one-shot
+# "Toolkit Installed" beacon — fail-open and non-blocking.
+set -uo pipefail
+
+DIR="$HOME/.codex/mc-agent-toolkit"
+mkdir -p "$DIR" 2>/dev/null || exit 0
+
+install_id_created=0
+if [[ ! -f "$DIR/install_id" ]]; then
+  uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
+  chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
+  install_id_created=1
+fi
+
+uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+
+# First-ever run for this editor: fire the one-shot install beacon now that both
+# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
+# fail-open — never let telemetry break a session, and never gate the id writes
+# above on the beacon's outcome.
+if [[ "$install_id_created" == "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+    "$DIR" \
+    "$SCRIPT_DIR/../../../.codex-plugin/plugin.json" \
+    "codex" 2>/dev/null || true
+fi
+
+exit 0

--- a/plugins/codex/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/codex/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
-# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# (one JSON line per invocation) and exits 0. Used by install-beacon and skill-beacon tests to
 # verify what would have been sent without making network calls.
 set -uo pipefail
 

--- a/plugins/codex/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/codex/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
+# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# verify what would have been sent without making network calls.
+set -uo pipefail
+
+LOG="${MOCK_CURL_LOG:-/dev/null}"
+STDIN_PAYLOAD="$(cat || true)"
+
+# Pull the body from -d/--data when present; otherwise fall back to stdin.
+data=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -d|--data|--data-raw|--data-binary) data="$arg" ;;
+  esac
+  prev="$arg"
+done
+[[ -z "$data" ]] && data="$STDIN_PAYLOAD"
+
+# argv as a JSON array; data as a string. jq handles all escaping.
+jq -nc \
+  --argjson argv "$(printf '%s\n' "$@" | jq -R . | jq -sc .)" \
+  --arg data "$data" \
+  '{argv: $argv, data: $data}' >> "$LOG"
+
+exit 0

--- a/plugins/codex/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+  IDS_DIR="$TEST_HOME/.codex/mc-agent-toolkit"
+
+  # First run now fires the install beacon — mock curl so no real network calls
+  # happen during tests, and run it synchronously for deterministic assertions.
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+  export MC_BEACON_SYNC=1
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+@test "creates install_id and toolkit_session_id files" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/install_id" ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}
+
+@test "files contain lowercase UUIDs" {
+  bash "$SCRIPT"
+  install_id="$(cat "$IDS_DIR/install_id")"
+  toolkit_session_id="$(cat "$IDS_DIR/toolkit_session_id")"
+  [[ "$install_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+  [[ "$toolkit_session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+@test "files have mode 600" {
+  bash "$SCRIPT"
+  perms_install="$(stat -f '%Lp' "$IDS_DIR/install_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/install_id")"
+  perms_session="$(stat -f '%Lp' "$IDS_DIR/toolkit_session_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/toolkit_session_id")"
+  [ "$perms_install" = "600" ]
+  [ "$perms_session" = "600" ]
+}
+
+@test "install_id is stable across runs; toolkit_session_id rotates" {
+  bash "$SCRIPT"
+  install_first="$(cat "$IDS_DIR/install_id")"
+  session_first="$(cat "$IDS_DIR/toolkit_session_id")"
+  bash "$SCRIPT"
+  install_second="$(cat "$IDS_DIR/install_id")"
+  session_second="$(cat "$IDS_DIR/toolkit_session_id")"
+  [ "$install_first" = "$install_second" ]
+  [ "$session_first" != "$session_second" ]
+}
+
+@test "creates parent directory when absent" {
+  rm -rf "$TEST_HOME/.codex"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -d "$IDS_DIR" ]
+}
+
+@test "exits 0 even when parent directory cannot be created" {
+  # Make $HOME a regular file so mkdir -p $HOME/.codex/... must fail.
+  rm -rf "$TEST_HOME"
+  touch "$TEST_HOME"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "first run fires exactly one Toolkit Installed beacon" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(wc -l < "$MOCK_CURL_LOG" | tr -d ' ')" = "1" ]
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "codex" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "$(cat "$IDS_DIR/install_id")" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
+}
+
+@test "second run does not fire the install beacon (install_id already exists)" {
+  bash "$SCRIPT"
+  : > "$MOCK_CURL_LOG"   # clear the first-run beacon
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+  bash "$SCRIPT"
+  rm "$IDS_DIR/install_id"
+  : > "$MOCK_CURL_LOG"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson.event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}
+
+@test "toolkit_session_id is written even on the first (beacon-firing) run" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}

--- a/plugins/codex/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -84,7 +84,7 @@ teardown() {
   [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
 }
 
-@test "second run does not fire the install beacon (install_id already exists)" {
+@test "second run does not fire the install beacon (same version)" {
   bash "$SCRIPT"
   : > "$MOCK_CURL_LOG"   # clear the first-run beacon
   run bash "$SCRIPT"
@@ -92,9 +92,9 @@ teardown() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+@test "re-fires the install beacon after a toolkit version change" {
   bash "$SCRIPT"
-  rm "$IDS_DIR/install_id"
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"   # simulate an older recorded version
   : > "$MOCK_CURL_LOG"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
@@ -114,3 +114,19 @@ wait_for_log() {
   [ -s "$MOCK_CURL_LOG" ]
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
 }
+
+@test "does not fire when beacon_sent_version matches the current version" {
+  echo "$(jq -r '.version' "$MANIFEST")" > "$IDS_DIR/beacon_sent_version"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires and updates the marker when beacon_sent_version differs" {
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+  [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
+}

--- a/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
@@ -130,3 +130,10 @@ wait_for_log() {
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
   [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
 }
+
+@test "does not fire (or write marker) when the toolkit version is unknown" {
+  run bash "$SCRIPT" "$IDS_DIR" "/nonexistent/plugin.json" "codex"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+  [ ! -f "$IDS_DIR/beacon_sent_version" ]
+}

--- a/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# The install beacon fires once, at first-ever session start, carrying the
+# "Toolkit Installed" event. It is editor-agnostic shared code synced from
+# plugins/shared/telemetry/lib/; these tests exercise the Codex copy.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.codex/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../lib/install-beacon.sh"
+  MANIFEST="$BATS_TEST_DIRNAME/../../../.codex-plugin/plugin.json"
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+  # Run curl synchronously so "no beacon" assertions are deterministic.
+  export MC_BEACON_SYNC=1
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires Toolkit Installed beacon with ids and codex harness" {
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  [ "$status" -eq 0 ]
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "codex" ]
+}
+
+@test "install payload carries no skill fields" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r 'has("skill")')" = "false" ]
+  [ "$(echo "$payload" | jq -r 'has("skill_args_present")')" = "false" ]
+}
+
+@test "payload includes toolkit_version from .codex-plugin/plugin.json" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$MANIFEST")"
+  [ "$version" = "$expected" ]
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing toolkit_session_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "curl is called with -m 2 and the prod beacon URL by default" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/codex/hooks/telemetry/tests/test_install_beacon.bats
@@ -105,3 +105,12 @@ wait_for_log() {
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
   ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }
+
+@test "backgrounded beacon (no MC_BEACON_SYNC) still fires" {
+  # Exercise the production default path: ( curl ... ) & disown.
+  unset MC_BEACON_SYNC
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "codex"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -101,7 +101,7 @@ done
 # --- Clean up dev artifacts ---
 find "$TARGET" -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
 find "$TARGET" -name "*.pyc" -delete 2>/dev/null || true
-rm -rf "$TARGET/hooks/prevent/lib/tests"
+rm -rf "$TARGET/hooks/prevent/lib/tests" "$TARGET/hooks/telemetry/tests"
 
 echo "  Plugin files installed."
 
@@ -134,14 +134,27 @@ done
 echo "[3/7] Registering hooks in .codex/hooks.json (project-level)..."
 
 HOOKS_DIR="$TARGET/hooks/prevent"
+TELEMETRY_DIR="$TARGET/hooks/telemetry/scripts"
 
 mkdir -p "$(dirname "$HOOKS_FILE")"
 
-# Note: Codex currently only emits PreToolUse/PostToolUse for the Bash tool.
-# Edit|Write matchers are omitted until Codex expands tool coverage.
+# SessionStart fires on every session (startup/resume/clear/compact) — no matcher,
+# since the install_id marker dedups the one-shot "Toolkit Installed" beacon to
+# once per machine+editor. Note: Codex currently only emits PreToolUse/PostToolUse
+# for the Bash tool; Edit|Write matchers are omitted until Codex expands tool coverage.
 cat > "$HOOKS_FILE" << HOOKEOF
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $TELEMETRY_DIR/ensure-toolkit-ids.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/plugins/codex/scripts/install.sh
+++ b/plugins/codex/scripts/install.sh
@@ -150,7 +150,7 @@ cat > "$HOOKS_FILE" << HOOKEOF
         "hooks": [
           {
             "type": "command",
-            "command": "bash $TELEMETRY_DIR/ensure-toolkit-ids.sh"
+            "command": "bash '$TELEMETRY_DIR/ensure-toolkit-ids.sh'"
           }
         ]
       }
@@ -161,7 +161,7 @@ cat > "$HOOKS_FILE" << HOOKEOF
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOOKS_DIR/bash_hook.py"
+            "command": "python3 '$HOOKS_DIR/bash_hook.py'"
           }
         ]
       }
@@ -171,7 +171,7 @@ cat > "$HOOKS_FILE" << HOOKEOF
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOOKS_DIR/turn_end_hook.py"
+            "command": "python3 '$HOOKS_DIR/turn_end_hook.py'"
           }
         ]
       }

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -108,7 +108,7 @@ plugins/copilot/
 
 ## Telemetry
 
-The toolkit sends a single anonymous install beacon the first time you start Copilot CLI after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`copilot`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session. The session-start hook is registered at the user level (`~/.copilot/hooks/`) so the install is counted once per machine, not once per repo.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`copilot`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Copilot CLI after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session. The session-start hook is registered at the user level (`~/.copilot/hooks/`) so the install is counted once per machine, not once per repo.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Copilot CLI. The toolkit will not phone home.
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -106,6 +106,14 @@ plugins/copilot/
 - Check that `.mcp.json` exists in the plugin directory
 - Run `/skills list` to verify the prevent skill is loaded
 
+## Telemetry
+
+The toolkit sends a single anonymous install beacon the first time you start Copilot CLI after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`copilot`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session. The session-start hook is registered at the user level (`~/.copilot/hooks/`) so the install is counted once per machine, not once per repo.
+
+To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Copilot CLI. The toolkit will not phone home.
+
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions. The UUIDs are generated locally on first session and stored under `~/.copilot/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+
 ## Architecture
 
 See the [plugins README](../README.md) for the overall plugin architecture and editor support comparison.

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -108,7 +108,7 @@ plugins/copilot/
 
 ## Telemetry
 
-The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`copilot`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Copilot CLI after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session. The session-start hook is registered at the user level (`~/.copilot/hooks/`) so the install is counted once per machine, not once per repo.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`copilot`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Copilot CLI after installing, and again after each version change (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session. The session-start hook is registered at the user level (`~/.copilot/hooks/`) so the install is counted once per machine, not once per repo.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Copilot CLI. The toolkit will not phone home.
 

--- a/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/copilot/hooks/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/plugins/copilot/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/copilot/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -5,35 +5,31 @@
 # Copilot is a distinct installation from one in Claude Code or Cortex Code (separate plugin
 # registries, separate install flows), so each editor keeps its own install/session identity.
 # Fails closed (exit 0) on any error — telemetry must never break a Copilot session.
-# On the first-ever run (when install_id is created) it also fires a one-shot
-# "Toolkit Installed" beacon — fail-open and non-blocking.
+# Every session it also invokes the install beacon, which fires once per toolkit
+# version (first install + upgrades) — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.copilot/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
-install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
-  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
-# First-ever run for this editor: fire the one-shot install beacon now that both
-# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
-# fail-open — never let telemetry break a session, and never gate the id writes
-# above on the beacon's outcome.
+# Invoke the install beacon now that both ids exist (the sink requires both). It
+# self-dedups by toolkit version — firing once per version (first install plus
+# upgrades). Backgrounded, fail-open — never let telemetry break a session, and
+# never gate the id writes above on its outcome.
 # Copilot's manifest is the plugin-root plugin.json (no .copilot-plugin/ subdir),
 # so the version path is one level shallower than the other editors.
-if [[ "$install_id_created" == "1" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
-    "$DIR" \
-    "$SCRIPT_DIR/../../../plugin.json" \
-    "copilot" 2>/dev/null || true
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+  "$DIR" \
+  "$SCRIPT_DIR/../../../plugin.json" \
+  "copilot" 2>/dev/null || true
 
 exit 0

--- a/plugins/copilot/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/copilot/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ensure stable install_id and fresh toolkit_session_id for the current Copilot session.
+# install_id is generated once and persisted; toolkit_session_id is regenerated every session.
+# IDs live under Copilot's own config home (~/.copilot), NOT ~/.claude: a toolkit install in
+# Copilot is a distinct installation from one in Claude Code or Cortex Code (separate plugin
+# registries, separate install flows), so each editor keeps its own install/session identity.
+# Fails closed (exit 0) on any error — telemetry must never break a Copilot session.
+# On the first-ever run (when install_id is created) it also fires a one-shot
+# "Toolkit Installed" beacon — fail-open and non-blocking.
+set -uo pipefail
+
+DIR="$HOME/.copilot/mc-agent-toolkit"
+mkdir -p "$DIR" 2>/dev/null || exit 0
+
+install_id_created=0
+if [[ ! -f "$DIR/install_id" ]]; then
+  uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
+  chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
+  install_id_created=1
+fi
+
+uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+
+# First-ever run for this editor: fire the one-shot install beacon now that both
+# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
+# fail-open — never let telemetry break a session, and never gate the id writes
+# above on the beacon's outcome.
+# Copilot's manifest is the plugin-root plugin.json (no .copilot-plugin/ subdir),
+# so the version path is one level shallower than the other editors.
+if [[ "$install_id_created" == "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+    "$DIR" \
+    "$SCRIPT_DIR/../../../plugin.json" \
+    "copilot" 2>/dev/null || true
+fi
+
+exit 0

--- a/plugins/copilot/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/copilot/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
-# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# (one JSON line per invocation) and exits 0. Used by install-beacon and skill-beacon tests to
 # verify what would have been sent without making network calls.
 set -uo pipefail
 

--- a/plugins/copilot/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/copilot/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
+# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# verify what would have been sent without making network calls.
+set -uo pipefail
+
+LOG="${MOCK_CURL_LOG:-/dev/null}"
+STDIN_PAYLOAD="$(cat || true)"
+
+# Pull the body from -d/--data when present; otherwise fall back to stdin.
+data=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -d|--data|--data-raw|--data-binary) data="$arg" ;;
+  esac
+  prev="$arg"
+done
+[[ -z "$data" ]] && data="$STDIN_PAYLOAD"
+
+# argv as a JSON array; data as a string. jq handles all escaping.
+jq -nc \
+  --argjson argv "$(printf '%s\n' "$@" | jq -R . | jq -sc .)" \
+  --arg data "$data" \
+  '{argv: $argv, data: $data}' >> "$LOG"
+
+exit 0

--- a/plugins/copilot/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+  IDS_DIR="$TEST_HOME/.copilot/mc-agent-toolkit"
+
+  # First run now fires the install beacon — mock curl so no real network calls
+  # happen during tests, and run it synchronously for deterministic assertions.
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+  export MC_BEACON_SYNC=1
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+@test "creates install_id and toolkit_session_id files" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/install_id" ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}
+
+@test "files contain lowercase UUIDs" {
+  bash "$SCRIPT"
+  install_id="$(cat "$IDS_DIR/install_id")"
+  toolkit_session_id="$(cat "$IDS_DIR/toolkit_session_id")"
+  [[ "$install_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+  [[ "$toolkit_session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+@test "files have mode 600" {
+  bash "$SCRIPT"
+  perms_install="$(stat -f '%Lp' "$IDS_DIR/install_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/install_id")"
+  perms_session="$(stat -f '%Lp' "$IDS_DIR/toolkit_session_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/toolkit_session_id")"
+  [ "$perms_install" = "600" ]
+  [ "$perms_session" = "600" ]
+}
+
+@test "install_id is stable across runs; toolkit_session_id rotates" {
+  bash "$SCRIPT"
+  install_first="$(cat "$IDS_DIR/install_id")"
+  session_first="$(cat "$IDS_DIR/toolkit_session_id")"
+  bash "$SCRIPT"
+  install_second="$(cat "$IDS_DIR/install_id")"
+  session_second="$(cat "$IDS_DIR/toolkit_session_id")"
+  [ "$install_first" = "$install_second" ]
+  [ "$session_first" != "$session_second" ]
+}
+
+@test "creates parent directory when absent" {
+  rm -rf "$TEST_HOME/.copilot"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -d "$IDS_DIR" ]
+}
+
+@test "exits 0 even when parent directory cannot be created" {
+  # Make $HOME a regular file so mkdir -p $HOME/.copilot/... must fail.
+  rm -rf "$TEST_HOME"
+  touch "$TEST_HOME"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "first run fires exactly one Toolkit Installed beacon" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(wc -l < "$MOCK_CURL_LOG" | tr -d ' ')" = "1" ]
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "copilot" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "$(cat "$IDS_DIR/install_id")" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
+}
+
+@test "second run does not fire the install beacon (install_id already exists)" {
+  bash "$SCRIPT"
+  : > "$MOCK_CURL_LOG"   # clear the first-run beacon
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+  bash "$SCRIPT"
+  rm "$IDS_DIR/install_id"
+  : > "$MOCK_CURL_LOG"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson.event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}
+
+@test "toolkit_session_id is written even on the first (beacon-firing) run" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}

--- a/plugins/copilot/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -84,7 +84,7 @@ teardown() {
   [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
 }
 
-@test "second run does not fire the install beacon (install_id already exists)" {
+@test "second run does not fire the install beacon (same version)" {
   bash "$SCRIPT"
   : > "$MOCK_CURL_LOG"   # clear the first-run beacon
   run bash "$SCRIPT"
@@ -92,9 +92,9 @@ teardown() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+@test "re-fires the install beacon after a toolkit version change" {
   bash "$SCRIPT"
-  rm "$IDS_DIR/install_id"
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"   # simulate an older recorded version
   : > "$MOCK_CURL_LOG"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
@@ -116,3 +116,19 @@ wait_for_log() {
   [ -s "$MOCK_CURL_LOG" ]
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
 }
+
+@test "does not fire when beacon_sent_version matches the current version" {
+  echo "$(jq -r '.version' "$MANIFEST")" > "$IDS_DIR/beacon_sent_version"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires and updates the marker when beacon_sent_version differs" {
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+  [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
+}

--- a/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
@@ -107,3 +107,12 @@ wait_for_log() {
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
   ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }
+
+@test "backgrounded beacon (no MC_BEACON_SYNC) still fires" {
+  # Exercise the production default path: ( curl ... ) & disown.
+  unset MC_BEACON_SYNC
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}

--- a/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
@@ -132,3 +132,10 @@ wait_for_log() {
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
   [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
 }
+
+@test "does not fire (or write marker) when the toolkit version is unknown" {
+  run bash "$SCRIPT" "$IDS_DIR" "/nonexistent/plugin.json" "copilot"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+  [ ! -f "$IDS_DIR/beacon_sent_version" ]
+}

--- a/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/copilot/hooks/telemetry/tests/test_install_beacon.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# The install beacon fires once, at first-ever session start, carrying the
+# "Toolkit Installed" event. It is editor-agnostic shared code synced from
+# plugins/shared/telemetry/lib/; these tests exercise the Copilot copy.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.copilot/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../lib/install-beacon.sh"
+  # Copilot's manifest is the plugin-root plugin.json (no .copilot-plugin/ subdir).
+  MANIFEST="$BATS_TEST_DIRNAME/../../../plugin.json"
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+  # Run curl synchronously so "no beacon" assertions are deterministic.
+  export MC_BEACON_SYNC=1
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires Toolkit Installed beacon with ids and copilot harness" {
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  [ "$status" -eq 0 ]
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "copilot" ]
+}
+
+@test "install payload carries no skill fields" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r 'has("skill")')" = "false" ]
+  [ "$(echo "$payload" | jq -r 'has("skill_args_present")')" = "false" ]
+}
+
+@test "payload includes toolkit_version from plugin.json" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$MANIFEST")"
+  [ "$version" = "$expected" ]
+  [ "$version" != "unknown" ]
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing toolkit_session_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "curl is called with -m 2 and the prod beacon URL by default" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "copilot"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/copilot/scripts/install.sh
+++ b/plugins/copilot/scripts/install.sh
@@ -72,6 +72,42 @@ cp "$SCRIPT_DIR/mc-prevent.json" "$HOOKS_DEST/"
 
 echo "  ✓ Hook registration copied to .github/hooks/mc-prevent.json"
 
+# --- 4. User-global session-start telemetry hook (install beacon) ---
+# Unlike the project-level Prevent hooks above, the install beacon is registered
+# at the user level (~/.copilot/hooks/) so the toolkit installation is counted
+# once per machine, regardless of which repo a session runs in. Fail-open: the
+# beacon never blocks a session and the marker dedups it to one POST per machine.
+COPILOT_HOME_DIR="${COPILOT_HOME:-$HOME/.copilot}"
+COPILOT_HOOKS_DIR="$COPILOT_HOME_DIR/hooks"
+TELEMETRY_DEST="$COPILOT_HOOKS_DIR/mc-agent-toolkit"
+
+mkdir -p "$TELEMETRY_DEST/hooks"
+# Copy the telemetry tree (scripts + synced lib) and the manifest, preserving the
+# layout so ensure-toolkit-ids.sh resolves ../../../plugin.json for the version.
+rm -rf "$TELEMETRY_DEST/hooks/telemetry"
+cp -R "$PLUGIN_DIR/hooks/telemetry" "$TELEMETRY_DEST/hooks/"
+cp "$PLUGIN_DIR/plugin.json" "$TELEMETRY_DEST/plugin.json"
+rm -rf "$TELEMETRY_DEST/hooks/telemetry/tests"
+ENSURE_IDS="$TELEMETRY_DEST/hooks/telemetry/scripts/ensure-toolkit-ids.sh"
+chmod +x "$ENSURE_IDS"
+
+cat > "$COPILOT_HOOKS_DIR/mc-agent-toolkit-telemetry.json" << EOF
+{
+    "version": 1,
+    "hooks": {
+        "sessionStart": [
+            {
+                "type": "command",
+                "bash": "bash '$ENSURE_IDS'",
+                "timeoutSec": 5
+            }
+        ]
+    }
+}
+EOF
+
+echo "  ✓ Session-start telemetry hook registered at $COPILOT_HOOKS_DIR/mc-agent-toolkit-telemetry.json"
+
 # --- Done ---
 
 echo ""

--- a/plugins/copilot/scripts/install.sh
+++ b/plugins/copilot/scripts/install.sh
@@ -16,9 +16,10 @@ TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$PLUGIN_DIR/../.." && pwd)"
 HOOKS_SRC="$PLUGIN_DIR/hooks/prevent"
-LIB_SRC="$REPO_ROOT/hooks/prevent/lib"
+# Plugin-local synced copy of the shared lib (kept in sync from plugins/shared/prevent/lib
+# by bump-version.sh), consistent with HOOKS_SRC above.
+LIB_SRC="$PLUGIN_DIR/hooks/prevent/lib"
 
 # --- Preflight checks ---
 

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/cortex-code/README.md
+++ b/plugins/cortex-code/README.md
@@ -37,7 +37,7 @@ You should see `mc-agent-toolkit` listed as `[enabled, managed]` with command, s
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`cortex-code`). No prompts, arguments, or code are ever sent.
 
-It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Cortex Code after installing, and again after each upgrade — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`cortex-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Cortex Code after installing, and again after each version change — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`cortex-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cortex Code. The toolkit will not phone home.
 

--- a/plugins/cortex-code/README.md
+++ b/plugins/cortex-code/README.md
@@ -37,6 +37,8 @@ You should see `mc-agent-toolkit` listed as `[enabled, managed]` with command, s
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`cortex-code`). No prompts, arguments, or code are ever sent.
 
+It also sends a one-shot `Toolkit Installed` beacon the first time you start Cortex Code after installing — deduped by a local marker so it fires at most once per machine, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`cortex-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cortex Code. The toolkit will not phone home.
 
 The data is stored in Mixpanel and Datadog and is used only for product-development decisions about which skills to invest in. The UUIDs are generated locally on first session and stored under `~/.snowflake/cortex/mc-agent-toolkit/` (Cortex Code's own config home) — separate from any Claude Code toolkit install, so each editor keeps its own anonymous identity. Deleting that directory resets the Cortex Code install identity to a fresh one.

--- a/plugins/cortex-code/README.md
+++ b/plugins/cortex-code/README.md
@@ -37,7 +37,7 @@ You should see `mc-agent-toolkit` listed as `[enabled, managed]` with command, s
 
 The toolkit sends anonymous skill-usage telemetry by default — which skills are invoked, how often. Each event includes an opaque per-install UUID, a per-session UUID, the skill name, the toolkit version, and the editor it runs in (`cortex-code`). No prompts, arguments, or code are ever sent.
 
-It also sends a one-shot `Toolkit Installed` beacon the first time you start Cortex Code after installing — deduped by a local marker so it fires at most once per machine, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`cortex-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
+It also sends a `Toolkit Installed` beacon once per toolkit version — the first time you start Cortex Code after installing, and again after each upgrade — deduped by a local marker, independent of whether you ever run a skill. It carries the install/session UUIDs, toolkit version, and editor (`cortex-code`) — no skill field. Like the skill beacon, it is fail-open and non-blocking.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cortex Code. The toolkit will not phone home.
 

--- a/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cortex-code/hooks/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/plugins/cortex-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/cortex-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -7,17 +7,33 @@
 # and the two never share an install_id or clobber each other's session_id.
 # Fails closed (exit 0) on any error — telemetry must never break a Cortex Code session.
 # If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
+# On the first-ever run (when install_id is created) it also fires a one-shot
+# "Toolkit Installed" beacon — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.snowflake/cortex/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
+install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
+  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+
+# First-ever run for this editor: fire the one-shot install beacon now that both
+# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
+# fail-open — never let telemetry break a session, and never gate the id writes
+# above on the beacon's outcome.
+if [[ "$install_id_created" == "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+    "$DIR" \
+    "$SCRIPT_DIR/../../../.cortex-plugin/plugin.json" \
+    "cortex-code" 2>/dev/null || true
+fi
 
 exit 0

--- a/plugins/cortex-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/cortex-code/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -7,33 +7,29 @@
 # and the two never share an install_id or clobber each other's session_id.
 # Fails closed (exit 0) on any error — telemetry must never break a Cortex Code session.
 # If UUID files don't get written, skill-beacon.sh detects missing IDs and bails out.
-# On the first-ever run (when install_id is created) it also fires a one-shot
-# "Toolkit Installed" beacon — fail-open and non-blocking.
+# Every session it also invokes the install beacon, which fires once per toolkit
+# version (first install + upgrades) — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.snowflake/cortex/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
-install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
-  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
-# First-ever run for this editor: fire the one-shot install beacon now that both
-# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
-# fail-open — never let telemetry break a session, and never gate the id writes
-# above on the beacon's outcome.
-if [[ "$install_id_created" == "1" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
-    "$DIR" \
-    "$SCRIPT_DIR/../../../.cortex-plugin/plugin.json" \
-    "cortex-code" 2>/dev/null || true
-fi
+# Invoke the install beacon now that both ids exist (the sink requires both). It
+# self-dedups by toolkit version — firing once per version (first install plus
+# upgrades). Backgrounded, fail-open — never let telemetry break a session, and
+# never gate the id writes above on its outcome.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+  "$DIR" \
+  "$SCRIPT_DIR/../../../.cortex-plugin/plugin.json" \
+  "cortex-code" 2>/dev/null || true
 
 exit 0

--- a/plugins/cortex-code/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/cortex-code/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
-# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# (one JSON line per invocation) and exits 0. Used by install-beacon and skill-beacon tests to
 # verify what would have been sent without making network calls.
 set -uo pipefail
 

--- a/plugins/cortex-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -4,10 +4,23 @@ setup() {
   TEST_HOME="$(mktemp -d)"
   export HOME="$TEST_HOME"
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+  IDS_DIR="$TEST_HOME/.snowflake/cortex/mc-agent-toolkit"
+
+  # First run now fires the install beacon — mock curl so no real network calls
+  # happen during tests, and run it synchronously for deterministic assertions.
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+  export MC_BEACON_SYNC=1
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
 }
 
 teardown() {
-  rm -rf "$TEST_HOME"
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
 }
 
 @test "creates install_id and toolkit_session_id files" {
@@ -57,4 +70,40 @@ teardown() {
   touch "$TEST_HOME"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
+}
+
+@test "first run fires exactly one Toolkit Installed beacon" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(wc -l < "$MOCK_CURL_LOG" | tr -d ' ')" = "1" ]
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "cortex-code" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "$(cat "$IDS_DIR/install_id")" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
+}
+
+@test "second run does not fire the install beacon (install_id already exists)" {
+  bash "$SCRIPT"
+  : > "$MOCK_CURL_LOG"   # clear the first-run beacon
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+  bash "$SCRIPT"
+  rm "$IDS_DIR/install_id"
+  : > "$MOCK_CURL_LOG"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson.event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}
+
+@test "toolkit_session_id is written even on the first (beacon-firing) run" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
 }

--- a/plugins/cortex-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -84,7 +84,7 @@ teardown() {
   [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
 }
 
-@test "second run does not fire the install beacon (install_id already exists)" {
+@test "second run does not fire the install beacon (same version)" {
   bash "$SCRIPT"
   : > "$MOCK_CURL_LOG"   # clear the first-run beacon
   run bash "$SCRIPT"
@@ -92,9 +92,9 @@ teardown() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+@test "re-fires the install beacon after a toolkit version change" {
   bash "$SCRIPT"
-  rm "$IDS_DIR/install_id"
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"   # simulate an older recorded version
   : > "$MOCK_CURL_LOG"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -130,3 +130,10 @@ wait_for_log() {
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
   [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
 }
+
+@test "does not fire (or write marker) when the toolkit version is unknown" {
+  run bash "$SCRIPT" "$IDS_DIR" "/nonexistent/plugin.json" "cortex-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+  [ ! -f "$IDS_DIR/beacon_sent_version" ]
+}

--- a/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -105,3 +105,12 @@ wait_for_log() {
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
   ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }
+
+@test "backgrounded beacon (no MC_BEACON_SYNC) still fires" {
+  # Exercise the production default path: ( curl ... ) & disown.
+  unset MC_BEACON_SYNC
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}

--- a/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# The install beacon fires once, at first-ever session start, carrying the
+# "Toolkit Installed" event. It is editor-agnostic shared code synced from
+# plugins/shared/telemetry/lib/; these tests exercise the Cortex Code copy.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.snowflake/cortex/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../lib/install-beacon.sh"
+  MANIFEST="$BATS_TEST_DIRNAME/../../../.cortex-plugin/plugin.json"
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+  # Run curl synchronously so "no beacon" assertions are deterministic.
+  export MC_BEACON_SYNC=1
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires Toolkit Installed beacon with ids and cortex-code harness" {
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  [ "$status" -eq 0 ]
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "cortex-code" ]
+}
+
+@test "install payload carries no skill fields" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r 'has("skill")')" = "false" ]
+  [ "$(echo "$payload" | jq -r 'has("skill_args_present")')" = "false" ]
+}
+
+@test "payload includes toolkit_version from .cortex-plugin/plugin.json" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$MANIFEST")"
+  [ "$version" = "$expected" ]
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing toolkit_session_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "curl is called with -m 2 and the prod beacon URL by default" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cortex-code/hooks/telemetry/tests/test_install_beacon.bats
@@ -114,3 +114,19 @@ wait_for_log() {
   [ -s "$MOCK_CURL_LOG" ]
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
 }
+
+@test "does not fire when beacon_sent_version matches the current version" {
+  echo "$(jq -r '.version' "$MANIFEST")" > "$IDS_DIR/beacon_sent_version"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires and updates the marker when beacon_sent_version differs" {
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cortex-code"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+  [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
+}

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -43,6 +43,14 @@ bash <(curl -fsSL https://raw.githubusercontent.com/monte-carlo-data/mc-agent-to
 
 - **Hook denials may not be enforced.** Cursor's `beforeReadFile` (and potentially other `before*` hooks) may fail to block the operation even when the hook exits with a deny response. This means Prevent hooks can detect and warn about breaking changes but cannot guarantee the edit is stopped. See [Cursor forum discussion](https://forum.cursor.com/t/hook-beforereadfile-does-not-work-in-the-agent/150520) for details.
 
+## Telemetry
+
+The toolkit sends a single anonymous install beacon the first time you start Cursor after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`cursor`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+
+To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cursor. The toolkit will not phone home.
+
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions. The UUIDs are generated locally on first session and stored under `~/.cursor/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+
 ## Architecture
 
 The toolkit plugin wraps shared skills and hook logic, with each feature namespaced independently:

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -45,7 +45,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/monte-carlo-data/mc-agent-to
 
 ## Telemetry
 
-The toolkit sends a single anonymous install beacon the first time you start Cursor after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`cursor`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`cursor`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Cursor after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cursor. The toolkit will not phone home.
 

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -45,7 +45,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/monte-carlo-data/mc-agent-to
 
 ## Telemetry
 
-The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`cursor`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Cursor after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`cursor`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start Cursor after installing, and again after each version change (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting Cursor. The toolkit will not phone home.
 

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -59,5 +59,6 @@ The toolkit plugin wraps shared skills and hook logic, with each feature namespa
 - **Shared hook logic** — copied from `plugins/shared/prevent/lib/` into each plugin's `hooks/prevent/lib/` (platform-agnostic business logic)
 - **Adapter hooks** — Cursor-specific JSON parsing and output formatting under `hooks/prevent/`
 - **MCP config** — Monte Carlo MCP server connection
+- **Telemetry hook** — the install-beacon `sessionStart` is registered in `hooks/prevent/hooks.json` (Cursor loads a single manifest-referenced hooks file per plugin), while the script itself lives under `hooks/telemetry/`
 
 See the [plugins README](../README.md) for the overall plugin architecture and editor support comparison.

--- a/plugins/cursor/hooks/prevent/hooks.json
+++ b/plugins/cursor/hooks/prevent/hooks.json
@@ -1,6 +1,11 @@
 {
     "version": 1,
     "hooks": {
+        "sessionStart": [
+            {
+                "command": "bash ${CURSOR_PLUGIN_ROOT}/hooks/telemetry/scripts/ensure-toolkit-ids.sh"
+            }
+        ],
         "preToolUse": [
             {
                 "command": "python3 ${CURSOR_PLUGIN_ROOT}/hooks/prevent/pre_edit_hook.py",

--- a/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
+++ b/plugins/cursor/hooks/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/plugins/cursor/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/cursor/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Ensure stable install_id and fresh toolkit_session_id for the current Cursor session.
+# install_id is generated once and persisted; toolkit_session_id is regenerated every session.
+# IDs live under Cursor's own config home (~/.cursor), NOT ~/.claude: a toolkit install in
+# Cursor is a distinct installation from one in Claude Code or Cortex Code (separate plugin
+# registries, separate install flows), so each editor keeps its own install/session identity.
+# Fails closed (exit 0) on any error — telemetry must never break a Cursor session.
+# On the first-ever run (when install_id is created) it also fires a one-shot
+# "Toolkit Installed" beacon — fail-open and non-blocking.
+set -uo pipefail
+
+DIR="$HOME/.cursor/mc-agent-toolkit"
+mkdir -p "$DIR" 2>/dev/null || exit 0
+
+install_id_created=0
+if [[ ! -f "$DIR/install_id" ]]; then
+  uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
+  chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
+  install_id_created=1
+fi
+
+uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
+
+# First-ever run for this editor: fire the one-shot install beacon now that both
+# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
+# fail-open — never let telemetry break a session, and never gate the id writes
+# above on the beacon's outcome.
+if [[ "$install_id_created" == "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+    "$DIR" \
+    "$SCRIPT_DIR/../../../.cursor-plugin/plugin.json" \
+    "cursor" 2>/dev/null || true
+fi
+
+exit 0

--- a/plugins/cursor/hooks/telemetry/scripts/ensure-toolkit-ids.sh
+++ b/plugins/cursor/hooks/telemetry/scripts/ensure-toolkit-ids.sh
@@ -5,33 +5,29 @@
 # Cursor is a distinct installation from one in Claude Code or Cortex Code (separate plugin
 # registries, separate install flows), so each editor keeps its own install/session identity.
 # Fails closed (exit 0) on any error — telemetry must never break a Cursor session.
-# On the first-ever run (when install_id is created) it also fires a one-shot
-# "Toolkit Installed" beacon — fail-open and non-blocking.
+# Every session it also invokes the install beacon, which fires once per toolkit
+# version (first install + upgrades) — fail-open and non-blocking.
 set -uo pipefail
 
 DIR="$HOME/.cursor/mc-agent-toolkit"
 mkdir -p "$DIR" 2>/dev/null || exit 0
 
-install_id_created=0
 if [[ ! -f "$DIR/install_id" ]]; then
   uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/install_id" 2>/dev/null || exit 0
   chmod 600 "$DIR/install_id" 2>/dev/null || exit 0
-  install_id_created=1
 fi
 
 uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' > "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 chmod 600 "$DIR/toolkit_session_id" 2>/dev/null || exit 0
 
-# First-ever run for this editor: fire the one-shot install beacon now that both
-# install_id and toolkit_session_id exist (the sink requires both). Backgrounded,
-# fail-open — never let telemetry break a session, and never gate the id writes
-# above on the beacon's outcome.
-if [[ "$install_id_created" == "1" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
-    "$DIR" \
-    "$SCRIPT_DIR/../../../.cursor-plugin/plugin.json" \
-    "cursor" 2>/dev/null || true
-fi
+# Invoke the install beacon now that both ids exist (the sink requires both). It
+# self-dedups by toolkit version — firing once per version (first install plus
+# upgrades). Backgrounded, fail-open — never let telemetry break a session, and
+# never gate the id writes above on its outcome.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/../lib/install-beacon.sh" \
+  "$DIR" \
+  "$SCRIPT_DIR/../../../.cursor-plugin/plugin.json" \
+  "cursor" 2>/dev/null || true
 
 exit 0

--- a/plugins/cursor/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/cursor/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
-# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# (one JSON line per invocation) and exits 0. Used by install-beacon and skill-beacon tests to
 # verify what would have been sent without making network calls.
 set -uo pipefail
 

--- a/plugins/cursor/hooks/telemetry/tests/helpers/mock_curl.sh
+++ b/plugins/cursor/hooks/telemetry/tests/helpers/mock_curl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test shim: replaces real curl on PATH. Logs argv + stdin to $MOCK_CURL_LOG
+# (one JSON line per invocation) and exits 0. Used by skill-beacon tests to
+# verify what would have been sent without making network calls.
+set -uo pipefail
+
+LOG="${MOCK_CURL_LOG:-/dev/null}"
+STDIN_PAYLOAD="$(cat || true)"
+
+# Pull the body from -d/--data when present; otherwise fall back to stdin.
+data=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -d|--data|--data-raw|--data-binary) data="$arg" ;;
+  esac
+  prev="$arg"
+done
+[[ -z "$data" ]] && data="$STDIN_PAYLOAD"
+
+# argv as a JSON array; data as a string. jq handles all escaping.
+jq -nc \
+  --argjson argv "$(printf '%s\n' "$@" | jq -R . | jq -sc .)" \
+  --arg data "$data" \
+  '{argv: $argv, data: $data}' >> "$LOG"
+
+exit 0

--- a/plugins/cursor/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/ensure-toolkit-ids.sh"
+  IDS_DIR="$TEST_HOME/.cursor/mc-agent-toolkit"
+
+  # First run now fires the install beacon — mock curl so no real network calls
+  # happen during tests, and run it synchronously for deterministic assertions.
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+  export MC_BEACON_SYNC=1
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+@test "creates install_id and toolkit_session_id files" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/install_id" ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}
+
+@test "files contain lowercase UUIDs" {
+  bash "$SCRIPT"
+  install_id="$(cat "$IDS_DIR/install_id")"
+  toolkit_session_id="$(cat "$IDS_DIR/toolkit_session_id")"
+  [[ "$install_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+  [[ "$toolkit_session_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+@test "files have mode 600" {
+  bash "$SCRIPT"
+  perms_install="$(stat -f '%Lp' "$IDS_DIR/install_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/install_id")"
+  perms_session="$(stat -f '%Lp' "$IDS_DIR/toolkit_session_id" 2>/dev/null || stat -c '%a' "$IDS_DIR/toolkit_session_id")"
+  [ "$perms_install" = "600" ]
+  [ "$perms_session" = "600" ]
+}
+
+@test "install_id is stable across runs; toolkit_session_id rotates" {
+  bash "$SCRIPT"
+  install_first="$(cat "$IDS_DIR/install_id")"
+  session_first="$(cat "$IDS_DIR/toolkit_session_id")"
+  bash "$SCRIPT"
+  install_second="$(cat "$IDS_DIR/install_id")"
+  session_second="$(cat "$IDS_DIR/toolkit_session_id")"
+  [ "$install_first" = "$install_second" ]
+  [ "$session_first" != "$session_second" ]
+}
+
+@test "creates parent directory when absent" {
+  rm -rf "$TEST_HOME/.cursor"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -d "$IDS_DIR" ]
+}
+
+@test "exits 0 even when parent directory cannot be created" {
+  # Make $HOME a regular file so mkdir -p $HOME/.cursor/... must fail.
+  rm -rf "$TEST_HOME"
+  touch "$TEST_HOME"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "first run fires exactly one Toolkit Installed beacon" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(wc -l < "$MOCK_CURL_LOG" | tr -d ' ')" = "1" ]
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "cursor" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "$(cat "$IDS_DIR/install_id")" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
+}
+
+@test "second run does not fire the install beacon (install_id already exists)" {
+  bash "$SCRIPT"
+  : > "$MOCK_CURL_LOG"   # clear the first-run beacon
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+  bash "$SCRIPT"
+  rm "$IDS_DIR/install_id"
+  : > "$MOCK_CURL_LOG"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson.event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}
+
+@test "toolkit_session_id is written even on the first (beacon-firing) run" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$IDS_DIR/toolkit_session_id" ]
+}

--- a/plugins/cursor/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_ensure_toolkit_ids.bats
@@ -84,7 +84,7 @@ teardown() {
   [ "$(echo "$payload" | jq -r '.session_id')" = "$(cat "$IDS_DIR/toolkit_session_id")" ]
 }
 
-@test "second run does not fire the install beacon (install_id already exists)" {
+@test "second run does not fire the install beacon (same version)" {
   bash "$SCRIPT"
   : > "$MOCK_CURL_LOG"   # clear the first-run beacon
   run bash "$SCRIPT"
@@ -92,9 +92,9 @@ teardown() {
   [ ! -s "$MOCK_CURL_LOG" ]
 }
 
-@test "re-fires the install beacon after install_id is deleted (marker wipe)" {
+@test "re-fires the install beacon after a toolkit version change" {
   bash "$SCRIPT"
-  rm "$IDS_DIR/install_id"
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"   # simulate an older recorded version
   : > "$MOCK_CURL_LOG"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
@@ -105,3 +105,12 @@ wait_for_log() {
   echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
   ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
 }
+
+@test "backgrounded beacon (no MC_BEACON_SYNC) still fires" {
+  # Exercise the production default path: ( curl ... ) & disown.
+  unset MC_BEACON_SYNC
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+}

--- a/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# The install beacon fires once, at first-ever session start, carrying the
+# "Toolkit Installed" event. It is editor-agnostic shared code synced from
+# plugins/shared/telemetry/lib/; these tests exercise the Cursor copy.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+  IDS_DIR="$TEST_HOME/.cursor/mc-agent-toolkit"
+  mkdir -p "$IDS_DIR"
+  echo "11111111-1111-1111-1111-111111111111" > "$IDS_DIR/install_id"
+  echo "22222222-2222-2222-2222-222222222222" > "$IDS_DIR/toolkit_session_id"
+
+  # Mock curl on PATH
+  MOCK_BIN="$(mktemp -d)"
+  cp "$BATS_TEST_DIRNAME/helpers/mock_curl.sh" "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+  export PATH="$MOCK_BIN:$PATH"
+  export MOCK_CURL_LOG="$(mktemp)"
+
+  SCRIPT="$BATS_TEST_DIRNAME/../lib/install-beacon.sh"
+  MANIFEST="$BATS_TEST_DIRNAME/../../../.cursor-plugin/plugin.json"
+  unset MC_AGENT_TOOLKIT_TELEMETRY_DISABLED
+  unset MCD_TOOLKIT_BEACON_URL
+  # Run curl synchronously so "no beacon" assertions are deterministic.
+  export MC_BEACON_SYNC=1
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+  rm -f "$MOCK_CURL_LOG"
+}
+
+wait_for_log() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$MOCK_CURL_LOG" ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+@test "fires Toolkit Installed beacon with ids and cursor harness" {
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  [ "$status" -eq 0 ]
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r '.event')" = "Toolkit Installed" ]
+  [ "$(echo "$payload" | jq -r '.install_id')" = "11111111-1111-1111-1111-111111111111" ]
+  [ "$(echo "$payload" | jq -r '.session_id')" = "22222222-2222-2222-2222-222222222222" ]
+  [ "$(echo "$payload" | jq -r '.harness')" = "cursor" ]
+}
+
+@test "install payload carries no skill fields" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  [ "$(echo "$payload" | jq -r 'has("skill")')" = "false" ]
+  [ "$(echo "$payload" | jq -r 'has("skill_args_present")')" = "false" ]
+}
+
+@test "payload includes toolkit_version from .cursor-plugin/plugin.json" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  payload="$(jq -r '.data' "$MOCK_CURL_LOG")"
+  version="$(echo "$payload" | jq -r '.toolkit_version')"
+  expected="$(jq -r '.version' "$MANIFEST")"
+  [ "$version" = "$expected" ]
+}
+
+@test "opt-out env var suppresses beacon" {
+  export MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing install_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/install_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "missing toolkit_session_id results in no beacon, exit 0" {
+  rm "$IDS_DIR/toolkit_session_id"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "curl is called with -m 2 and the prod beacon URL by default" {
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"-m"'
+  echo "$argv" | grep -q '"2"'
+  echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}
+
+@test "MCD_TOOLKIT_BEACON_URL overrides the default URL" {
+  export MCD_TOOLKIT_BEACON_URL="https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  argv="$(jq -c '.argv' "$MOCK_CURL_LOG")"
+  echo "$argv" | grep -q '"https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"'
+  ! echo "$argv" | grep -q '"https://mcp.getmontecarlo.com/mcp/toolkit/beacon"'
+}

--- a/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
@@ -114,3 +114,19 @@ wait_for_log() {
   [ -s "$MOCK_CURL_LOG" ]
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
 }
+
+@test "does not fire when beacon_sent_version matches the current version" {
+  echo "$(jq -r '.version' "$MANIFEST")" > "$IDS_DIR/beacon_sent_version"
+  run bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+}
+
+@test "re-fires and updates the marker when beacon_sent_version differs" {
+  echo "0.0.0" > "$IDS_DIR/beacon_sent_version"
+  bash "$SCRIPT" "$IDS_DIR" "$MANIFEST" "cursor"
+  wait_for_log
+  [ -s "$MOCK_CURL_LOG" ]
+  [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
+  [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
+}

--- a/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
+++ b/plugins/cursor/hooks/telemetry/tests/test_install_beacon.bats
@@ -130,3 +130,10 @@ wait_for_log() {
   [ "$(jq -r '.data | fromjson | .event' "$MOCK_CURL_LOG")" = "Toolkit Installed" ]
   [ "$(cat "$IDS_DIR/beacon_sent_version")" = "$(jq -r '.version' "$MANIFEST")" ]
 }
+
+@test "does not fire (or write marker) when the toolkit version is unknown" {
+  run bash "$SCRIPT" "$IDS_DIR" "/nonexistent/plugin.json" "cursor"
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_CURL_LOG" ]
+  [ ! -f "$IDS_DIR/beacon_sent_version" ]
+}

--- a/plugins/cursor/scripts/install.sh
+++ b/plugins/cursor/scripts/install.sh
@@ -55,6 +55,7 @@ cp -rL "$CLONE_DIR/$PLUGIN_SRC" "$TARGET"
 
 # --- Remove test files and dev artifacts from installation ---
 rm -rf "$TARGET/tests" "$TARGET/scripts" "$TARGET/hooks/prevent/lib/tests" \
+       "$TARGET/hooks/telemetry/tests" \
        "$TARGET/__pycache__" "$TARGET/.DS_Store" "$TARGET/.git"
 find "$TARGET" -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
 find "$TARGET" -name "*.pyc" -delete 2>/dev/null || true

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each upgrade — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+- `Toolkit Installed` telemetry beacon, fired once per machine+editor **per toolkit version** — on first install and after each version change — independent of skill usage, closing the gap where an install that never invoked a skill was invisible and adding version-adoption signal. Deduped by a per-editor `beacon_sent_version` marker. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
 
 ### Changed
 

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-06-18
+
+### Added
+
+- One-shot `Toolkit Installed` telemetry beacon, fired once per machine+editor at first session start (deduped by the persistent `install_id` marker), independent of skill usage — closing the gap where an install that never invoked a skill was invisible. Wired across all six editor plugins (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode). Fail-open and non-blocking; honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and the `MCD_TOOLKIT_BEACON_URL` override.
+
+### Changed
+
+- Shared hook logic now also covers telemetry: the canonical install beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor plugin by `./scripts/bump-version.sh --sync-only`, with a CI check enforcing it stays in sync — mirroring the existing `prevent/lib` convention.
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -155,7 +155,7 @@ See [skills/prevent/references/TROUBLESHOOTING.md](../../../skills/prevent/refer
 
 ## Telemetry
 
-The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`opencode`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start OpenCode after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`opencode`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start OpenCode after installing, and again after each version change (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting OpenCode. The toolkit will not phone home.
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -153,6 +153,14 @@ See [skills/prevent/references/TROUBLESHOOTING.md](../../../skills/prevent/refer
 2. Check that `opencode.json` has the `mcp.monte-carlo-mcp` configuration
 3. Verify connectivity: the `testConnection` tool should succeed
 
+## Telemetry
+
+The toolkit sends a single anonymous install beacon the first time you start OpenCode after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`opencode`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+
+To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting OpenCode. The toolkit will not phone home.
+
+The data is stored in Mixpanel and Datadog and is used only for product-development decisions. The UUIDs are generated locally on first session and stored under `~/.config/opencode/mc-agent-toolkit/`. Deleting that directory resets your install identity to a fresh anonymous one.
+
 ## Architecture
 
 See the [plugins README](../README.md) for the overall plugin architecture and editor support comparison.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -155,7 +155,7 @@ See [skills/prevent/references/TROUBLESHOOTING.md](../../../skills/prevent/refer
 
 ## Telemetry
 
-The toolkit sends a single anonymous install beacon the first time you start OpenCode after installing — a one-shot `Toolkit Installed` event so we can count installations. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`opencode`). No prompts, arguments, skill names, or code are ever sent. It fires at most once per machine (deduped by a local marker), and is fail-open and non-blocking — it never delays or interrupts your session.
+The toolkit sends an anonymous install beacon — a `Toolkit Installed` event so we can count installations and version adoption. It includes an opaque per-install UUID, a per-session UUID, the toolkit version, and the editor it runs in (`opencode`). No prompts, arguments, skill names, or code are ever sent. It fires once per machine per toolkit version — the first time you start OpenCode after installing, and again after each upgrade (deduped by a local marker) — and is fail-open and non-blocking, never delaying or interrupting your session.
 
 To opt out, set `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` in your shell environment before starting OpenCode. The toolkit will not phone home.
 

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/opencode/src/prevent/index.ts
+++ b/plugins/opencode/src/prevent/index.ts
@@ -11,6 +11,7 @@
  */
 import type { Plugin } from "@opencode-ai/plugin";
 import { existsSync } from "fs";
+import { ensureToolkitIdsAndBeacon } from "../telemetry/install-beacon";
 import { isDbtModel, isDbtSchemaFile, extractTableName } from "./detect";
 import {
   cleanupStaleCache,
@@ -278,6 +279,14 @@ export const McPrevent: Plugin = async ({ client, directory, worktree }) => {
     },
 
     event: async ({ event }) => {
+      // Install telemetry: on the first-ever session start, fire a one-shot
+      // "Toolkit Installed" beacon (deduped by the persistent install_id marker).
+      // Detached + fail-open so it never blocks or breaks the session.
+      if (event.type === "session.created") {
+        void ensureToolkitIdsAndBeacon().catch(() => {});
+        return;
+      }
+
       try {
         if (event.type !== "session.idle") return;
         const sessionID = (event as any).properties?.sessionID;

--- a/plugins/opencode/src/telemetry/install-beacon.ts
+++ b/plugins/opencode/src/telemetry/install-beacon.ts
@@ -3,8 +3,9 @@
  *
  * OpenCode has no bash/Python hook layer, so this is the TypeScript equivalent of
  * the other editors' ensure-toolkit-ids.sh + shared install-beacon.sh: it persists
- * a per-machine install_id (the dedup marker) plus a rotating toolkit_session_id,
- * and on the first-ever run fires a single "Toolkit Installed" beacon. The payload
+ * a per-machine install_id plus a rotating toolkit_session_id, and fires a "Toolkit
+ * Installed" beacon once per (machine+editor, toolkit version) — on first install
+ * and on every version change — deduped by a beacon_sent_version marker. The payload
  * shape matches the bash beacon exactly (a cross-harness parity test guards this).
  *
  * Fail-open and non-blocking: every path swallows errors, the POST is detached with
@@ -90,9 +91,10 @@ async function postInstallBeacon(installId: string, sessionId: string): Promise<
 }
 
 /**
- * Ensure a stable install_id and a fresh toolkit_session_id, and fire the one-shot
- * install beacon on the first-ever run (when install_id is created). Awaitable for
- * tests; callers fire it detached so it never blocks session start.
+ * Ensure a stable install_id and a fresh toolkit_session_id, and fire the install
+ * beacon once per (machine+editor, toolkit version) — first install and every
+ * version change, deduped by a beacon_sent_version marker. Awaitable for tests;
+ * callers fire it detached so it never blocks session start.
  */
 export async function ensureToolkitIdsAndBeacon(): Promise<void> {
   if (process.env.MC_AGENT_TOOLKIT_TELEMETRY_DISABLED === "1") return;
@@ -108,7 +110,6 @@ export async function ensureToolkitIdsAndBeacon(): Promise<void> {
     const installPath = join(dir, "install_id");
     const sessionPath = join(dir, "toolkit_session_id");
 
-    let installIdCreated = false;
     let installId = readId(installPath);
     if (!installId) {
       installId = randomUUID();
@@ -118,7 +119,6 @@ export async function ensureToolkitIdsAndBeacon(): Promise<void> {
       } catch {
         // best-effort
       }
-      installIdCreated = true;
     }
 
     // Rotate the session id every session.
@@ -130,10 +130,21 @@ export async function ensureToolkitIdsAndBeacon(): Promise<void> {
       // best-effort
     }
 
-    // Dedup: only beacon on the first-ever creation of install_id. The sink also
-    // dedups on install_id as a backstop if the marker is wiped and this re-fires.
-    if (!installIdCreated) return;
     if (!installId || !sessionId) return; // never send empty/null ids
+
+    // Dedup: fire once per (install, version). The marker records the version we
+    // last beaconed for; re-fire only when it differs from the current version
+    // (first run, or any upgrade/downgrade). The sink also dedups on
+    // (install_id, toolkit_version) as a backstop if the marker is lost.
+    const version = toolkitVersion();
+    const sentPath = join(dir, "beacon_sent_version");
+    if (readId(sentPath) === version) return;
+    writeFileSync(sentPath, version, { mode: 0o600 });
+    try {
+      chmodSync(sentPath, 0o600);
+    } catch {
+      // best-effort
+    }
 
     await postInstallBeacon(installId, sessionId);
   } catch {

--- a/plugins/opencode/src/telemetry/install-beacon.ts
+++ b/plugins/opencode/src/telemetry/install-beacon.ts
@@ -137,6 +137,9 @@ export async function ensureToolkitIdsAndBeacon(): Promise<void> {
     // (first run, or any upgrade/downgrade). The sink also dedups on
     // (install_id, toolkit_version) as a backstop if the marker is lost.
     const version = toolkitVersion();
+    // If the version can't be resolved, skip — don't send a junk "unknown" beacon
+    // or write the marker; retry next session once a real version is available.
+    if (version === "unknown") return;
     const sentPath = join(dir, "beacon_sent_version");
     if (readId(sentPath) === version) return;
     writeFileSync(sentPath, version, { mode: 0o600 });

--- a/plugins/opencode/src/telemetry/install-beacon.ts
+++ b/plugins/opencode/src/telemetry/install-beacon.ts
@@ -1,0 +1,142 @@
+/**
+ * One-shot "Toolkit Installed" telemetry beacon for OpenCode.
+ *
+ * OpenCode has no bash/Python hook layer, so this is the TypeScript equivalent of
+ * the other editors' ensure-toolkit-ids.sh + shared install-beacon.sh: it persists
+ * a per-machine install_id (the dedup marker) plus a rotating toolkit_session_id,
+ * and on the first-ever run fires a single "Toolkit Installed" beacon. The payload
+ * shape matches the bash beacon exactly (a cross-harness parity test guards this).
+ *
+ * Fail-open and non-blocking: every path swallows errors, the POST is detached with
+ * a hard timeout, and an empty id is never sent (the sink requires valid v4 UUIDs).
+ */
+import { mkdirSync, readFileSync, writeFileSync, chmodSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { randomUUID } from "node:crypto";
+
+const HARNESS = "opencode";
+const BEACON_TIMEOUT_MS = 2000;
+
+/** Beacon endpoint; defaults to prod, overridable to dev for verification work. */
+function beaconUrl(): string {
+  return (
+    process.env.MCD_TOOLKIT_BEACON_URL ||
+    "https://mcp.getmontecarlo.com/mcp/toolkit/beacon"
+  );
+}
+
+/**
+ * Per-editor id directory under OpenCode's config home (XDG-aware), NOT ~/.claude:
+ * an OpenCode install is a distinct installation from one in another editor, so each
+ * keeps its own install/session identity.
+ */
+export function idsDir(): string {
+  const base = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(base, "opencode", "mc-agent-toolkit");
+}
+
+function readId(path: string): string {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+/** Resolve the toolkit version from the plugin's package.json (../../ from here). */
+function toolkitVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", "..", "package.json"), "utf8")
+    );
+    return typeof pkg.version === "string" && pkg.version ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Build the "Toolkit Installed" payload. Same key set as the bash install-beacon:
+ * event, install_id, session_id, toolkit_version, harness, ts. No skill fields.
+ */
+export function buildInstallPayload(installId: string, sessionId: string) {
+  return {
+    event: "Toolkit Installed",
+    install_id: installId,
+    session_id: sessionId,
+    toolkit_version: toolkitVersion(),
+    harness: HARNESS,
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+  };
+}
+
+/** POST the beacon with a hard timeout. Never throws. */
+async function postInstallBeacon(installId: string, sessionId: string): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), BEACON_TIMEOUT_MS);
+  try {
+    await fetch(beaconUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildInstallPayload(installId, sessionId)),
+      signal: controller.signal,
+    });
+  } catch {
+    // Swallow — telemetry must never surface an error to the session.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Ensure a stable install_id and a fresh toolkit_session_id, and fire the one-shot
+ * install beacon on the first-ever run (when install_id is created). Awaitable for
+ * tests; callers fire it detached so it never blocks session start.
+ */
+export async function ensureToolkitIdsAndBeacon(): Promise<void> {
+  if (process.env.MC_AGENT_TOOLKIT_TELEMETRY_DISABLED === "1") return;
+  try {
+    const dir = idsDir();
+    mkdirSync(dir, { recursive: true });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // best-effort
+    }
+
+    const installPath = join(dir, "install_id");
+    const sessionPath = join(dir, "toolkit_session_id");
+
+    let installIdCreated = false;
+    let installId = readId(installPath);
+    if (!installId) {
+      installId = randomUUID();
+      writeFileSync(installPath, installId, { mode: 0o600 });
+      try {
+        chmodSync(installPath, 0o600);
+      } catch {
+        // best-effort
+      }
+      installIdCreated = true;
+    }
+
+    // Rotate the session id every session.
+    const sessionId = randomUUID();
+    writeFileSync(sessionPath, sessionId, { mode: 0o600 });
+    try {
+      chmodSync(sessionPath, 0o600);
+    } catch {
+      // best-effort
+    }
+
+    // Dedup: only beacon on the first-ever creation of install_id. The sink also
+    // dedups on install_id as a backstop if the marker is wiped and this re-fires.
+    if (!installIdCreated) return;
+    if (!installId || !sessionId) return; // never send empty/null ids
+
+    await postInstallBeacon(installId, sessionId);
+  } catch {
+    // Fail-open — telemetry must never break a session.
+  }
+}

--- a/plugins/opencode/tests/telemetry/install-beacon.test.ts
+++ b/plugins/opencode/tests/telemetry/install-beacon.test.ts
@@ -6,9 +6,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   readFileSync,
+  writeFileSync,
   statSync,
   existsSync,
-  unlinkSync,
   mkdtempSync,
   rmSync,
 } from "fs";
@@ -125,16 +125,17 @@ describe("ensureToolkitIdsAndBeacon", () => {
     expect(session2).not.toBe(session1);
   });
 
-  it("second run does not fire the beacon (install_id already exists)", async () => {
+  it("second run does not fire the beacon (same version)", async () => {
     await ensureToolkitIdsAndBeacon();
     fetchCalls = [];
     await ensureToolkitIdsAndBeacon();
     expect(fetchCalls.length).toBe(0);
   });
 
-  it("re-fires the beacon after install_id is deleted (marker wipe)", async () => {
+  it("re-fires the beacon after a toolkit version change", async () => {
     await ensureToolkitIdsAndBeacon();
-    unlinkSync(installIdPath());
+    // Simulate an older recorded version so the next run sees a version change.
+    writeFileSync(join(idsDir(), "beacon_sent_version"), "0.0.0");
     fetchCalls = [];
     await ensureToolkitIdsAndBeacon();
     expect(fetchCalls.length).toBe(1);

--- a/plugins/opencode/tests/telemetry/install-beacon.test.ts
+++ b/plugins/opencode/tests/telemetry/install-beacon.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the OpenCode install beacon (TypeScript equivalent of the bash
+ * ensure-toolkit-ids.sh + install-beacon.sh). Mocks global fetch and points the
+ * id directory at a temp XDG_CONFIG_HOME so no real network or home writes happen.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  readFileSync,
+  statSync,
+  existsSync,
+  unlinkSync,
+  mkdtempSync,
+  rmSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ensureToolkitIdsAndBeacon,
+  buildInstallPayload,
+  idsDir,
+} from "../../src/telemetry/install-beacon";
+
+const V4_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PROD_URL = "https://mcp.getmontecarlo.com/mcp/toolkit/beacon";
+
+let fetchCalls: Array<{ url: string; init: any }>;
+let fetchImpl: (url: string, init: any) => Promise<any>;
+const realFetch = globalThis.fetch;
+
+let tmp: string;
+let origXDG: string | undefined;
+
+function installIdPath(): string {
+  return join(idsDir(), "install_id");
+}
+function sessionIdPath(): string {
+  return join(idsDir(), "toolkit_session_id");
+}
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchImpl = async (url, init) => {
+    fetchCalls.push({ url, init });
+    return { ok: true, status: 204 } as any;
+  };
+  globalThis.fetch = ((url: any, init: any) =>
+    fetchImpl(String(url), init)) as any;
+
+  tmp = mkdtempSync(join(tmpdir(), "mc-oc-tele-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = tmp;
+  delete process.env.MC_AGENT_TOOLKIT_TELEMETRY_DISABLED;
+  delete process.env.MCD_TOOLKIT_BEACON_URL;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (origXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = origXDG;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("buildInstallPayload", () => {
+  it("carries no skill fields and matches the cross-harness key set", () => {
+    const payload = buildInstallPayload(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222"
+    );
+    expect("skill" in payload).toBe(false);
+    expect("skill_args_present" in payload).toBe(false);
+    // Same keys the bash install-beacon emits.
+    expect(Object.keys(payload).sort()).toEqual([
+      "event",
+      "harness",
+      "install_id",
+      "session_id",
+      "toolkit_version",
+      "ts",
+    ]);
+    expect(payload.event).toBe("Toolkit Installed");
+    expect(payload.harness).toBe("opencode");
+  });
+
+  it("resolves a real toolkit_version from package.json (not 'unknown')", () => {
+    const expected = JSON.parse(
+      readFileSync(join(import.meta.dir, "../../package.json"), "utf8")
+    ).version;
+    const payload = buildInstallPayload("a", "b");
+    expect(payload.toolkit_version).toBe(expected);
+    expect(payload.toolkit_version).not.toBe("unknown");
+  });
+});
+
+describe("ensureToolkitIdsAndBeacon", () => {
+  it("first run mints v4 ids and fires exactly one Toolkit Installed beacon", async () => {
+    await ensureToolkitIdsAndBeacon();
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe(PROD_URL);
+    expect(fetchCalls[0].init.method).toBe("POST");
+
+    const installId = readFileSync(installIdPath(), "utf8").trim();
+    const sessionId = readFileSync(sessionIdPath(), "utf8").trim();
+    expect(installId).toMatch(V4_UUID_RE);
+    expect(sessionId).toMatch(V4_UUID_RE);
+
+    const body = JSON.parse(fetchCalls[0].init.body);
+    expect(body.event).toBe("Toolkit Installed");
+    expect(body.harness).toBe("opencode");
+    expect(body.install_id).toBe(installId);
+    expect(body.session_id).toBe(sessionId);
+  });
+
+  it("install_id is stable across runs; toolkit_session_id rotates", async () => {
+    await ensureToolkitIdsAndBeacon();
+    const install1 = readFileSync(installIdPath(), "utf8").trim();
+    const session1 = readFileSync(sessionIdPath(), "utf8").trim();
+
+    await ensureToolkitIdsAndBeacon();
+    const install2 = readFileSync(installIdPath(), "utf8").trim();
+    const session2 = readFileSync(sessionIdPath(), "utf8").trim();
+
+    expect(install2).toBe(install1);
+    expect(session2).not.toBe(session1);
+  });
+
+  it("second run does not fire the beacon (install_id already exists)", async () => {
+    await ensureToolkitIdsAndBeacon();
+    fetchCalls = [];
+    await ensureToolkitIdsAndBeacon();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it("re-fires the beacon after install_id is deleted (marker wipe)", async () => {
+    await ensureToolkitIdsAndBeacon();
+    unlinkSync(installIdPath());
+    fetchCalls = [];
+    await ensureToolkitIdsAndBeacon();
+    expect(fetchCalls.length).toBe(1);
+    expect(JSON.parse(fetchCalls[0].init.body).event).toBe("Toolkit Installed");
+  });
+
+  it("opt-out env var suppresses the beacon and writes no id files", async () => {
+    process.env.MC_AGENT_TOOLKIT_TELEMETRY_DISABLED = "1";
+    await ensureToolkitIdsAndBeacon();
+    expect(fetchCalls.length).toBe(0);
+    expect(existsSync(installIdPath())).toBe(false);
+  });
+
+  it("is fail-open when the POST rejects (does not throw)", async () => {
+    fetchImpl = async () => {
+      throw new Error("network down");
+    };
+    await expect(ensureToolkitIdsAndBeacon()).resolves.toBeUndefined();
+    // ids are still written even though the beacon failed
+    expect(existsSync(installIdPath())).toBe(true);
+    expect(existsSync(sessionIdPath())).toBe(true);
+  });
+
+  it("writes id files with mode 0600", async () => {
+    await ensureToolkitIdsAndBeacon();
+    expect(statSync(installIdPath()).mode & 0o777).toBe(0o600);
+    expect(statSync(sessionIdPath()).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors MCD_TOOLKIT_BEACON_URL override", async () => {
+    process.env.MCD_TOOLKIT_BEACON_URL =
+      "https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon";
+    await ensureToolkitIdsAndBeacon();
+    expect(fetchCalls[0].url).toBe(
+      "https://mcp.dev.getmontecarlo.com/mcp/toolkit/beacon"
+    );
+  });
+});

--- a/plugins/shared/telemetry/lib/install-beacon.sh
+++ b/plugins/shared/telemetry/lib/install-beacon.sh
@@ -24,7 +24,7 @@ fi
 IDS_DIR="${1:-}"
 PLUGIN_JSON="${2:-}"
 HARNESS="${3:-}"
-[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+[[ -z "$IDS_DIR" || -z "$PLUGIN_JSON" || -z "$HARNESS" ]] && exit 0
 
 INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
 TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"

--- a/plugins/shared/telemetry/lib/install-beacon.sh
+++ b/plugins/shared/telemetry/lib/install-beacon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+#
+# Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
+# editor's id directory, plugin manifest path, and harness name, so this single
+# body is synced UNCHANGED into every editor plugin
+# (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
+# `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
+#
+# Dedup is the caller's job: it invokes this only on the first run that creates
+# install_id (the persistent per-machine+editor marker). The sink also dedups on
+# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+#
+# Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
+#
+# Fails closed (exit 0) on any error — telemetry must never break a session.
+set -uo pipefail
+
+# Opt-out
+if [[ "${MC_AGENT_TOOLKIT_TELEMETRY_DISABLED:-}" == "1" ]]; then
+  exit 0
+fi
+
+IDS_DIR="${1:-}"
+PLUGIN_JSON="${2:-}"
+HARNESS="${3:-}"
+[[ -z "$IDS_DIR" || -z "$HARNESS" ]] && exit 0
+
+INSTALL_ID="$(cat "$IDS_DIR/install_id" 2>/dev/null || echo "")"
+TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
+
+# Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
+[[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
+
+# Beacon URL defaults to prod; MC engineers can override to dev for verification
+# work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
+BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
+
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# harness identifies the editor this install runs under, so the sink can tell a
+# Cortex Code install apart from a Claude Code one (each has its own install_id).
+# Note: unlike the skill beacon, the install event carries NO skill /
+# skill_args_present — the sink validates this event shape separately.
+PAYLOAD="$(jq -nc \
+  --arg event "Toolkit Installed" \
+  --arg install_id "$INSTALL_ID" \
+  --arg session_id "$TOOLKIT_SESSION_ID" \
+  --arg toolkit_version "$TOOLKIT_VERSION" \
+  --arg harness "$HARNESS" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{event: $event, install_id: $install_id, session_id: $session_id, toolkit_version: $toolkit_version, harness: $harness, ts: $ts}')"
+
+# Fire-and-forget. 2s timeout so a slow server never delays session start.
+# MC_BEACON_SYNC (test-only) runs curl in the foreground so tests can assert
+# deterministically whether the beacon fired; production always backgrounds it.
+if [[ -n "${MC_BEACON_SYNC:-}" ]]; then
+  curl -fsS -m 2 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BEACON_URL" >/dev/null 2>&1 || true
+else
+  ( curl -fsS -m 2 -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" \
+      "$BEACON_URL" \
+      >/dev/null 2>&1 || true ) &
+  disown
+fi
+
+exit 0

--- a/plugins/shared/telemetry/lib/install-beacon.sh
+++ b/plugins/shared/telemetry/lib/install-beacon.sh
@@ -36,6 +36,11 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 
 TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
+# If the version can't be resolved (no jq, unreadable/`.version`-less manifest),
+# skip entirely: don't send a junk "unknown" beacon and don't write the marker —
+# just retry next session once a real version is available.
+[[ "$TOOLKIT_VERSION" == "unknown" ]] && exit 0
+
 # Dedup: fire once per (install, version). The marker records the version we last
 # beaconed for; re-fire only when it differs from the current version (first run,
 # or any upgrade/downgrade). Same version → nothing to do.

--- a/plugins/shared/telemetry/lib/install-beacon.sh
+++ b/plugins/shared/telemetry/lib/install-beacon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fire a one-shot "Toolkit Installed" beacon at first-ever session start.
+# Fire a "Toolkit Installed" beacon once per (machine+editor, toolkit version).
 #
 # Editor-agnostic: the caller (each editor's ensure-toolkit-ids.sh) passes the
 # editor's id directory, plugin manifest path, and harness name, so this single
@@ -7,9 +7,11 @@
 # (plugins/shared/telemetry/lib/ -> plugins/<editor>/hooks/telemetry/lib/ via
 # `./scripts/bump-version.sh --sync-only`). Edit it here, never in the copies.
 #
-# Dedup is the caller's job: it invokes this only on the first run that creates
-# install_id (the persistent per-machine+editor marker). The sink also dedups on
-# install_id as a backstop in case the marker is wiped and the beacon re-fires.
+# Dedup lives here, keyed on a per-editor `beacon_sent_version` marker that records
+# the toolkit version the beacon last fired for. The beacon fires on first install
+# AND whenever the version changes (install -> upgrade), then updates the marker.
+# Callers invoke this every session start; it self-dedups. The sink also dedups on
+# (install_id, toolkit_version) as a backstop if the marker is lost.
 #
 # Usage: install-beacon.sh <ids_dir> <plugin_manifest_json> <harness>
 #
@@ -32,11 +34,24 @@ TOOLKIT_SESSION_ID="$(cat "$IDS_DIR/toolkit_session_id" 2>/dev/null || echo "")"
 # Don't send null/empty IDs — the sink requires valid v4 UUIDs for both.
 [[ -z "$INSTALL_ID" || -z "$TOOLKIT_SESSION_ID" ]] && exit 0
 
+TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
+
+# Dedup: fire once per (install, version). The marker records the version we last
+# beaconed for; re-fire only when it differs from the current version (first run,
+# or any upgrade/downgrade). Same version → nothing to do.
+SENT_MARKER="$IDS_DIR/beacon_sent_version"
+SENT_VERSION="$(cat "$SENT_MARKER" 2>/dev/null || echo "")"
+[[ "$TOOLKIT_VERSION" == "$SENT_VERSION" ]] && exit 0
+
+# Record this version as beaconed BEFORE firing, so a rapid second session in the
+# same version doesn't double-fire. Best-effort; if it fails, the sink's
+# (install_id, toolkit_version) dedup is the backstop.
+printf '%s' "$TOOLKIT_VERSION" > "$SENT_MARKER" 2>/dev/null || true
+chmod 600 "$SENT_MARKER" 2>/dev/null || true
+
 # Beacon URL defaults to prod; MC engineers can override to dev for verification
 # work (e.g. against mcp.dev.getmontecarlo.com before promoting an endpoint change).
 BEACON_URL="${MCD_TOOLKIT_BEACON_URL:-https://mcp.getmontecarlo.com/mcp/toolkit/beacon}"
-
-TOOLKIT_VERSION="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")"
 
 # harness identifies the editor this install runs under, so the sink can tell a
 # Cortex Code install apart from a Claude Code one (each has its own install_id).

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,8 +14,9 @@
 #   ./scripts/bump-version.sh minor              # 1.0.0 → 1.1.0
 #   ./scripts/bump-version.sh 2.0.0              # Set explicit version
 #   ./scripts/bump-version.sh patch --dry-run    # Preview without changes
-#   ./scripts/bump-version.sh --sync-only        # Re-sync plugins/shared/prevent/lib/
-#                                                # into all editor plugins (no version bump)
+#   ./scripts/bump-version.sh --sync-only        # Re-sync plugins/shared/<skill>/lib/
+#                                                # (prevent, telemetry) into all editor
+#                                                # plugins (no version bump)
 #
 set -euo pipefail
 
@@ -72,32 +73,44 @@ for arg in "$@"; do
   esac
 done
 
-# ── Sync shared hook lib into all editor plugins ────────────────────────────
+# ── Sync shared hook libs into all editor plugins ───────────────────────────
 # Run unconditionally as part of bump (after version is known) and as a
-# standalone op via --sync-only.
+# standalone op via --sync-only. Each shared skill lib lives at
+# plugins/shared/<skill>/lib and is copied into plugins/<editor>/hooks/<skill>/lib.
+# An editor only receives a given lib if it already has that hooks/<skill>/ dir,
+# so editors without telemetry wiring are skipped automatically.
+SHARED_LIB_SKILLS=(prevent telemetry)
+
 sync_shared_lib() {
-  local SHARED_LIB_DIR="$REPO_ROOT/plugins/shared/prevent/lib"
-  # opencode is intentionally excluded — it ports the prevent logic to TypeScript
-  # (plugins/opencode/src/prevent/) rather than copying the Python lib.
+  for skill in "${SHARED_LIB_SKILLS[@]}"; do
+    _sync_shared_lib_skill "$skill"
+  done
+}
+
+_sync_shared_lib_skill() {
+  local skill="$1"
+  local SHARED_LIB_DIR="$REPO_ROOT/plugins/shared/$skill/lib"
+  # opencode is intentionally excluded — it ports hook logic to TypeScript
+  # (plugins/opencode/src/) rather than copying the shared lib.
   local EDITOR_PLUGINS=(claude-code cursor copilot codex cortex-code)
   echo ""
   if [[ ! -d "$SHARED_LIB_DIR" ]]; then
-    echo "Warning: $SHARED_LIB_DIR does not exist; skipping shared lib sync."
+    echo "Warning: $SHARED_LIB_DIR does not exist; skipping $skill lib sync."
     return
   fi
   for editor in "${EDITOR_PLUGINS[@]}"; do
-    local target="$REPO_ROOT/plugins/$editor/hooks/prevent/lib"
+    local target="$REPO_ROOT/plugins/$editor/hooks/$skill/lib"
     if [[ ! -d "$(dirname "$target")" ]]; then
       continue
     fi
     if [[ "$DRY_RUN" == true ]]; then
-      echo "[dry-run] Would sync shared lib → plugins/$editor/hooks/prevent/lib"
+      echo "[dry-run] Would sync $skill lib → plugins/$editor/hooks/$skill/lib"
     else
       rm -rf "$target"
       cp -R "$SHARED_LIB_DIR" "$target"
       rm -rf "$target/__pycache__" "$target/tests"
       find "$target" -name "*.pyc" -delete 2>/dev/null || true
-      echo "Synced shared lib → plugins/$editor/hooks/prevent/lib"
+      echo "Synced $skill lib → plugins/$editor/hooks/$skill/lib"
     fi
   done
 }


### PR DESCRIPTION
## Summary

Fires a **`Toolkit Installed`** telemetry beacon at session start across **all six editor plugins** (Claude Code, Cortex Code, Cursor, Codex, Copilot, OpenCode), **once per machine+editor per toolkit version** — first install *and* after each upgrade — deduped by a local `beacon_sent_version` marker, independent of skill usage.

Closes [DOL-8692](https://linear.app/montecarloai/issue/DOL-8692). Today an install is only learned about *implicitly* when the first skill beacon arrives, so an install that never invokes a skill is invisible — a systematic undercount biased toward active users. This adds a dedicated install signal (and, with per-version firing, version-adoption signal too).

## What this enables

- **All six editors report installs + upgrades.** Previously only Claude Code and Cortex Code had any telemetry; the other four had none. Each now mints a per-machine `install_id` (+ rotating `toolkit_session_id`) and fires the beacon once per toolkit version.
- **Dedup keyed on version, centralized in the shared beacon.** `install-beacon.sh` (and opencode's `install-beacon.ts`) reads a `beacon_sent_version` marker and re-fires only when the manifest version differs, then updates it. `install_id` is now a stable identity only — callers invoke the beacon every session and it self-dedups (which also makes the five `ensure-toolkit-ids.sh` callers near-identical).
- **One canonical beacon, no drift.** The bash beacon lives in `plugins/shared/telemetry/lib/` and is synced into each editor by `bump-version.sh --sync-only`, with a CI check enforcing sync (same convention as `prevent/lib`). OpenCode is the TS exception, guarded by a cross-harness payload-parity test.
- **Safe by construction.** Fail-open and non-blocking (2s timeout, errors swallowed, never delays a session); honors `MC_AGENT_TOOLKIT_TELEMETRY_DISABLED=1` and `MCD_TOOLKIT_BEACON_URL`; id/marker files are `0600`; payload carries only opaque UUIDs + toolkit version + editor name (no prompts, args, skill names, or code).
- **Telemetry disclosed for every editor** — Telemetry/opt-out sections in all six plugin READMEs + root.

## Per-editor wiring

| Editor | Trigger | Registration |
|--------|---------|--------------|
| Claude Code / Cortex Code | `SessionStart` | bundled `hooks/telemetry/hooks.json` → `ensure-toolkit-ids.sh` |
| Cursor | `sessionStart` | bundled `hooks/prevent/hooks.json` (Cursor loads one hooks file per plugin) |
| Codex | `SessionStart` (no matcher) | generated project-level `.codex/hooks.json` |
| Copilot | `sessionStart` | **user-global** `~/.copilot/hooks/` (once per machine, not per repo) |
| OpenCode | `session.created` | TS branch in the existing plugin event dispatch |

## Key decisions

- **Fire per toolkit version, not once-ever** — captures upgrades/version adoption, not just first install. Dedup moved into the shared beacon (keyed on `beacon_sent_version`); `install_id` decoupled to stable identity.
- **Bash + shared lib over per-editor duplication or Python** — one telemetry runtime, reuses the established `bump-version.sh` sync + CI enforcement. OpenCode stays TS (no bash layer) with a payload-parity test.
- **Per-machine dedup comes from the `$HOME`-scoped marker, not global hook registration** — so each editor is wired the way it already wires hooks (bundled / project / user-global). Copilot is user-global so installs aren't undercounted per-repo.
- **Codex `SessionStart` confirmed** — the prior in-repo note referred only to Bash tool-event coverage.

## Manual testing

Verified end-to-end on the client (beacon fires, marker written) on **Claude Code, Codex, Copilot, Cursor, OpenCode** (Cortex Code not tested — no account; identical mechanism to Claude Code + bats pass). See the [testing notes & findings doc](https://app.notion.com/p/383334399e6581f59c83f08782506b66). Testing also surfaced pre-existing Codex install issues (cpio-through-symlink, `${CODEX_PLUGIN_ROOT}` prevent wiring, deprecated `codex_hooks` flag) — tracked in that doc for a **separate ticket**, not fixed here.

## Out of scope / follow-up

- **Sink (workstream C) ships separately in `monte-carlo-data/ai-agent` (`mcp-server/`).** It must add `"Toolkit Installed"` to the event allowlist and branch payload validation (the install event has no `skill` field). ⚠️ **Dedup must be on `(install_id, toolkit_version)`, not `install_id` alone** — the client re-fires per version, so an install_id-only dedup would collapse upgrade events. **Release gate:** the sink must merge + deploy before this branch is released (it currently 400s unknown events; the beacon is fail-open so the only impact of wrong ordering is dropped telemetry).
- Skill-usage telemetry on the four new editors (DOL-8691) reuses the id foundation built here.

## Drive-by fix (included)

- `fix(copilot): correct install.sh shared-lib path (LIB_SRC)` — a pre-existing Copilot installer bug (pointed `LIB_SRC` at a repo-root path that never existed, aborting the install before anything ran). Caught while testing; small and self-contained.

## Verification checklist

- [x] Lint/syntax: `bash -n` on shell scripts; `tsc --noEmit` for OpenCode
- [x] Tests: all editor telemetry suites pass (bats per editor + `bun test`), incl. version-dedup + async-path cases
- [x] Version bumped (1.13.1) + changelogs updated
- [x] Docs updated (telemetry disclosed for all editors)
- [x] Ran `/code-review`
- [na] DB migration — none
- [na] Manual end-to-end beacon → sink — blocked until the ai-agent sink change deploys (fail-open until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
