### PR TITLE
docs(automated-triage): document triage_alert alongside alert_assessment (K2-849)

### DIFF
--- a/skills/automated-triage/SKILL.md
+++ b/skills/automated-triage/SKILL.md
@@ -55,13 +55,21 @@ All tools are available via the `monte-carlo-mcp` MCP server.
 | Tool                             | Toolset  | Purpose                                                         |
 | -------------------------------- | -------- | --------------------------------------------------------------- |
 | `get_alerts`                          | default  | Fetch recent alerts for a time window                                                                             |
-| `alert_assessment`                    | default  | Score an alert by incident likelihood and potential impact (HIGH/MEDIUM/LOW each)                                 |
+| `alert_assessment`                    | default  | **Read-only** scoring — scores an alert by incident likelihood and potential impact (HIGH/MEDIUM/LOW each) and returns the verdict without recording anything. Steerable via `user_instructions`; safe to run in parallel across many alerts |
+| `triage_alert`                        | default  | **Persisted** triage — scores an alert and writes the verdict back onto it, exactly like the in-app Triage button (marks the alert triaged, posts a completion notification, records ML feedback). Blocks until done; reuses an existing triage if the alert was already triaged |
 | `run_troubleshooting_agent`           | default  | Run the Monte Carlo Troubleshooting Agent on a single alert; async by default — returns immediately, reuses existing results when available |
 | `get_troubleshooting_agent_results`   | default  | Poll an async troubleshooting run by `incident_id`; returns status (`not_found`/`running`/`success`/`failed`) and results when complete |
 | `update_alert`                        | default  | Update an alert's status and/or declare an incident by setting severity                                           |
 | `set_alert_owner`                     | default  | Assign an owner to an alert by email                                                                              |
 | `create_or_update_alert_comment`      | default  | Post or update a triage comment on an alert                                                                       |
 | `mark_event_as_normal`                | default  | Mark all anomaly events in an alert as normal, triggering ML threshold recalibration to prevent re-alerting on the same pattern |
+
+### `alert_assessment` vs `triage_alert` — which to use
+
+Both score an alert on the same two dimensions; the difference is whether the result is recorded.
+
+- **`alert_assessment` — read-only scoring.** Nothing is written to the alert. Use it to score in bulk and decide what to do next, to preview a verdict without committing to it, or when you want to record the outcome your own way using the action tools below (`update_alert`, `create_or_update_alert_comment`, `mark_event_as_normal`). It accepts `user_instructions` to steer the scoring. This is the tool the workflow stages below are built around.
+- **`triage_alert` — persisted triage.** Equivalent to a user clicking **Triage** in the product: it scores the alert *and* writes the verdict back (marks it triaged, posts a notification, records ML feedback), so the triage is visible in the UI and feeds the anomaly model. Use it when the user asks to triage a specific alert and have that recorded — not for bulk scoring where you don't want every alert marked triaged. It's idempotent: if the alert is already triaged it returns the existing verdict without re-running. It requires the `mcp/edit` scope (it's a write); read-only integrations won't see it.
 
 ---
 
@@ -116,7 +124,9 @@ The user wants to look at specific alerts now. Use the triage tools directly to 
 3. For any alert where both incident likelihood and potential impact are MEDIUM or higher, offer to run `run_troubleshooting_agent` for a deeper root cause analysis. Wait for confirmation before running it.
 4. Summarise findings. Do not prompt to save a workflow file or set up automation unless the user brings it up.
 
-**Write tools in interactive triage:** After findings are clear, proactively offer relevant actions — updating status, declaring a severity, assigning an owner, posting a comment, or marking events as normal (for alerts that are natural data variation). Ask before executing.
+**When the user wants the triage recorded:** if the ask is to triage a specific alert *and have it show up in the product* (e.g. "triage alert X" rather than "score my alerts"), use `triage_alert` — it scores and persists in one step, just like the in-app Triage button. Ask first, since it writes to the alert. For scoring many alerts to decide what to do, stay on `alert_assessment` (read-only) and record outcomes with the action tools below.
+
+**Write tools in interactive triage:** After findings are clear, proactively offer relevant actions — running `triage_alert` to record the triage, updating status, declaring a severity, assigning an owner, posting a comment, or marking events as normal (for alerts that are natural data variation). Ask before executing.
 
 ---
 
@@ -151,7 +161,7 @@ Ask how they'd like to get started:
 
 Execute the workflow from the file, following its instructions exactly. Do not improvise steps or add actions not described in the file.
 
-**Action guard — workflow mode:** Never call write tools (`update_alert`, `set_alert_owner`, `create_or_update_alert_comment`) while building or testing a workflow, regardless of what the workflow document says. Only describe what would be done. This guard exists to prevent accidental writes on real alerts during development; lift it only when the user explicitly switches to action mode for a production run.
+**Action guard — workflow mode:** Never call write tools (`triage_alert`, `update_alert`, `set_alert_owner`, `create_or_update_alert_comment`) while building or testing a workflow, regardless of what the workflow document says. Only describe what would be done. In workflow mode, score with `alert_assessment` (read-only) rather than `triage_alert`, which would mark every alert triaged. This guard exists to prevent accidental writes on real alerts during development; lift it only when the user explicitly switches to action mode for a production run.
 
 **For first runs (starting fresh):** always run step by step — after each stage completes, summarise what it produced, proactively suggest alternatives or adjustments based on what you observed, and wait for confirmation before continuing.
 

--- a/skills/automated-triage/references/triage-stages.md
+++ b/skills/automated-triage/references/triage-stages.md
@@ -56,6 +56,12 @@ It returns:
 
 Start with the defaults and tune `user_instructions` once you've seen real output.
 
+### Scoring vs. persisting: `alert_assessment` vs `triage_alert`
+
+`alert_assessment` is **read-only** — it returns a verdict but records nothing. That's exactly what you want for this stage: score every alert cheaply, then decide per alert whether it warrants troubleshooting and which action to take. The workflow persists outcomes later, in Stage 5, through the explicit action tools — so you stay in control of what gets written and when.
+
+`triage_alert` is the **persisted** counterpart: it scores *and* writes the verdict back onto the alert (marks it triaged, posts a notification, records ML feedback), identical to the in-app Triage button. It's the right tool for interactive "triage this alert" requests where the user wants the result recorded, but it's a poor fit for the scoring stage of a batch workflow — it would mark every alert in the batch triaged and fire a notification for each. Keep batch scoring on `alert_assessment`, and reserve `triage_alert` for the case where recording a single alert's triage *is* the action. It's idempotent (re-running on an already-triaged alert returns the existing verdict) and requires the `mcp/edit` scope.
+
 ---
 
 ## Stage 3: Deep troubleshooting


### PR DESCRIPTION
## Changes

`triage_alert` is being promoted to the public **default** MCP toolset (ai-agent PR monte-carlo-data/ai-agent#1570), so the `automated-triage` skill can now use it. This documents when to reach for each of the two triage-scoring tools:

- **`alert_assessment` — read-only scoring.** Nothing is recorded. The tool the batch workflow stages are built around: score in bulk, then act via the explicit write tools. Steerable via `user_instructions`.
- **`triage_alert` — persisted triage.** Equivalent to a user clicking the in-app **Triage** button — scores the alert *and* writes the verdict back (marks it triaged, posts a completion notification, records ML feedback). For interactive "triage this alert" requests where the result should be recorded. A poor fit for batch scoring (would mark every alert triaged and fire a notification per alert). Idempotent; requires the `mcp/edit` scope (it's a write, so read-only integrations don't see it).

Edits (`skills/automated-triage/`):
- `SKILL.md` — new `triage_alert` row in the tools table (and `alert_assessment` clarified as read-only); a new "which to use" section; an interactive-triage note on recording a single alert's triage; and `triage_alert` added to the workflow-mode **action guard** (it's a write, so it must never fire while building/testing a workflow — batch scoring stays on `alert_assessment`).
- `references/triage-stages.md` — a "scoring vs. persisting" subsection under Stage 2 explaining why batch scoring stays on `alert_assessment`.

No frontmatter/plugin version bump — matches the convention for skill-content PRs in this repo (e.g. #100, #97); plugin versioning is handled separately via `bump-version.sh` at release.

## Context

- Linear: K2-849 — "MCP triage tool should persist results to the alert (mirror TSA pattern)"
- Companion PR: monte-carlo-data/ai-agent#1570 (promotes `triage_alert` to the default toolset; it's gated behind `mcp/edit` via `readOnlyHint=False`, so `mcp/access`-only callers don't see it; also removes the dead `TRIAGE_AGENT_TOOLS` set)
- `triage_alert` itself shipped in ai-agent #1524, reusing the monolith `triageAlerts` mutation (the same path the in-app Triage button fires).

## Testing

- Docs-only change. CI `validate.yml` checks (no hook symlinks, shared-lib sync) are unaffected.
- Depends on ai-agent#1570 merging + deploying so `triage_alert` is actually visible on the public toolset; the skill guidance is otherwise self-consistent.