### PR TITLE
docs(skills): remove references to the retired get_current_time tool

### DIFF
--- a/skills/analyze-root-cause/SKILL.md
+++ b/skills/analyze-root-cause/SKILL.md
@@ -78,7 +78,6 @@ Do not activate when the user is:
 | `get_github_prs` | Recent GitHub PRs from the account's MC GitHub integration |
 | `get_jobs_performance` | Job runtime stats, failure rates, 7-day trends |
 | `get_change_timeline` | Unified timeline: query changes + volume + ETL failures |
-| `get_current_time` | Current timestamp for relative time ranges |
 | `alert_assessment` | Optional ~2-min triage of an incident — returns HIGH/MEDIUM/LOW confidence and impact. Useful when you want a quick read before deciding to escalate to TSA. |
 | `run_troubleshooting_agent` | Starts the Troubleshooting Agent (TSA) on an incident. Async by default; idempotent (returns existing results unless `force_rerun=True`). Auto-invoked at Step 1.5 when an incident UUID is present. |
 | `get_troubleshooting_agent_results` | Polls TSA results for an incident (`status` is `not_found` / `running` / `success` / `failed`). Use to check on the async run started at Step 1.5. |
@@ -107,7 +106,9 @@ Do not activate when the user is:
 Read `references/intake-no-incident.md` for the full intake flow. In short:
 1. Ask clarifying questions: what table? what looks wrong? when did it start?
 2. Search for the table: `search(query="table_name")`
-3. Search for related alerts: `get_alerts` with a recent time range
+3. Search for related alerts: `get_alerts` with a recent time range. Pass ISO 8601
+   timestamps computed from the current date — e.g. `created_after="2026-07-03T00:00:00Z"`,
+   `created_before="2026-07-10T00:00:00Z"` for a 7-day window (use the actual current date).
 4. Check table health: `get_table_freshness`, `get_table_size_history`
 5. Narrow down the issue type and proceed to Step 2.
 

--- a/skills/asset-health/references/parameters.md
+++ b/skills/asset-health/references/parameters.md
@@ -16,7 +16,9 @@ statuses
 ```
 
 Always provide `created_after` and `created_before`. Max window is 60 days.
-Use `get_current_time()` to get the current ISO timestamp when needed.
+Pass ISO 8601 timestamps computed from the current date — e.g. for a 7-day
+window ending now: `created_after="2026-07-03T00:00:00Z"`,
+`created_before="2026-07-10T00:00:00Z"` (use the actual current date).
 
 When requesting active alerts, pass these three statuses:
 
@@ -88,13 +90,6 @@ environment). Call once in Phase 1 and store the result. Use it to construct all
 Monte Carlo links — never hardcode the base URL:
 - Assets/tables: `{result}/assets/{mcon}`
 - Alerts: `{result}/alerts/{alert_uuid}`
-
----
-
-## `get_current_time` — get current timestamp
-
-Takes no arguments. Returns an ISO 8601 timestamp. Use this to compute
-`created_after` and `created_before` for `get_alerts`.
 
 ---
 

--- a/skills/asset-health/references/workflows.md
+++ b/skills/asset-health/references/workflows.md
@@ -54,8 +54,9 @@ get_asset_lineage(mcon="<mcon>", direction="upstream")
 → 1-hop upstream parent assets
 ```
 
-Use `get_current_time()` in Phase 1 or Phase 2 if you need the current timestamp
-for `get_alerts`. Or compute it from system time if available.
+For the `get_alerts` time range, compute ISO 8601 timestamps from the current
+date — e.g. `created_before` = now (`2026-07-10T00:00:00Z`) and `created_after`
+= 7 days earlier (`2026-07-03T00:00:00Z`), using the actual current date.
 
 ### Phase 3 — Check upstream health (ALL parents in parallel)
 

--- a/skills/prevent/SKILL.md
+++ b/skills/prevent/SKILL.md
@@ -196,7 +196,6 @@ All tools are available via the `monte-carlo-mcp` MCP server.
 | `getAudiences`               | List notification audiences                                          |
 | `getDomains`                 | List MC domains                                                      |
 | `getUser`                    | Current user info                                                    |
-| `getCurrentTime`             | ISO timestamp for API calls                                          |
 
 ## Core workflows
 

--- a/skills/prevent/references/parameters.md
+++ b/skills/prevent/references/parameters.md
@@ -17,7 +17,9 @@ The MCP tool uses Python snake_case, **not** the camelCase params from the MC we
 ```
 
 Always provide `created_after` and `created_before`. Max window is 60 days.
-Use `getCurrentTime()` to get the current ISO timestamp when needed.
+Pass ISO 8601 timestamps computed from the current date — e.g. for a 7-day
+window ending now: `created_after="2026-07-03T00:00:00Z"`,
+`created_before="2026-07-10T00:00:00Z"` (use the actual current date).
 
 ---
 


### PR DESCRIPTION
## What

`get_current_time` (and its camelCase form `getCurrentTime`) is no longer a tool the toolkit provides. This PR removes all references to it from the skills and replaces them with instructions plus ISO 8601 examples for building the timestamps that were the tool's only use case (`created_after` / `created_before` for `get_alerts`).

## Changes

5 references across 4 files:

- **`skills/analyze-root-cause/SKILL.md`** — dropped the tool-table row; added an ISO example to the `get_alerts` intake step.
- **`skills/asset-health/references/parameters.md`** — replaced the inline `get_alerts` note and deleted the dedicated `## get_current_time` section.
- **`skills/asset-health/references/workflows.md`** — replaced the Phase 1/2 timestamp note.
- **`skills/prevent/SKILL.md`** — dropped the tool-table row.
- **`skills/prevent/references/parameters.md`** — replaced the inline `getAlerts` note.

Each replacement instructs the model to compute ISO 8601 timestamps from the current date, with a concrete 7-day-window example and a reminder to use the actual current date.

SQL `CURRENT_TIMESTAMP()` usages in monitor/query examples are unrelated to the tool and were left untouched.

## Notes

- No PR template exists in this repo.
- Out of scope, but noted: the `prevent` skill's docs use camelCase MCP tool names, which conflicts with the repo's snake_case rule in `.claude/rules/skills.md`. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)