### PR TITLE
K2-839: point monitoring-advisor at the new create_or_update_agent_*_monitor tools

### DIFF
--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -104,13 +104,13 @@ All five tools follow a **two-call preview-then-confirm pattern**: the first cal
 
 | Tool | Purpose |
 | --- | --- |
-| `get_agent_metadata` | List AI agents -- returns agent names, trace table MCONs, source types |
+| `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types |
 | `get_agent_conversation` | Retrieve recent LLM interactions/conversations for an agent |
 | `get_agent_trace` | Inspect execution traces and span trees |
-| `create_agent_metric_monitor` | Create monitors for quantitative span-level metrics |
-| `create_agent_evaluation_monitor` | Create monitors for LLM-evaluated quality metrics |
-| `create_agent_trajectory` | Create trajectory monitors for execution pattern alerts |
-| `create_agent_validation` | Create validation monitors for logical assertions |
+| `create_or_update_agent_metric_monitor` | Create or update monitors for quantitative span-level metrics (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_agent_evaluation_monitor` | Create or update monitors for LLM-evaluated quality metrics (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_agent_trajectory_monitor` | Create or update trajectory monitors for execution pattern alerts (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
+| `create_or_update_agent_validation_monitor` | Create or update validation monitors for logical assertions (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 
 ---
 

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -84,9 +84,9 @@ These have default output field names — no `alias` needed and do NOT set `fiel
 
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
-| `word_count` | `word_count` | number | Word count of the completion |
+| `output_length` | `word_count` | number | Word count of the completion |
 | `json_validity` | `json_valid` | boolean | Is the completion valid JSON? |
-| `content_safety` | `content_safe` | boolean | Does the completion avoid PII/secrets? |
+| `keywords` | `content_safe` | boolean | Does the completion avoid PII/secrets? |
 
 ## Custom transforms
 
@@ -149,7 +149,7 @@ create_or_update_agent_evaluation_monitor(
     description="Chat Agent content safety check",
     agent="checkout-agent",
     transforms=[
-        {"function": "content_safety"}
+        {"function": "keywords"}
     ],
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["content_safe"],

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -12,18 +12,19 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 
 ## Constraints
 
-> **CRITICAL:** Agent monitors can ONLY be created on the `traceTableMcon` returned by
-> `get_agent_metadata`. You cannot use any other table or MCON — the API will reject it
-> with "table must be validated".
+> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
+> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
+> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
+> pass an MCON as `agent`.
 
-> **CRITICAL:** Always use the exact `traceTableMcon` from `get_agent_metadata` as the
-> `data_source.mcon` — NEVER modify, truncate, or reconstruct it.
+> **IMPORTANT:** `transforms` is now a TOP-LEVEL parameter (not nested under
+> `data_source`). It defines the evaluation logic.
 
-> **IMPORTANT:** Always use `FIXED` (uppercase) for `scheduleType` in schedule configs.
-> All schedule type values must be uppercase. Using lowercase causes
-> "Expected type ScheduleType" errors.
+> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
+> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
 
-> **IMPORTANT:** Agent span filters always need at least the `agent` field set.
+> **IMPORTANT:** `agent_span_filters` is an optional refinement; when used, include at
+> least the `agent` field.
 
 > **IMPORTANT:** Use predefined transforms when possible — they have known output field
 > names (see the predefined transforms tables below). Custom transforms require you to
@@ -38,9 +39,10 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 
 ## Key characteristics
 
-- Requires `sampling_config` — controls how many traces are sampled for evaluation
-- Supports `transforms` in `data_source` — defines the evaluation logic
+- Requires `sampling_config` — controls how many spans are sampled for evaluation
+- Supports a top-level `transforms` array — defines the evaluation logic
 - Transform output field names are used in `alert_conditions.fields`
+- Optional `is_agent_conversation_aggregation=True` to aggregate per conversation
 - Does NOT support a `context` field on transforms — do not use it
 - For predefined transforms, do NOT set the `field` parameter — omit it entirely
 
@@ -48,14 +50,21 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `dw_id` | string | Yes | Warehouse UUID |
-| `description` | string | Yes | Human-readable monitor description |
-| `data_source` | object | Yes | Includes `type`, `mcon`, and `transforms` array |
+| `description` | string | Yes | Human-readable monitor description (shown as display name) |
+| `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
 | `alert_conditions` | array | Yes | Alert conditions using transform output field names |
-| `schedule_config` | object | Yes | `{"scheduleType": "FIXED", "intervalMinutes": 60}` |
-| `agent_span_filters` | array | Yes | Span filters — always include at least `agent` |
-| `sampling_config` | object | Yes | `{"percentage": 10.0}` or `{"count": 100}` (max 10,000) |
-| `dry_run` | boolean | No | Default `True` — preview without creating |
+| `sampling_config` | object | Yes | `{"percentage": 10.0}` or `{"count": 100}` |
+| `transforms` | array | No | Evaluation transforms (predefined or custom); top-level, not under `data_source` |
+| `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation instead of per span |
+| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
+| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
+| `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators |
+| `aggregate_by` | string | No | Time-window bucketing (`hour`/`day`/`week`/`month`) |
+| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
+| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
+| `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## Predefined LLM transforms
 
@@ -107,52 +116,44 @@ Use `thresholdValue` (camelCase) for threshold operators — NOT `threshold_valu
 
 ## Examples
 
-### Answer relevance evaluation
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
+first example uses a platform `{database}:{schema}.{name}` reference; the others use an
+OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
+Note that `transforms` is now a top-level parameter, no longer nested under `data_source`.
+
+### Answer relevance evaluation (platform agent reference)
 
 ```
-create_agent_evaluation_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_evaluation_monitor(
     description="Chat Agent relevance evaluation",
-    data_source={
-        "type": "TABLE",
-        "mcon": "<trace_table_mcon>",
-        "transforms": [
-            {"function": "answer_relevance"}
-        ]
-    },
+    agent="analytics:agents.support_bot",
+    transforms=[
+        {"function": "answer_relevance"}
+    ],
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["relevance_score"],
          "thresholdValue": 2}
     ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
+    sampling_config={"percentage": 10.0},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
-    sampling_config={"percentage": 10.0},
     dry_run=True
 )
 ```
 
-### Content safety check
+### Content safety check (OTel service_name)
 
 ```
-create_agent_evaluation_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_evaluation_monitor(
     description="Chat Agent content safety check",
-    data_source={
-        "type": "TABLE",
-        "mcon": "<trace_table_mcon>",
-        "transforms": [
-            {"function": "content_safety"}
-        ]
-    },
+    agent="checkout-agent",
+    transforms=[
+        {"function": "content_safety"}
+    ],
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["content_safe"],
          "thresholdValue": 1}
-    ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
     ],
     sampling_config={"count": 100},
     dry_run=True
@@ -162,33 +163,27 @@ create_agent_evaluation_monitor(
 ### Custom classification
 
 ```
-create_agent_evaluation_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_evaluation_monitor(
     description="Chat Agent response tone classification",
-    data_source={
-        "type": "TABLE",
-        "mcon": "<trace_table_mcon>",
-        "transforms": [
-            {
-                "function": "classification",
-                "alias": "tone_label",
-                "categories": [
-                    {"label": "professional", "description": "Business-appropriate tone"},
-                    {"label": "casual", "description": "Informal or overly relaxed tone"},
-                    {"label": "inappropriate", "description": "Rude, dismissive, or harmful tone"}
-                ]
-            }
-        ]
-    },
+    agent="checkout-agent",
+    transforms=[
+        {
+            "function": "classification",
+            "alias": "tone_label",
+            "categories": [
+                {"label": "professional", "description": "Business-appropriate tone"},
+                {"label": "casual", "description": "Informal or overly relaxed tone"},
+                {"label": "inappropriate", "description": "Rude, dismissive, or harmful tone"}
+            ]
+        }
+    ],
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "GT", "fields": ["tone_label"],
          "thresholdValue": 0}
     ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 360},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
-    ],
     sampling_config={"percentage": 5.0},
+    schedule_type="fixed",
+    interval_minutes=360,
     dry_run=True
 )
 ```
@@ -197,6 +192,5 @@ create_agent_evaluation_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| "table must be validated" | MCON doesn't match a registered trace table | Verify the exact `traceTableMcon` from `get_agent_metadata` — use it as-is, do not modify |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
 | "Field X doesn't exist" | Wrong transform output field name used in `alert_conditions.fields` | For predefined transforms, use the documented output field name (e.g., `relevance_score` for `answer_relevance`); for custom transforms, verify the `alias` matches |
-| "Expected type ScheduleType" | Schedule type is lowercase or invalid | Use `FIXED` (uppercase) — all schedule type values must be uppercase |

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -7,7 +7,7 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 - **Answer relevance scoring** — is the response relevant to the question?
 - **Helpfulness and clarity** — is the response useful and well-structured?
 - **Task completion** — did the agent complete what was asked?
-- **Content safety** — does the output avoid PII/secrets?
+- **Banned-keyword check** — does the output avoid specific banned keywords (e.g. password, ssn, api secret)?
 - **Custom evaluation criteria** — via custom transforms
 
 ## Constraints
@@ -86,7 +86,7 @@ These have default output field names — no `alias` needed and do NOT set `fiel
 |-------------------|-------------|-------------|-------------|
 | `output_length` | `word_count` | number | Word count of the completion |
 | `json_validity` | `json_valid` | boolean | Is the completion valid JSON? |
-| `keywords` | `content_safe` | boolean | Does the completion avoid PII/secrets? |
+| `keywords` | `content_safe` | boolean | TRUE if output does NOT contain banned keywords (password, ssn, api secret, credit card). Not a general PII/secrets detector. |
 
 ## Custom transforms
 
@@ -142,7 +142,7 @@ create_or_update_agent_evaluation_monitor(
 )
 ```
 
-### Content safety check (OTel service_name)
+### Banned-keyword check (OTel service_name)
 
 ```
 create_or_update_agent_evaluation_monitor(

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -10,18 +10,16 @@ Track quantitative span-level metrics over time. Best for:
 
 ## Constraints
 
-> **CRITICAL:** Agent monitors can ONLY be created on the `traceTableMcon` returned by
-> `get_agent_metadata`. You cannot use any other table or MCON — the API will reject it
-> with "table must be validated".
+> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
+> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
+> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
+> pass an MCON as `agent`.
 
-> **CRITICAL:** Always use the exact `traceTableMcon` from `get_agent_metadata` as the
-> `data_source.mcon` — NEVER modify, truncate, or reconstruct it.
+> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
+> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
 
-> **IMPORTANT:** Always use `FIXED` (uppercase) for `scheduleType` in schedule configs.
-> All schedule type values must be uppercase. Using lowercase (e.g., `fixed`) causes
-> "Expected type ScheduleType" errors.
-
-> **IMPORTANT:** Agent span filters always need at least the `agent` field set.
+> **IMPORTANT:** `agent_span_filters` is an optional refinement — the `agent` reference
+> already scopes the monitor. When you do filter, include at least the `agent` field.
 
 > **IMPORTANT:** Use `duration_sec` (not `duration_ms`) for latency monitoring. The field
 > is named `duration_sec` in the PARSED_SPANS layer — `duration_ms` does not exist.
@@ -35,22 +33,28 @@ Track quantitative span-level metrics over time. Best for:
 ## Key characteristics
 
 - Uses `alert_conditions` with metric + operator (same as standard metric monitors)
-- Supports AUTO (anomaly detection) and threshold operators (GT, LT, EQ, GTE, LTE, NE)
+- Supports AUTO (anomaly detection) and threshold operators (GT, LT, EQ, GTE, LTE, NEQ)
 - Optional `is_agent_trace_aggregation=True` to aggregate per trace instead of per span
+- Optional `sensitivity` to tune anomaly detection for AUTO operators
 - Does NOT support transforms or sampling — raw numeric fields only
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `dw_id` | string | Yes | Warehouse UUID |
-| `description` | string | Yes | Human-readable monitor description |
-| `data_source` | object | Yes | `{"type": "TABLE", "mcon": "<trace_table_mcon>"}` |
+| `description` | string | Yes | Human-readable monitor description (shown as display name) |
+| `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
 | `alert_conditions` | array | Yes | List of alert condition objects (see below) |
-| `schedule_config` | object | Yes | `{"scheduleType": "FIXED", "intervalMinutes": 60}` |
-| `agent_span_filters` | array | Yes | Span filters — always include at least `agent` |
+| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
+| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
 | `is_agent_trace_aggregation` | boolean | No | Aggregate per trace instead of per span |
-| `dry_run` | boolean | No | Default `True` — preview without creating |
+| `aggregate_by` | string | No | Time-window bucketing (`hour`/`day`/`week`/`month`) |
+| `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators |
+| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
+| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
+| `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## Alert condition format
 
@@ -66,23 +70,25 @@ Available metrics: `NUMERIC_MEAN`, `NUMERIC_MIN`, `NUMERIC_MAX`, `ROW_COUNT_CHAN
 
 Available operators:
 - `AUTO` — anomaly detection (recommended for most cases)
-- `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE` — threshold-based (requires `thresholdValue`)
+- `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NEQ` — threshold-based (requires `thresholdValue`)
 
 **Important:** For `ROW_COUNT_CHANGE`, do NOT include the `fields` array — it operates on row counts, not specific fields.
 
 ## Examples
 
-### Latency monitoring
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
+first example uses a platform `{database}:{schema}.{name}` reference; the others use an
+OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
+
+### Latency monitoring (platform agent reference)
 
 ```
-create_agent_metric_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_metric_monitor(
     description="Chat Agent latency monitor",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="analytics:agents.support_bot",
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["duration_sec"]}
     ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
@@ -90,18 +96,16 @@ create_agent_metric_monitor(
 )
 ```
 
-### Token usage monitoring
+### Token usage monitoring (OTel service_name)
 
 ```
-create_agent_metric_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_metric_monitor(
     description="Chat Agent token usage monitor",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "GT", "fields": ["total_tokens"],
          "thresholdValue": 5000}
     ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
@@ -112,14 +116,12 @@ create_agent_metric_monitor(
 ### Volume monitoring (ROW_COUNT_CHANGE — no fields array)
 
 ```
-create_agent_metric_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_metric_monitor(
     description="Chat Agent span volume monitor",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     alert_conditions=[
         {"metric": "ROW_COUNT_CHANGE", "operator": "AUTO"}
     ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
@@ -130,16 +132,11 @@ create_agent_metric_monitor(
 ### Trace-level latency (aggregated per trace)
 
 ```
-create_agent_metric_monitor(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_metric_monitor(
     description="Chat Agent end-to-end trace latency",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["duration_sec"]}
-    ],
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
     ],
     is_agent_trace_aggregation=True,
     dry_run=True
@@ -150,6 +147,5 @@ create_agent_metric_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| "table must be validated" | MCON doesn't match a registered trace table | Verify the exact `traceTableMcon` from `get_agent_metadata` — use it as-is, do not modify |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
 | "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md` for valid field names; use `duration_sec` not `duration_ms` |
-| "Expected type ScheduleType" | Schedule type is lowercase or invalid | Use `FIXED` (uppercase) — all schedule type values must be uppercase |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -19,14 +19,15 @@ Key fields in the response:
 | Field | Description |
 |-------|-------------|
 | `agentName` | Human-readable agent name |
-| `traceTableMcon` | Needed as the `data_source.mcon` when creating monitors |
+| `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
+| `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for `get_agent_conversation`/`get_agent_trace` |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
 
 **Duplicate agents across warehouses:** The same agent name may appear in
 multiple warehouses (e.g., deployed in both prod and staging). When this
 happens, present the warehouse **names** (never UUIDs) and ask the user which
-warehouse they want to monitor. Each warehouse has a different
-`traceTableMcon`, so the choice determines which data source the monitor uses.
+warehouse they want to monitor. Pass the chosen warehouse as the `warehouse`
+arg (name or UUID) when the agent reference does not pin it down.
 
 ---
 
@@ -56,11 +57,31 @@ to see the full span tree. Look for:
 
 ---
 
+## The `agent` reference
+
+All four `create_or_update_agent_*_monitor` tools author the monitor's source via
+a single top-level **`agent`** argument — there is no `dw_id` or `data_source`/MCON.
+Two accepted forms:
+
+- **Platform agent reference** — `{database}:{schema}.{name}` (Snowflake Cortex /
+  Databricks agents), e.g. `analytics:agents.support_bot`.
+- **OpenTelemetry `service_name`** — for OTel-instrumented agents, e.g. `checkout-agent`.
+
+Get the exact value from `get_agent_metadata`'s **`agentReference`** field — never
+construct it by hand. Two optional companions:
+
+- `warehouse` (name or UUID) — only needed when the agent reference doesn't pin down
+  the warehouse. Resolve names via `get_warehouses`.
+- `trace_table` — only for non-ClickHouse OTel agents whose trace storage cannot be
+  inferred from the agent reference.
+
+---
+
 ## Agent span filters
 
-The `agent_span_filters` parameter narrows which spans are monitored. Each
-filter is an object with optional fields: `agent`, `workflow`, `task`,
-`spanName`. Each field contains a `{"value": "..."}` sub-object.
+The optional `agent_span_filters` parameter refines which spans are monitored. Each
+filter is an object with optional fields: `agent`, `workflow`, `task`, `spanName`.
+Each field contains a `{"value": "..."}` sub-object.
 
 | Filter field | Description | Example |
 |-------------|-------------|---------|
@@ -74,21 +95,22 @@ Multiple fields can be combined in one filter object. Example:
 [{"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}, "task": {"value": "call_model"}}]
 ```
 
-Always include at least the `agent` field in span filters.
+`agent_span_filters` is a refinement and is optional — the `agent` reference already
+scopes the monitor. (Trajectory monitors are the exception: there `agent_span_filters`
+may set ONLY the `agent` field — see `agent-trajectory-monitor.md`.)
 
 ---
 
 ## Schedule configuration
 
-Common schedule patterns:
+Schedule is set via two top-level args, not a nested object:
 
-- **Hourly**: `{"scheduleType": "FIXED", "intervalMinutes": 60}`
-- **Every 6 hours**: `{"scheduleType": "FIXED", "intervalMinutes": 360}`
-- **Daily**: `{"scheduleType": "FIXED", "intervalMinutes": 1440}`
+- `schedule_type` — defaults to `fixed`. Valid values: `fixed`, `dynamic`, `manual`.
+- `interval_minutes` — defaults to `60` for `fixed`. Common patterns: `60` (hourly),
+  `360` (every 6 hours), `1440` (daily).
 
-Valid `scheduleType` values: `FIXED`, `LOOSE`, `DYNAMIC`, `MANUAL` (always uppercase).
-
-Use shorter intervals for critical agents, longer for less critical ones.
+Omit both to accept the hourly fixed default. Use shorter intervals for critical
+agents, longer for less critical ones.
 
 ---
 
@@ -126,10 +148,18 @@ get the detailed parameter guide, examples, constraints, and creation workflow.
 
 ## Step 4: Create the monitor
 
+All four tools follow the same **two-call preview-then-confirm pattern** as the data
+monitor tools: the first call (`dry_run=True`, the default) returns the rendered MaC
+YAML for review; the second call (`dry_run=False`) deploys the monitor live and
+returns its UUID. Pass `monitor_uuid` on either call to update an existing agent
+monitor in place instead of creating a new one (PUT semantics — re-pass every field
+you want to keep).
+
 1. **Always start with `dry_run=True`** (the default). Show the user the
    generated queries and configuration preview.
 2. Call `get_audiences` to list available notification audiences. Suggest the
-   most relevant one and ask the user to pick.
+   most relevant one and ask the user to pick. Pass audience **names** (not UUIDs)
+   as the `audiences` list.
 3. After showing the preview, offer to create or adjust settings.
 4. Only set `dry_run=False` when the user explicitly confirms creation.
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -156,7 +156,7 @@ monitor in place instead of creating a new one (PUT semantics — re-pass every 
 you want to keep).
 
 1. **Always start with `dry_run=True`** (the default). Show the user the
-   generated queries and configuration preview.
+   configuration preview (the rendered YAML).
 2. Call `get_audiences` to list available notification audiences. Suggest the
    most relevant one and ask the user to pick. Pass audience **names** (not UUIDs)
    as the `audiences` list.

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -11,27 +11,22 @@ Alert on specific execution patterns or span sequences. Best for:
 
 ## Constraints
 
-> **CRITICAL:** Agent monitors can ONLY be created on the `traceTableMcon` returned by
-> `get_agent_metadata`. You cannot use any other table or MCON — the API will reject it
-> with "table must be validated".
-
-> **CRITICAL:** Always use the exact `traceTableMcon` from `get_agent_metadata` as the
-> `data_source.mcon` — NEVER modify, truncate, or reconstruct it.
+> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
+> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
+> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
+> pass an MCON as `agent`.
 
 > **CRITICAL:** Trajectory `agent_span_filters`: only the `agent` field is allowed.
 > Setting `workflow`, `task`, or `spanName` in `agent_span_filters` will cause a
 > "workflow should not be set" validation error. Use `spanField` in the
 > `agent_span_alert_condition` for workflow/task/spanName filtering instead.
 
-> **IMPORTANT:** Always use `FIXED` (uppercase) for `scheduleType` in schedule configs.
-> All schedule type values must be uppercase. Using lowercase causes
-> "Expected type ScheduleType" errors.
+> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
+> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
 
 > **IMPORTANT:** Always use `ingest_ts` as the `timeField`. The time filter must be
 > `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": <hours>}`. Using any other
-> time field will fail.
-
-> **IMPORTANT:** Agent span filters always need at least the `agent` field set.
+> time field will fail. `time_filter` is REQUIRED.
 
 ## Key characteristics
 
@@ -47,14 +42,17 @@ Alert on specific execution patterns or span sequences. Best for:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `dw_id` | string | Yes | Warehouse UUID |
-| `description` | string | Yes | Human-readable monitor description |
-| `data_source` | object | Yes | `{"type": "TABLE", "mcon": "<trace_table_mcon>"}` |
+| `description` | string | Yes | Human-readable monitor description (shown as display name) |
+| `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
 | `agent_span_alert_condition` | object | Yes | Span occurrence conditions (see below) |
 | `time_filter` | object | Yes | `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24}` |
-| `schedule_config` | object | Yes | `{"scheduleType": "FIXED", "intervalMinutes": 60}` |
-| `agent_span_filters` | array | Yes | **Only `agent` field allowed** — no `workflow`, `task`, or `spanName` |
-| `dry_run` | boolean | No | Default `True` — preview without creating |
+| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
+| `agent_span_filters` | array | No | Optional — **only the `agent` field allowed** (no `workflow`, `task`, or `spanName`) |
+| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
+| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
+| `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## agent_span_alert_condition format
 
@@ -90,13 +88,16 @@ Alert on specific execution patterns or span sequences. Best for:
 
 ## Examples
 
-### Alert on excessive LLM calls
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field — a
+platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Use whichever
+form `get_agent_metadata` returns for your agent.
+
+### Alert on excessive LLM calls (platform agent reference)
 
 ```
-create_agent_trajectory(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_trajectory_monitor(
     description="Alert on excessive LLM calls",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="analytics:agents.support_bot",
     agent_span_alert_condition={
         "operator": "AND",
         "conditions": [
@@ -115,7 +116,6 @@ create_agent_trajectory(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}}
     ],
@@ -123,13 +123,12 @@ create_agent_trajectory(
 )
 ```
 
-### Alert on missing expected step
+### Alert on missing expected step (OTel service_name)
 
 ```
-create_agent_trajectory(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_trajectory_monitor(
     description="Alert when validation step is missing",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     agent_span_alert_condition={
         "operator": "AND",
         "conditions": [
@@ -148,7 +147,6 @@ create_agent_trajectory(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}}
     ],
@@ -160,6 +158,5 @@ create_agent_trajectory(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| "table must be validated" | MCON doesn't match a registered trace table | Verify the exact `traceTableMcon` from `get_agent_metadata` — use it as-is, do not modify |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
 | "workflow should not be set" in agentSpanFilters | Trajectory monitors only allow the `agent` field in `agent_span_filters` | Remove `workflow`, `task`, and `spanName` from `agent_span_filters`; use `spanField` in the `agent_span_alert_condition` instead |
-| "Expected type ScheduleType" | Schedule type is lowercase or invalid | Use `FIXED` (uppercase) — all schedule type values must be uppercase |

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -11,27 +11,25 @@ Assert logical conditions on aggregated agent span data. Best for:
 
 ## Constraints
 
-> **CRITICAL:** Agent monitors can ONLY be created on the `traceTableMcon` returned by
-> `get_agent_metadata`. You cannot use any other table or MCON — the API will reject it
-> with "table must be validated".
+> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
+> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
+> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
+> pass an MCON as `agent`.
 
-> **CRITICAL:** Always use the exact `traceTableMcon` from `get_agent_metadata` as the
-> `data_source.mcon` — NEVER modify, truncate, or reconstruct it.
-
-> **IMPORTANT:** Always use `FIXED` (uppercase) for `scheduleType` in schedule configs.
-> All schedule type values must be uppercase. Using lowercase causes
-> "Expected type ScheduleType" errors.
+> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
+> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
 
 > **IMPORTANT:** Always use `ingest_ts` as the `timeField`. The time filter must be
 > `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": <hours>}`. Using any other
-> time field will fail.
+> time field will fail. `time_filter` is REQUIRED.
 
-> **IMPORTANT:** Agent span filters always need at least the `agent` field set.
+> **IMPORTANT:** `agent_span_filters` is an optional refinement; when used, include at
+> least the `agent` field.
 
 ## Key characteristics
 
 - Uses `alert_condition` as a `FilterGroup` with `left`/`right` typed values
-- Requires `time_filter` and `agent_span_filters`
+- Requires `time_filter`
 - Optional `is_agent_trace_aggregation` for trace-level assertions
 - Returns a `CustomRule`
 
@@ -39,15 +37,18 @@ Assert logical conditions on aggregated agent span data. Best for:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `dw_id` | string | Yes | Warehouse UUID |
-| `description` | string | Yes | Human-readable monitor description |
-| `data_source` | object | Yes | `{"type": "TABLE", "mcon": "<trace_table_mcon>"}` |
+| `description` | string | Yes | Human-readable monitor description (shown as display name) |
+| `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
 | `alert_condition` | object | Yes | FilterGroup with conditions (see below) |
 | `time_filter` | object | Yes | `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24}` |
-| `schedule_config` | object | Yes | `{"scheduleType": "FIXED", "intervalMinutes": 60}` |
-| `agent_span_filters` | array | Yes | Span filters — always include at least `agent` |
+| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
+| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
 | `is_agent_trace_aggregation` | boolean | No | Aggregate per trace for trace-level assertions |
-| `dry_run` | boolean | No | Default `True` — preview without creating |
+| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
+| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
+| `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## alert_condition format
 
@@ -74,13 +75,16 @@ Assert logical conditions on aggregated agent span data. Best for:
 
 ## Examples
 
-### Assert token usage below threshold
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
+first example uses a platform `{database}:{schema}.{name}` reference; the others use an
+OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
+
+### Assert token usage below threshold (platform agent reference)
 
 ```
-create_agent_validation(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_validation_monitor(
     description="Assert token usage below threshold",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="analytics:agents.support_bot",
     alert_condition={
         "operator": "AND",
         "conditions": [
@@ -93,7 +97,6 @@ create_agent_validation(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
@@ -101,13 +104,12 @@ create_agent_validation(
 )
 ```
 
-### Assert latency stays reasonable (trace-level)
+### Assert latency stays reasonable (trace-level, OTel service_name)
 
 ```
-create_agent_validation(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_validation_monitor(
     description="Assert trace duration under 120 seconds",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     alert_condition={
         "operator": "AND",
         "conditions": [
@@ -120,10 +122,6 @@ create_agent_validation(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 60},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
-    ],
     is_agent_trace_aggregation=True,
     dry_run=True
 )
@@ -132,10 +130,9 @@ create_agent_validation(
 ### Compound condition — token usage AND latency
 
 ```
-create_agent_validation(
-    dw_id="<warehouse_uuid>",
+create_or_update_agent_validation_monitor(
     description="Assert token and latency within bounds",
-    data_source={"type": "TABLE", "mcon": "<trace_table_mcon>"},
+    agent="checkout-agent",
     alert_condition={
         "operator": "OR",
         "conditions": [
@@ -154,10 +151,11 @@ create_agent_validation(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    schedule_config={"scheduleType": "FIXED", "intervalMinutes": 1440},
     agent_span_filters=[
         {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
     ],
+    schedule_type="fixed",
+    interval_minutes=1440,
     dry_run=True
 )
 ```
@@ -166,6 +164,5 @@ create_agent_validation(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| "table must be validated" | MCON doesn't match a registered trace table | Verify the exact `traceTableMcon` from `get_agent_metadata` — use it as-is, do not modify |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
 | "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md` for valid field names |
-| "Expected type ScheduleType" | Schedule type is lowercase or invalid | Use `FIXED` (uppercase) — all schedule type values must be uppercase |


### PR DESCRIPTION
# Changes

Migrates the `monitoring-advisor` skill's agent-monitor references from the old `create_agent_*` tools to the new Monitors-as-Code tools: `create_or_update_agent_metric_monitor`, `create_or_update_agent_evaluation_monitor`, `create_or_update_agent_trajectory_monitor`, `create_or_update_agent_validation_monitor`.

Files: `skills/monitoring-advisor/SKILL.md` (capability table + the `get_agent_metadata` row now surfaces `agentReference`) and the five `references/agent-*.md` (the four per-type references + `agent-monitor-creation.md`).

Every example and parameter table now authors the source via a single top-level **`agent`** reference — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`, discoverable via `get_agent_metadata`'s new `agentReference` — instead of `dw_id` + `data_source`. Per-type parameters updated to the new surface: `transforms` (top-level) + `sampling_config` for eval, `agent_span_alert_condition` + `time_filter` for trajectory, `alert_condition` + `time_filter` for validation, `schedule_type`/`interval_minutes` (valid values `fixed`/`dynamic`/`manual`), `aggregate_by` (lowercase), `is_agent_trace_aggregation` (metric/validation) vs `is_agent_conversation_aggregation` (eval), `warehouse`, `trace_table`, `monitor_uuid`. Alert-condition operator literals corrected to the values the tools accept (e.g. `NEQ`).

The old `create_agent_*` tools remain callable for backward compatibility (they are only hidden from the default tool listing in the mcp-server change).

## Context

- Linear: K2-839
- Depends on the mcp-server PR introducing the `create_or_update_agent_*_monitor` tools and the monolith PR (monte-carlo-data/monolith-django#14137) adding the backing `createOrUpdateAgent*MonitorFromDefinition` mutations + `agentReference`.

## Verification

- `grep -rn "create_agent_metric_monitor\|create_agent_evaluation_monitor\|create_agent_trajectory\|create_agent_validation" skills/monitoring-advisor/` returns nothing.
- Each example produces a valid call against the new tool signatures (verified against the tool definitions).