### PR TITLE
Refresh monitoring-advisor agent monitor references to current tool contract

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.13.3",
+    "version": "1.14.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.13.3",
+    "version": "1.14.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-03
+
+### Changed
+
+- Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
+- Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
+- Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.
+- Trajectory reference: `SPAN_OCCURRENCE` and `SPAN_RELATION` conditions, OR-only combination, occurrence count floors, `spanField` hierarchy, and the negated-relation pattern for a missing step.
+- Span-field reference: add `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OpenTelemetry availability caveat.
+
 ## [1.13.3] - 2026-06-23
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Refresh agent monitor references to match the current tool contract: single `agent` reference source (no `dw_id`/`data_source`), required `warehouse` for metric/evaluation/validation, `schedule_type` limited to `fixed`/`manual` with per-type interval floors, and `agent_span_filters` capped at one filter object.
+- Agent monitor warehouse is now sourced from `get_agent_metadata`'s `warehouse_uuid`/`warehouse_name` (show the name, pass the uuid; fall back to `get_warehouses` only when both are null).
 - Evaluation reference: correct predefined transform functions (`output_length`, `json_validity`, `keywords`), typed custom transforms (`custom_prompt`/`custom_sql` with camelCase `outputType`/`sqlExpression`), boolean-output alerting via `TRUE_RATE`/`FALSE_RATE`, and removal of unsupported `classification`/`sentiment`.
 - Metric reference: full agent metric catalog, `NEQ` operator, operator/threshold rules, `ROW_COUNT_CHANGE` and trace-aggregation constraints.
 - Validation reference: `negated`-flag negation (no `not_equal`/`not_null`), UNARY `value` vs BINARY `left`/`right`, numeric `status_code`.

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -104,7 +104,7 @@ All five tools follow a **two-call preview-then-confirm pattern**: the first cal
 
 | Tool | Purpose |
 | --- | --- |
-| `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types |
+| `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types, and each agent's `warehouse_uuid`/`warehouse_name` (the `warehouse` arg -- show the name, pass the uuid) |
 | `get_agent_conversations` | List recent conversations for an agent (newest first; filter by errors/status/turns/tokens/duration; optional inline transcripts) |
 | `get_agent_conversation` | Retrieve one conversation's full prompt/completion thread by `conversation_id` |
 | `get_agent_traces` | List traces with per-trace workflows, tasks, models, LLM-call counts, tokens, duration, and error counts |

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -105,8 +105,11 @@ All five tools follow a **two-call preview-then-confirm pattern**: the first cal
 | Tool | Purpose |
 | --- | --- |
 | `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types |
-| `get_agent_conversation` | Retrieve recent LLM interactions/conversations for an agent |
-| `get_agent_trace` | Inspect execution traces and span trees |
+| `get_agent_conversations` | List recent conversations for an agent (newest first; filter by errors/status/turns/tokens/duration; optional inline transcripts) |
+| `get_agent_conversation` | Retrieve one conversation's full prompt/completion thread by `conversation_id` |
+| `get_agent_traces` | List traces with per-trace workflows, tasks, models, LLM-call counts, tokens, duration, and error counts |
+| `get_agent_trace` | Inspect one execution trace's full span tree |
+| `get_agent_segments` | Enumerate the distinct `workflow` / `task` / `model` values to scope a monitor to a real segment |
 | `create_or_update_agent_metric_monitor` | Create or update monitors for quantitative span-level metrics (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 | `create_or_update_agent_evaluation_monitor` | Create or update monitors for LLM-evaluated quality metrics (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 | `create_or_update_agent_trajectory_monitor` | Create or update trajectory monitors for execution pattern alerts (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -21,9 +21,9 @@ transforms, which those don't need.
 > `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
 > truncate, or reconstruct it, and never pass an MCON.
 
-> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) the
-> agent's traces live in; omitting it fails with "Warehouse not found". List the
-> account's warehouses with `get_warehouses`.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the agent's `warehouse_uuid` from
+> `get_agent_metadata`; omitting it fails with "Warehouse not found". Use
+> `get_warehouses` when `warehouse_uuid` is null or to resolve a warehouse by name.
 
 > **CRITICAL:** `sampling_config` is REQUIRED. Provide `percentage`, `count`, or
 > both. Per-span monitors cap `count` at 10,000; conversation-level monitors cap it
@@ -305,7 +305,7 @@ create_or_update_agent_evaluation_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the agent's `warehouse_uuid` from `get_agent_metadata`; if null, list warehouses via `get_warehouses` |
 | invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
 | "Field X doesn't exist" | Wrong transform output field name, or a `classification`/`sentiment` output that isn't in the schema | Use the documented output field (e.g. `relevance_score`) or a custom transform's `alias`; replace `classification`/`sentiment` with a `custom_prompt` (`outputType` `boolean`/`string`) |
 | metric/output-type mismatch | Numeric metric on a boolean field (or vice versa) | `NUMERIC_MEAN` for numbers, `TRUE_RATE`/`FALSE_RATE` for booleans, `NULL_RATE` for any type |

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -8,43 +8,51 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 - **Helpfulness and clarity** — is the response useful and well-structured?
 - **Task completion** — did the agent complete what was asked?
 - **Banned-keyword check** — does the output avoid specific banned keywords (e.g. password, ssn, api secret)?
-- **Custom evaluation criteria** — via custom transforms
+- **Custom evaluation criteria** — a custom LLM check (`custom_prompt`) or SQL check (`custom_sql`) over span text
+
+Do NOT use this for a raw numeric metric like latency or token count (use
+`create_or_update_agent_metric_monitor`) — evaluation monitors add sampling and
+transforms, which those don't need.
 
 ## Constraints
 
-> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
-> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
-> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
-> pass an MCON as `agent`.
+> **CRITICAL:** The monitor's source is the `agent` reference. Pass the
+> `agentReference` value from `get_agent_metadata` verbatim — a platform
+> `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
+> truncate, or reconstruct it, and never pass an MCON.
 
-> **IMPORTANT:** `transforms` is now a TOP-LEVEL parameter (not nested under
-> `data_source`). It defines the evaluation logic.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) the
+> agent's traces live in; omitting it fails with "Warehouse not found". List the
+> account's warehouses with `get_warehouses`.
 
-> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
-> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
+> **CRITICAL:** `sampling_config` is REQUIRED. Provide `percentage`, `count`, or
+> both. Per-span monitors cap `count` at 10,000; conversation-level monitors cap it
+> at 500 (a percentage-only conversation config is capped at 500 per run).
 
-> **IMPORTANT:** `agent_span_filters` is an optional refinement; when used, include at
-> least the `agent` field.
+> **IMPORTANT:** `transforms` is a TOP-LEVEL parameter. Each transform produces an
+> output field that `alert_conditions.fields` references.
 
-> **IMPORTANT:** Use predefined transforms when possible — they have known output field
-> names (see the predefined transforms tables below). Custom transforms require you to
-> set the `alias` parameter correctly, which becomes the output field name used in
-> `alert_conditions.fields`.
+> **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
+> `interval_minutes` defaults to `60` and must be at least 60 **and** a multiple of 60.
 
-> **NEVER** set the `field` parameter on predefined transforms — omit it entirely.
-> Setting `field` on a predefined transform causes "Field X doesn't exist" errors
-> because the transform output field name is predetermined.
+> **NEVER** set a `field` parameter on any transform. Predefined judges pull their
+> inputs automatically; `custom_prompt` reads from its prompt's template variables;
+> `custom_sql` reads from the columns in its expression. There is no `field` param,
+> and no `context` param either.
 
-> **NEVER** use a `context` field on transforms — it is not supported and will cause errors.
+> **NEVER** use `classification` or `sentiment` as a transform function. Their output
+> column is not added to the evaluated schema, so no `alert_conditions` field can
+> reference it — the monitor can't alert on the result (you get "Field `<alias>`
+> doesn't exist"). To bucket or pass/fail a response, use a `custom_prompt` with
+> `outputType: "boolean"` (a check) or `"string"`.
 
 ## Key characteristics
 
-- Requires `sampling_config` — controls how many spans are sampled for evaluation
-- Supports a top-level `transforms` array — defines the evaluation logic
-- Transform output field names are used in `alert_conditions.fields`
-- Optional `is_agent_conversation_aggregation=True` to aggregate per conversation
-- Does NOT support a `context` field on transforms — do not use it
-- For predefined transforms, do NOT set the `field` parameter — omit it entirely
+- Requires `sampling_config` — controls how many spans/conversations are sampled
+- Supports a top-level `transforms` array — the evaluation logic
+- Transform output field names are what `alert_conditions.fields` reference
+- Optional `is_agent_conversation_aggregation=True` aggregates per conversation
+  (see the conversation-grain section — OTel agents only)
 
 ## Parameters
 
@@ -52,23 +60,25 @@ Run LLM-evaluated quality checks on agent outputs. Best for:
 |-----------|------|----------|-------------|
 | `description` | string | Yes | Human-readable monitor description (shown as display name) |
 | `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
+| `warehouse` | string | Yes | Warehouse name or UUID where the agent's traces live |
 | `alert_conditions` | array | Yes | Alert conditions using transform output field names |
-| `sampling_config` | object | Yes | `{"percentage": 10.0}` or `{"count": 100}` |
-| `transforms` | array | No | Evaluation transforms (predefined or custom); top-level, not under `data_source` |
-| `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation instead of per span |
-| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `sampling_config` | object | Yes | `{"percentage": 10.0}`, `{"count": 100}`, or both |
+| `transforms` | array | No | Evaluation transforms (predefined or custom); top-level |
+| `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation (OTel agents only) |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
-| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
-| `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators |
+| `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object |
+| `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators (`low`/`medium`/`high`) |
 | `aggregate_by` | string | No | Time-window bucketing (`hour`/`day`/`week`/`month`) |
-| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
-| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `schedule_type` | string | No | `fixed` (default) or `manual` |
+| `interval_minutes` | int | No | Default `60`; at least 60 and a multiple of 60 |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## Predefined LLM transforms
 
-These have default output field names — no `alias` needed and do NOT set `field`:
+Pass only `function` (and an optional `alias`, plus `modelConnectionId` on
+BigQuery). Do NOT set `prompt`, `sqlExpression`, `outputType`, or `field` — the tool
+rejects them. Each writes a numeric 1–5 score to its built-in output field:
 
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
@@ -82,28 +92,63 @@ These have default output field names — no `alias` needed and do NOT set `fiel
 
 ## Predefined SQL transforms (rule-based, no LLM needed)
 
+Same rule: pass only `function` (and an optional `alias`); do NOT set `prompt`,
+`sqlExpression`, `outputType`, `modelConnectionId`, or `field`.
+
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
-| `output_length` | `word_count` | number | Word count of the completion |
-| `json_validity` | `json_valid` | boolean | Is the completion valid JSON? |
+| `output_length` | `word_count` | number | Non-whitespace word count of the first completion |
+| `json_validity` | `json_valid` | boolean | Is the first completion valid JSON? |
 | `keywords` | `content_safe` | boolean | TRUE if output does NOT contain banned keywords (password, ssn, api secret, credit card). Not a general PII/secrets detector. |
 
 ## Custom transforms
 
-For `custom_prompt`, `custom_sql`, and `classification` transforms, the `alias`
-parameter becomes the output field name — you MUST set `alias`.
+Each writes an output column named by its `alias`, and that alias is what
+`alert_conditions.fields` references. `outputType` is **camelCase** and one of
+`"number"`, `"string"`, `"boolean"`.
 
-Transform `categories` must be objects with `label` and optional `description`:
-```json
-[
-    {"label": "relevant", "description": "The response addresses the user's question"},
-    {"label": "not_relevant"}
-]
-```
+| Function | Set these | Do NOT set | Output type |
+|----------|-----------|------------|-------------|
+| `custom_prompt` | `prompt` (with a `{{variable}}`), `alias`, `outputType` | `field`, `sqlExpression` | number / string / boolean |
+| `custom_sql` | `sqlExpression`, `alias`, `outputType` | `field`, `prompt`, `modelConnectionId` | number / string / boolean |
+
+- **`custom_prompt` prompts MUST reference at least one template variable** —
+  `{{prompts}}`, `{{completions}}`, or `{{expected_output}}` for a per-span monitor,
+  or `{{conversation}}` for a conversation-level monitor. A prompt with no variable,
+  an unknown variable, or the wrong variable for the grain is rejected.
+- **`custom_sql` runs against warehouse columns.** On Snowflake Cortex agents,
+  `prompts`/`completions` are arrays — reference the string columns
+  `first_completion` / `full_completion` / `first_prompt` instead. The dry-run does
+  not evaluate the SQL, so a bad column surfaces only at run time.
+- **`modelConnectionId`** is optional for LLM-based transforms (predefined judges and
+  `custom_prompt`) and REQUIRED on BigQuery warehouses. Omit it elsewhere.
+
+## Conversation-grain judges
+
+Each LLM judge has a `*_conversation` variant that evaluates a whole conversation
+instead of a single span. These require `is_agent_conversation_aggregation: true`
+**AND an OpenTelemetry agent** (platform agents like Snowflake Cortex reject
+conversation aggregation). The output/score column is not always the span judge's
+name:
+
+| Conversation function | Output/score field |
+|-----------------------|--------------------|
+| `answer_relevance_conversation` | `relevance_score` |
+| `task_completion_conversation` | `task_completion_score` |
+| `helpfulness_conversation` | `helpfulness_score` |
+| `clarity_conversation` | `clarity_score` |
+| `prompt_adherence_conversation` | `adherence_score` |
+| `language_match_conversation` | `match_score` |
+| `satisfaction_conversation` | `satisfaction_score` (no per-span counterpart) |
+
+At conversation grain, a `custom_prompt` may only reference `{{conversation}}`, and
+the predefined SQL checks and `custom_sql` are not supported. At span grain,
+`{{conversation}}` is not available.
 
 ## Alert conditions
 
-Use `thresholdValue` (camelCase) for threshold operators — NOT `threshold_value` (snake_case).
+Use `thresholdValue` (camelCase) for threshold operators — NOT `threshold_value`
+(snake_case). Each condition names one or more transform output fields in `fields`.
 
 ```json
 {
@@ -114,12 +159,26 @@ Use `thresholdValue` (camelCase) for threshold operators — NOT `threshold_valu
 }
 ```
 
+**Match the metric to the transform's output type** (a mismatch is rejected at
+dry-run):
+
+- **number** (the 1–5 judges, `output_length`, numeric `custom_prompt`/`custom_sql`)
+  → `NUMERIC_MEAN` and other numeric metrics.
+- **boolean** (`json_validity`, `keywords`, boolean `custom_prompt`/`custom_sql`) →
+  `TRUE_RATE` / `FALSE_RATE`. NEVER a numeric metric — a boolean field has no mean.
+- `NULL_RATE` works on any output type.
+
+`fields` must name a column in the evaluated schema — a predefined judge's built-in
+field, a custom transform's `alias`, or a raw source column (span grain:
+`duration_sec`, `total_tokens`, …; conversation grain: `turn_count`,
+`duration_seconds`, `status`). Duplicate `(metric, field)` pairs across conditions
+are rejected.
+
 ## Examples
 
-The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
-first example uses a platform `{database}:{schema}.{name}` reference; the others use an
-OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
-Note that `transforms` is now a top-level parameter, no longer nested under `data_source`.
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field.
+The first example uses a platform `{database}:{schema}.{name}` reference; the others
+use an OTel `service_name`. Use whichever form your agent returns.
 
 ### Answer relevance evaluation (platform agent reference)
 
@@ -127,6 +186,7 @@ Note that `transforms` is now a top-level parameter, no longer nested under `dat
 create_or_update_agent_evaluation_monitor(
     description="Chat Agent relevance evaluation",
     agent="analytics:agents.support_bot",
+    warehouse="Prod Warehouse",
     transforms=[
         {"function": "answer_relevance"}
     ],
@@ -135,55 +195,106 @@ create_or_update_agent_evaluation_monitor(
          "thresholdValue": 2}
     ],
     sampling_config={"percentage": 10.0},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
-    ],
     dry_run=True
 )
 ```
 
-### Banned-keyword check (OTel service_name)
+### Banned-keyword check as a boolean rate (OTel service_name)
+
+`keywords` outputs the boolean `content_safe`, so alert on its false rate — a
+numeric metric on a boolean field is rejected.
 
 ```
 create_or_update_agent_evaluation_monitor(
-    description="Chat Agent content safety check",
+    description="Chat Agent banned-keyword check",
     agent="checkout-agent",
+    warehouse="Agent Observability",
     transforms=[
         {"function": "keywords"}
     ],
     alert_conditions=[
-        {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["content_safe"],
-         "thresholdValue": 1}
+        {"metric": "FALSE_RATE", "operator": "GT", "fields": ["content_safe"],
+         "thresholdValue": 0.05}
     ],
     sampling_config={"count": 100},
     dry_run=True
 )
 ```
 
-### Custom classification
+### Custom prompt as a pass/fail (boolean) check
+
+The prompt references `{{completions}}`; there is no `field`; `outputType` is
+`boolean` so the alert watches the true/false rate. This is the right shape for
+"how often did the agent do X".
 
 ```
 create_or_update_agent_evaluation_monitor(
-    description="Chat Agent response tone classification",
+    description="Did the agent disambiguate the product before answering?",
     agent="checkout-agent",
+    warehouse="Agent Observability",
     transforms=[
         {
-            "function": "classification",
-            "alias": "tone_label",
-            "categories": [
-                {"label": "professional", "description": "Business-appropriate tone"},
-                {"label": "casual", "description": "Informal or overly relaxed tone"},
-                {"label": "inappropriate", "description": "Rude, dismissive, or harmful tone"}
-            ]
+            "function": "custom_prompt",
+            "alias": "disambiguated_product",
+            "prompt": "Did this response either ask which product the user meant, or state which product it assumed, before answering? Response: {{completions}}. Answer true or false.",
+            "outputType": "boolean"
         }
     ],
     alert_conditions=[
-        {"metric": "NUMERIC_MEAN", "operator": "GT", "fields": ["tone_label"],
-         "thresholdValue": 0}
+        {"metric": "FALSE_RATE", "operator": "GT", "fields": ["disambiguated_product"],
+         "thresholdValue": 0.2}
     ],
-    sampling_config={"percentage": 5.0},
-    schedule_type="fixed",
-    interval_minutes=360,
+    sampling_config={"percentage": 20.0},
+    dry_run=True
+)
+```
+
+### Custom SQL numeric check
+
+`custom_sql` needs `sqlExpression` + `alias` + `outputType`; alert with a numeric
+metric on the alias.
+
+```
+create_or_update_agent_evaluation_monitor(
+    description="Completion length floor",
+    agent="checkout-agent",
+    warehouse="Agent Observability",
+    transforms=[
+        {
+            "function": "custom_sql",
+            "alias": "answer_chars",
+            "sqlExpression": "LENGTH(first_completion)",
+            "outputType": "number"
+        }
+    ],
+    alert_conditions=[
+        {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["answer_chars"],
+         "thresholdValue": 40}
+    ],
+    sampling_config={"percentage": 10.0},
+    dry_run=True
+)
+```
+
+### Conversation-level evaluation (OTel agent only)
+
+Set `is_agent_conversation_aggregation=True`, use a `*_conversation` judge, and alert
+on its score field (`task_completion_conversation` → `task_completion_score`).
+Sampling `count` ≤ 500.
+
+```
+create_or_update_agent_evaluation_monitor(
+    description="Task completion across full conversations",
+    agent="checkout-agent",
+    warehouse="Agent Observability",
+    is_agent_conversation_aggregation=True,
+    transforms=[
+        {"function": "task_completion_conversation"}
+    ],
+    alert_conditions=[
+        {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["task_completion_score"]}
+    ],
+    sampling_config={"count": 100},
     dry_run=True
 )
 ```
@@ -192,5 +303,7 @@ create_or_update_agent_evaluation_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
-| "Field X doesn't exist" | Wrong transform output field name used in `alert_conditions.fields` | For predefined transforms, use the documented output field name (e.g., `relevance_score` for `answer_relevance`); for custom transforms, verify the `alias` matches |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
+| "Field X doesn't exist" | Wrong transform output field name, or a `classification`/`sentiment` output that isn't in the schema | Use the documented output field (e.g. `relevance_score`) or a custom transform's `alias`; replace `classification`/`sentiment` with a `custom_prompt` (`outputType` `boolean`/`string`) |
+| metric/output-type mismatch | Numeric metric on a boolean field (or vice versa) | `NUMERIC_MEAN` for numbers, `TRUE_RATE`/`FALSE_RATE` for booleans, `NULL_RATE` for any type |

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -66,7 +66,7 @@ transforms, which those don't need.
 | `transforms` | array | No | Evaluation transforms (predefined or custom); top-level |
 | `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation (OTel agents only) |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
-| `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object |
+| `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object. At conversation grain (`is_agent_conversation_aggregation=True`) only `agent`/`workflow` are allowed — not `task`/`spanName` |
 | `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators (`low`/`medium`/`high`) |
 | `aggregate_by` | string | No | Time-window bucketing (`hour`/`day`/`week`/`month`) |
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
@@ -78,7 +78,8 @@ transforms, which those don't need.
 
 Pass only `function` (and an optional `alias`, plus `modelConnectionId` on
 BigQuery). Do NOT set `prompt`, `sqlExpression`, `outputType`, or `field` — the tool
-rejects them. Each writes a numeric 1–5 score to its built-in output field:
+rejects them. Each writes a numeric score (1–5, except `semantic_similarity` which is
+0–5) to its built-in output field:
 
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
@@ -143,7 +144,8 @@ name:
 
 At conversation grain, a `custom_prompt` may only reference `{{conversation}}`, and
 the predefined SQL checks and `custom_sql` are not supported. At span grain,
-`{{conversation}}` is not available.
+`{{conversation}}` is not available. `agent_span_filters` at conversation grain may
+scope only by `agent`/`workflow` — `task`/`spanName` are span-level and are rejected.
 
 ## Alert conditions
 
@@ -307,3 +309,4 @@ create_or_update_agent_evaluation_monitor(
 | invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
 | "Field X doesn't exist" | Wrong transform output field name, or a `classification`/`sentiment` output that isn't in the schema | Use the documented output field (e.g. `relevance_score`) or a custom transform's `alias`; replace `classification`/`sentiment` with a `custom_prompt` (`outputType` `boolean`/`string`) |
 | metric/output-type mismatch | Numeric metric on a boolean field (or vice versa) | `NUMERIC_MEAN` for numbers, `TRUE_RATE`/`FALSE_RATE` for booleans, `NULL_RATE` for any type |
+| `task`/`spanName` rejected in `agent_span_filters` | Used a span-level filter dimension at conversation grain | At conversation grain (`is_agent_conversation_aggregation=True`), scope only by `agent`/`workflow` — `task`/`spanName` are span-level |

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -107,8 +107,9 @@ Each condition has:
 | `UNIQUE_COUNT` | numeric / text / date |
 
 Numeric metrics apply to `duration_sec` / `*_tokens` / `status_code`; boolean metrics
-apply to `is_tool_call` / `is_llm_call` / `has_prompts` / `has_completions`;
-`NULL_RATE` applies to any field. Duplicate `(metric, field)` pairs across conditions
+apply to `is_tool_call` / `is_llm_call` / `has_prompts` / `has_completions` (the last
+three are OTel/ClickHouse only — platform/Cortex agents lack them); `NULL_RATE`
+applies to any field. Duplicate `(metric, field)` pairs across conditions
 are rejected.
 
 Common numeric fields: `duration_sec`, `total_tokens`, `prompt_tokens`,

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -6,37 +6,44 @@ Track quantitative span-level metrics over time. Best for:
 
 - **Latency monitoring** — `duration_sec` trending up
 - **Token usage tracking** — `total_tokens`, `prompt_tokens`, `completion_tokens` per call
-- **Volume monitoring** — number of spans per time window
+- **Volume monitoring** — number of spans per time window (`ROW_COUNT_CHANGE`)
+- **Boolean rates** — e.g. tool-call rate via `is_tool_call`
+- **Anomaly detection** on any of the above with automatic thresholds
+
+Do NOT use this for LLM-evaluated quality (relevance, correctness, tone) — that's
+`create_or_update_agent_evaluation_monitor`, which adds sampling + transforms.
 
 ## Constraints
 
-> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
-> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
-> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
-> pass an MCON as `agent`.
+> **CRITICAL:** The monitor's source is the `agent` reference. Pass the
+> `agentReference` value from `get_agent_metadata` verbatim — a platform
+> `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
+> truncate, or reconstruct it, and never pass an MCON.
 
-> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
-> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) holding
+> the agent's traces; resolve via `get_warehouses`.
 
-> **IMPORTANT:** `agent_span_filters` is an optional refinement — the `agent` reference
-> already scopes the monitor. When you do filter, include at least the `agent` field.
+> **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
+> `interval_minutes` defaults to `60` and must be at least 60 **and** a multiple of 60.
 
-> **IMPORTANT:** Use `duration_sec` (not `duration_ms`) for latency monitoring. The field
-> is named `duration_sec` in the PARSED_SPANS layer — `duration_ms` does not exist.
+> **IMPORTANT:** Use `duration_sec` (not `duration_ms`) for latency. The field is
+> named `duration_sec` in the PARSED_SPANS layer — `duration_ms` does not exist.
 
-> **IMPORTANT:** Use `total_tokens`, `prompt_tokens`, `completion_tokens` for token
-> monitoring. These are the only token-related fields available.
+> **IMPORTANT:** `ROW_COUNT_CHANGE` is table-level — do NOT include a `fields` array,
+> and use only an anomaly operator (`AUTO`/`AUTO_HIGH`/`AUTO_LOW`) or `NOOP`. A manual
+> comparison operator has no field to bind to and is rejected.
 
-> **IMPORTANT:** Use `ROW_COUNT_CHANGE` metric without the `fields` array for volume
-> monitoring. Including `fields` with `ROW_COUNT_CHANGE` will cause an error.
+> **IMPORTANT:** Match the metric to the field type — numeric metrics need numeric
+> fields, boolean metrics need boolean fields. A numeric metric on a non-numeric
+> field is rejected at dry-run.
 
 ## Key characteristics
 
-- Uses `alert_conditions` with metric + operator (same as standard metric monitors)
-- Supports AUTO (anomaly detection) and threshold operators (GT, LT, EQ, GTE, LTE, NEQ)
-- Optional `is_agent_trace_aggregation=True` to aggregate per trace instead of per span
-- Optional `sensitivity` to tune anomaly detection for AUTO operators
-- Does NOT support transforms or sampling — raw numeric fields only
+- Uses `alert_conditions` with metric + operator (no transforms, no sampling)
+- Supports anomaly (`AUTO`) and threshold operators
+- Optional `is_agent_trace_aggregation=True` aggregates per trace instead of per span
+  (OTel agents only — see Trace aggregation)
+- Optional `sensitivity` (`low`/`medium`/`high`) tunes AUTO operators
 
 ## Parameters
 
@@ -44,101 +51,160 @@ Track quantitative span-level metrics over time. Best for:
 |-----------|------|----------|-------------|
 | `description` | string | Yes | Human-readable monitor description (shown as display name) |
 | `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
+| `warehouse` | string | Yes | Warehouse name or UUID holding the agent's traces |
 | `alert_conditions` | array | Yes | List of alert condition objects (see below) |
-| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
-| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
-| `is_agent_trace_aggregation` | boolean | No | Aggregate per trace instead of per span |
+| `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object |
+| `is_agent_trace_aggregation` | boolean | No | Aggregate per trace instead of per span (OTel only) |
 | `aggregate_by` | string | No | Time-window bucketing (`hour`/`day`/`week`/`month`) |
 | `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators |
-| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
-| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `schedule_type` | string | No | `fixed` (default) or `manual` |
+| `interval_minutes` | int | No | Default `60`; at least 60 and a multiple of 60 |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
-## Alert condition format
+## Alert conditions
 
-```json
-{
-    "metric": "NUMERIC_MEAN",
-    "operator": "AUTO",
-    "fields": ["duration_sec"]
-}
-```
+Each condition has:
 
-Available metrics: `NUMERIC_MEAN`, `NUMERIC_MIN`, `NUMERIC_MAX`, `ROW_COUNT_CHANGE`
+| Field | Required | Description |
+|-------|----------|-------------|
+| `metric` | Yes | The metric to compute (see Metrics below). |
+| `operator` | Yes | See Operators below. |
+| `fields` | Depends | PARSED_SPANS field name(s). Required for every manual operator and range. Omit for `ROW_COUNT_CHANGE`. |
+| `thresholdValue` | Depends | Required for single-value operators (`GT`/`GTE`/`LT`/`LTE`/`EQ`/`NEQ`). camelCase — NOT `threshold_value`. |
+| `lowerThreshold` / `upperThreshold` | Depends | Both required for `INSIDE_RANGE` / `OUTSIDE_RANGE`; `lowerThreshold` ≤ `upperThreshold`. |
+| `type` | No | `threshold` (default) or `noop` (collect without alerting; pair with `operator: "NOOP"`). |
 
-Available operators:
-- `AUTO` — anomaly detection (recommended for most cases)
-- `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NEQ` — threshold-based (requires `thresholdValue`)
+### Operators
 
-**Important:** For `ROW_COUNT_CHANGE`, do NOT include the `fields` array — it operates on row counts, not specific fields.
+- **Anomaly detection:** `AUTO`, `AUTO_HIGH`, `AUTO_LOW` — learn thresholds
+  automatically. Do NOT pass any threshold.
+- **Single threshold:** `GT`, `GTE`, `LT`, `LTE`, `EQ`, `NEQ` — require
+  `thresholdValue` **and** `fields`. (The not-equal operator is `NEQ`, not `NE`.)
+- **Range:** `INSIDE_RANGE`, `OUTSIDE_RANGE` — require both `lowerThreshold` and
+  `upperThreshold` (and `fields`).
+- **Collect-only:** `NOOP` — record the metric without alerting; pair with
+  `type: "noop"`.
+
+### Metrics
+
+**Table-level metric (no `fields`; anomaly / NOOP operators only):**
+
+| Metric | Notes |
+|--------|-------|
+| `ROW_COUNT_CHANGE` | Anomalous span volume. `AUTO` / `AUTO_HIGH` / `AUTO_LOW` (or `NOOP`) only; no `fields`. |
+
+**Field-level metrics (must specify `fields`), by field type:**
+
+| Metric | Field type |
+|--------|-----------|
+| `NUMERIC_MEAN`, `NUMERIC_MEDIAN`, `NUMERIC_MIN`, `NUMERIC_MAX`, `NUMERIC_STDDEV`, `SUM` | numeric |
+| `PERCENTILE_20`, `PERCENTILE_40`, `PERCENTILE_60`, `PERCENTILE_80`, `PERCENTILE_95`, `PERCENTILE_99` | numeric |
+| `ZERO_RATE`, `ZERO_COUNT`, `NEGATIVE_RATE`, `NEGATIVE_COUNT` | numeric |
+| `TRUE_RATE`, `TRUE_COUNT`, `FALSE_RATE`, `FALSE_COUNT` | boolean |
+| `NULL_RATE`, `NULL_COUNT`, `NON_NULL_COUNT` | any |
+| `UNIQUE_COUNT` | numeric / text / date |
+
+Numeric metrics apply to `duration_sec` / `*_tokens` / `status_code`; boolean metrics
+apply to `is_tool_call` / `is_llm_call` / `has_prompts` / `has_completions`;
+`NULL_RATE` applies to any field. Duplicate `(metric, field)` pairs across conditions
+are rejected.
+
+Common numeric fields: `duration_sec`, `total_tokens`, `prompt_tokens`,
+`completion_tokens`, `status_code` (span grain); `span_count`, `llm_call_count`,
+token totals, `duration_sec` (trace grain). Do NOT use `duration_ms` or raw table
+column names.
+
+## Trace aggregation
+
+`is_agent_trace_aggregation=True` rolls spans up per trace. Constraints:
+
+- **OTel agents only.** Platform agent references (`{database}:{schema}.{name}`) are
+  rejected — the per-trace query isn't built for them. Target an OTel `service_name`,
+  or pass an explicit `trace_table`.
+- **Only the `agent` span filter is allowed** — remove `workflow` / `task` /
+  `spanName` from `agent_span_filters`, since the per-trace result has no such column.
+- Use the trace-aggregation field names (`span_count`, `llm_call_count`, trace-summed
+  tokens, total `duration_sec`). See `agent-span-fields.md`.
 
 ## Examples
 
-The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
-first example uses a platform `{database}:{schema}.{name}` reference; the others use an
-OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field —
+a platform `{database}:{schema}.{name}` reference or an OTel `service_name`.
 
-### Latency monitoring (platform agent reference)
+### Latency anomaly detection (platform agent reference)
 
 ```
 create_or_update_agent_metric_monitor(
     description="Chat Agent latency monitor",
     agent="analytics:agents.support_bot",
+    warehouse="Prod Warehouse",
     alert_conditions=[
         {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["duration_sec"]}
     ],
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
-    ],
     dry_run=True
 )
 ```
 
-### Token usage monitoring (OTel service_name)
-
-```
-create_or_update_agent_metric_monitor(
-    description="Chat Agent token usage monitor",
-    agent="checkout-agent",
-    alert_conditions=[
-        {"metric": "NUMERIC_MEAN", "operator": "GT", "fields": ["total_tokens"],
-         "thresholdValue": 5000}
-    ],
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
-    ],
-    dry_run=True
-)
-```
-
-### Volume monitoring (ROW_COUNT_CHANGE — no fields array)
+### Span volume anomaly detection (OTel service_name, ROW_COUNT_CHANGE — no fields)
 
 ```
 create_or_update_agent_metric_monitor(
     description="Chat Agent span volume monitor",
     agent="checkout-agent",
+    warehouse="Prod Warehouse",
     alert_conditions=[
         {"metric": "ROW_COUNT_CHANGE", "operator": "AUTO"}
     ],
     agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
+        {"workflow": {"value": "Chat Agent"}}
     ],
     dry_run=True
 )
 ```
 
-### Trace-level latency (aggregated per trace)
+### Token usage with threshold (span grain)
 
 ```
 create_or_update_agent_metric_monitor(
-    description="Chat Agent end-to-end trace latency",
-    agent="checkout-agent",
+    description="Alert when mean token usage exceeds 5000",
+    agent="analytics:agents.support_bot",
+    warehouse="Prod Warehouse",
     alert_conditions=[
-        {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["duration_sec"]}
+        {"metric": "NUMERIC_MEAN", "operator": "GT", "fields": ["total_tokens"],
+         "thresholdValue": 5000}
+    ],
+    dry_run=True
+)
+```
+
+### Trace-level token rollup (OTel agent, trace aggregation)
+
+```
+create_or_update_agent_metric_monitor(
+    description="Alert on anomalous per-trace token totals",
+    agent="checkout-agent",
+    warehouse="Prod Warehouse",
+    alert_conditions=[
+        {"metric": "NUMERIC_MEAN", "operator": "AUTO", "fields": ["total_tokens"]}
     ],
     is_agent_trace_aggregation=True,
+    dry_run=True
+)
+```
+
+### Tool-call rate (OTel agent, boolean field)
+
+```
+create_or_update_agent_metric_monitor(
+    description="Alert when tool-call rate drops",
+    agent="checkout-agent",
+    warehouse="Prod Warehouse",
+    alert_conditions=[
+        {"metric": "TRUE_RATE", "operator": "LT", "fields": ["is_tool_call"],
+         "thresholdValue": 0.1}
+    ],
     dry_run=True
 )
 ```
@@ -147,5 +213,8 @@ create_or_update_agent_metric_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
-| "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md` for valid field names; use `duration_sec` not `duration_ms` |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
+| "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md`; use `duration_sec` not `duration_ms` |
+| metric/field-type mismatch | Numeric metric on a boolean field (or vice versa) | Numeric metrics on numeric fields, boolean metrics on boolean fields, `NULL_RATE` on any |
+| `ROW_COUNT_CHANGE` rejected | Included `fields`, or used a manual operator | Drop `fields`; use `AUTO`/`AUTO_HIGH`/`AUTO_LOW` or `NOOP` |

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -20,8 +20,8 @@ Do NOT use this for LLM-evaluated quality (relevance, correctness, tone) — tha
 > `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
 > truncate, or reconstruct it, and never pass an MCON.
 
-> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) holding
-> the agent's traces; resolve via `get_warehouses`.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the agent's `warehouse_uuid` from
+> `get_agent_metadata`; use `get_warehouses` when it is null or to resolve by name.
 
 > **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
 > `interval_minutes` defaults to `60` and must be at least 60 **and** a multiple of 60.
@@ -214,7 +214,7 @@ create_or_update_agent_metric_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the agent's `warehouse_uuid` from `get_agent_metadata`; if null, list warehouses via `get_warehouses` |
 | invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
 | "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md`; use `duration_sec` not `duration_ms` |
 | metric/field-type mismatch | Numeric metric on a boolean field (or vice versa) | Numeric metrics on numeric fields, boolean metrics on boolean fields, `NULL_RATE` on any |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -20,68 +20,99 @@ Key fields in the response:
 |-------|-------------|
 | `agentName` | Human-readable agent name |
 | `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
-| `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for `get_agent_conversation`/`get_agent_trace` |
+| `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
 
 **Duplicate agents across warehouses:** The same agent name may appear in
 multiple warehouses (e.g., deployed in both prod and staging). When this
 happens, present the warehouse **names** (never UUIDs) and ask the user which
-warehouse they want to monitor. Pass the chosen warehouse as the `warehouse`
-arg (name or UUID) when the agent reference does not pin it down.
+warehouse they want to monitor. Each entry has a different `agentReference` /
+`warehouse`, so the choice determines which agent the monitor tracks. Pass the
+chosen warehouse as the `warehouse` arg (name or UUID); resolve names via
+`get_warehouses` when the agent reference does not pin it.
 
 ---
 
 ## Step 2: Investigate agent behavior
 
 Use the read tools to understand the agent's behavior before suggesting monitors.
+These read tools are your sampling surface — do **not** query the trace store with
+SQL. Agents are tracked as agents, not tables: platform agents (Snowflake Cortex /
+Databricks) have no queryable trace table, and for custom agents the raw table's
+columns are not the fields monitors use.
 
 ### 2a. Review recent conversations
 
-Call `get_agent_conversation` with the agent's `agent_name` and
-`trace_table_mcon` to see recent LLM interactions. Look for:
+Call `get_agent_conversations` with the agent's `agent_name` and `trace_table_mcon`
+to list recent conversations (newest first). Filter to surface interesting ones —
+`has_errors`, `status`, or turn/token/duration bounds — and set
+`include_transcript=True` to read the prompt/completion transcripts inline. Drill
+into one conversation you already have the id for with `get_agent_conversation`.
+Look for:
 
 - **Error patterns** — spans with error status or failure indicators
 - **Latency outliers** — unusually long durations
 - **Token usage** — high token counts that may indicate inefficiency
 - **Conversation quality** — check prompt/completion text for relevance
 
-### 2b. Inspect execution traces
+### 2b. Inspect execution shape and traces
 
-Pick a few trace IDs from the conversation results and call `get_agent_trace`
-to see the full span tree. Look for:
+Call `get_agent_traces` to list traces with per-trace `workflows`, `tasks`,
+`models`, `count_llm_calls`, `total_tokens`, `duration_seconds`, and error counts —
+sort by the field you plan to monitor to see typical values and outliers. Call
+`get_agent_segments` to enumerate the distinct `workflow` / `task` / `model` values
+so you can scope a monitor to a real segment. Then pick a trace id and call
+`get_agent_trace` to see the full span tree. Look for:
 
 - **Excessive tool calls** — an agent calling the same tool many times
 - **Missing steps** — expected spans that don't appear
 - **Error cascades** — a failed span causing downstream failures
 - **Unusual paths** — the agent taking an unexpected execution route
 
+You are identifying **what** to monitor — you don't need exact percentiles up
+front; anomaly-detection operators (`AUTO`) learn the baseline themselves.
+
 ---
 
 ## The `agent` reference
 
-All four `create_or_update_agent_*_monitor` tools author the monitor's source via
-a single top-level **`agent`** argument — there is no `dw_id` or `data_source`/MCON.
-Two accepted forms:
+All four `create_or_update_agent_*_monitor` tools author the monitor's source from
+a single top-level **`agent`** argument. Two accepted forms:
 
 - **Platform agent reference** — `{database}:{schema}.{name}` (Snowflake Cortex /
   Databricks agents), e.g. `analytics:agents.support_bot`.
 - **OpenTelemetry `service_name`** — for OTel-instrumented agents, e.g. `checkout-agent`.
 
-Get the exact value from `get_agent_metadata`'s **`agentReference`** field — never
-construct it by hand. Two optional companions:
+Get the exact value from `get_agent_metadata`'s **`agentReference`** field and pass
+it verbatim — never construct, modify, or truncate it, and never pass an MCON. Two
+optional companions:
 
-- `warehouse` (name or UUID) — only needed when the agent reference doesn't pin down
-  the warehouse. Resolve names via `get_warehouses`.
 - `trace_table` — only for non-ClickHouse OTel agents whose trace storage cannot be
   inferred from the agent reference.
+- The per-type reference tells you whether `warehouse` is required (see below).
+
+There is no `dw_id` and no `data_source` argument — the `agent` reference is the
+whole source.
+
+---
+
+## Warehouse
+
+`warehouse` is the name or UUID of the warehouse the agent's trace data lives in.
+Resolve names via `get_warehouses`, or use the `warehouse` returned alongside the
+agent in `get_agent_metadata`.
+
+- **Required** for metric, evaluation, and validation monitors — omitting it fails
+  with "Warehouse not found".
+- **Optional** for trajectory monitors — they fall back to the account default.
 
 ---
 
 ## Agent span filters
 
-The optional `agent_span_filters` parameter refines which spans are monitored. Each
-filter is an object with optional fields: `agent`, `workflow`, `task`, `spanName`.
-Each field contains a `{"value": "..."}` sub-object.
+The optional `agent_span_filters` parameter refines which spans are monitored. It
+accepts **at most one** filter object. Each field of the object holds a
+`{"value": "..."}` sub-object.
 
 | Filter field | Description | Example |
 |-------------|-------------|---------|
@@ -90,14 +121,20 @@ Each field contains a `{"value": "..."}` sub-object.
 | `task` | Filter by task name | `{"task": {"value": "call_model"}}` |
 | `spanName` | Filter by span name | `{"spanName": {"value": "ChatBedrockConverse.chat"}}` |
 
-Multiple fields can be combined in one filter object. Example:
+Multiple fields can be combined in the single filter object:
+
 ```json
-[{"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}, "task": {"value": "call_model"}}]
+[{"workflow": {"value": "Chat Agent"}, "task": {"value": "call_model"}}]
 ```
 
 `agent_span_filters` is a refinement and is optional — the `agent` reference already
-scopes the monitor. (Trajectory monitors are the exception: there `agent_span_filters`
-may set ONLY the `agent` field — see `agent-trajectory-monitor.md`.)
+scopes the monitor. Two exceptions, covered in the per-type references:
+
+- **Trajectory monitors** allow only the `agent` field here — workflow / task /
+  spanName go in the alert condition's `spanField` instead (see
+  `agent-trajectory-monitor.md`).
+- **Trace-aggregated metric / validation monitors** allow only the `agent` field —
+  the per-trace result has no workflow / task / spanName column.
 
 ---
 
@@ -105,12 +142,16 @@ may set ONLY the `agent` field — see `agent-trajectory-monitor.md`.)
 
 Schedule is set via two top-level args, not a nested object:
 
-- `schedule_type` — defaults to `fixed`. Valid values: `fixed`, `dynamic`, `manual`.
-- `interval_minutes` — defaults to `60` for `fixed`. Common patterns: `60` (hourly),
-  `360` (every 6 hours), `1440` (daily).
+- `schedule_type` — defaults to `fixed`. Valid values: `fixed`, `manual`.
+- `interval_minutes` — defaults to `60`. The floor and alignment depend on the
+  monitor type:
+  - **Metric and evaluation:** at least 60 minutes **and** a multiple of 60
+    (`60` hourly, `360` every 6 hours, `1440` daily).
+  - **Validation and trajectory:** at least 5 minutes; sub-hourly is allowed with no
+    60-minute alignment.
 
-Omit both to accept the hourly fixed default. Use shorter intervals for critical
-agents, longer for less critical ones.
+No agent monitor accepts a dynamic schedule — use `fixed` or `manual`. Use shorter
+intervals for critical agents, longer for less critical ones.
 
 ---
 
@@ -153,13 +194,13 @@ monitor tools: the first call (`dry_run=True`, the default) returns the rendered
 YAML for review; the second call (`dry_run=False`) deploys the monitor live and
 returns its UUID. Pass `monitor_uuid` on either call to update an existing agent
 monitor in place instead of creating a new one (PUT semantics — re-pass every field
-you want to keep).
+you want to keep, since omitted fields revert to defaults).
 
 1. **Always start with `dry_run=True`** (the default). Show the user the
    configuration preview (the rendered YAML).
 2. Call `get_audiences` to list available notification audiences. Suggest the
-   most relevant one and ask the user to pick. Pass audience **names** (not UUIDs)
-   as the `audiences` list.
+   most relevant one(s) and ask the user to pick — they can choose one or several.
+   Pass audience **names** (not UUIDs) as the `audiences` list.
 3. After showing the preview, offer to create or adjust settings.
 4. Only set `dry_run=False` when the user explicitly confirms creation.
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -22,8 +22,8 @@ Key fields in the response:
 | `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
 | `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
-| `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when it cannot be derived; fall back to `get_warehouses` (see Warehouse below). |
-| `warehouse_name` | Display name of that warehouse — what you show the user. Null when unavailable; fall back to `get_warehouses`. |
+| `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when the warehouse was deleted or cannot be resolved; fall back to `get_warehouses` (see Warehouse below). |
+| `warehouse_name` | Display name of that warehouse — what you show the user. Null alongside `warehouse_uuid`; fall back to `get_warehouses`. |
 
 **Duplicate agent names:** The same agent name may appear more than once (e.g.,
 deployed in both prod and staging). Each entry is distinguished by its own

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -23,13 +23,12 @@ Key fields in the response:
 | `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
 
-**Duplicate agents across warehouses:** The same agent name may appear in
-multiple warehouses (e.g., deployed in both prod and staging). When this
-happens, present the warehouse **names** (never UUIDs) and ask the user which
-warehouse they want to monitor. Each entry has a different `agentReference` /
-`warehouse`, so the choice determines which agent the monitor tracks. Pass the
-chosen warehouse as the `warehouse` arg (name or UUID); resolve names via
-`get_warehouses` when the agent reference does not pin it.
+**Duplicate agent names:** The same agent name may appear more than once (e.g.,
+deployed in both prod and staging). Each entry is distinguished by its own
+`agentReference` and `traceTableMcon` — ask the user which one they want to monitor
+and pass that entry's `agentReference` verbatim. The warehouse the traces live in is
+resolved separately via `get_warehouses` (see Warehouse below); when you ask the user
+to choose a warehouse, present its **name** (never a UUID).
 
 ---
 
@@ -77,7 +76,8 @@ front; anomaly-detection operators (`AUTO`) learn the baseline themselves.
 ## The `agent` reference
 
 All four `create_or_update_agent_*_monitor` tools author the monitor's source from
-a single top-level **`agent`** argument. Two accepted forms:
+a single top-level **`agent`** argument (there is no `dw_id` and no `data_source`
+argument — the `agent` reference is the whole source). Two accepted forms:
 
 - **Platform agent reference** — `{database}:{schema}.{name}` (Snowflake Cortex /
   Databricks agents), e.g. `analytics:agents.support_bot`.
@@ -91,20 +91,13 @@ optional companions:
   inferred from the agent reference.
 - The per-type reference tells you whether `warehouse` is required (see below).
 
-There is no `dw_id` and no `data_source` argument — the `agent` reference is the
-whole source.
-
 ---
 
 ## Warehouse
 
-`warehouse` is the name or UUID of the warehouse the agent's trace data lives in.
-Resolve names via `get_warehouses`, or use the `warehouse` returned alongside the
-agent in `get_agent_metadata`.
-
-- **Required** for metric, evaluation, and validation monitors — omitting it fails
-  with "Warehouse not found".
-- **Optional** for trajectory monitors — they fall back to the account default.
+`warehouse` names the warehouse the agent's trace data lives in — pass it as a name
+or UUID. Resolve names to the right warehouse with `get_warehouses`. Whether it is
+required or optional depends on the monitor type — see the per-type reference.
 
 ---
 
@@ -128,13 +121,9 @@ Multiple fields can be combined in the single filter object:
 ```
 
 `agent_span_filters` is a refinement and is optional — the `agent` reference already
-scopes the monitor. Two exceptions, covered in the per-type references:
-
-- **Trajectory monitors** allow only the `agent` field here — workflow / task /
-  spanName go in the alert condition's `spanField` instead (see
-  `agent-trajectory-monitor.md`).
-- **Trace-aggregated metric / validation monitors** allow only the `agent` field —
-  the per-trace result has no workflow / task / spanName column.
+scopes the monitor. Some monitor types restrict which fields are allowed here (e.g.
+trajectory monitors, and trace-aggregated metric / validation monitors) — see the
+per-type reference for the exact rule.
 
 ---
 
@@ -143,12 +132,8 @@ scopes the monitor. Two exceptions, covered in the per-type references:
 Schedule is set via two top-level args, not a nested object:
 
 - `schedule_type` — defaults to `fixed`. Valid values: `fixed`, `manual`.
-- `interval_minutes` — defaults to `60`. The floor and alignment depend on the
-  monitor type:
-  - **Metric and evaluation:** at least 60 minutes **and** a multiple of 60
-    (`60` hourly, `360` every 6 hours, `1440` daily).
-  - **Validation and trajectory:** at least 5 minutes; sub-hourly is allowed with no
-    60-minute alignment.
+- `interval_minutes` — defaults to `60`. The floor and alignment differ per monitor
+  type — see each reference.
 
 No agent monitor accepts a dynamic schedule — use `fixed` or `manual`. Use shorter
 intervals for critical agents, longer for less critical ones.

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -22,13 +22,13 @@ Key fields in the response:
 | `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
 | `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
+| `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when it cannot be derived; fall back to `get_warehouses` (see Warehouse below). |
 
 **Duplicate agent names:** The same agent name may appear more than once (e.g.,
 deployed in both prod and staging). Each entry is distinguished by its own
-`agentReference` and `traceTableMcon` — ask the user which one they want to monitor
-and pass that entry's `agentReference` verbatim. The warehouse the traces live in is
-resolved separately via `get_warehouses` (see Warehouse below); when you ask the user
-to choose a warehouse, present its **name** (never a UUID).
+`agentReference`, `traceTableMcon`, and `warehouse_uuid` — ask the user which one
+they want to monitor and pass that entry's `agentReference` verbatim. When you ask
+the user to choose, present warehouse **names** (via `get_warehouses`), never UUIDs.
 
 ---
 
@@ -96,8 +96,10 @@ optional companions:
 ## Warehouse
 
 `warehouse` names the warehouse the agent's trace data lives in — pass it as a name
-or UUID. Resolve names to the right warehouse with `get_warehouses`. Whether it is
-required or optional depends on the monitor type — see the per-type reference.
+or UUID. Use the agent entry's `warehouse_uuid` from `get_agent_metadata`; when it is
+null, or when you need to resolve a warehouse by display name, use `get_warehouses`.
+Whether `warehouse` is required or optional depends on the monitor type — see the
+per-type reference.
 
 ---
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -20,7 +20,7 @@ Key fields in the response:
 |-------|-------------|
 | `agentName` | Human-readable agent name |
 | `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
-| `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
+| `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_segments`; the parameter is named `mcon` on `get_agent_trace`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
 | `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when the warehouse was deleted or cannot be resolved; fall back to `get_warehouses` (see Warehouse below). |
 | `warehouse_name` | Display name of that warehouse — what you show the user. Null alongside `warehouse_uuid`; fall back to `get_warehouses`. |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -23,12 +23,13 @@ Key fields in the response:
 | `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_trace`, `get_agent_segments`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
 | `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when it cannot be derived; fall back to `get_warehouses` (see Warehouse below). |
+| `warehouse_name` | Display name of that warehouse — what you show the user. Null when unavailable; fall back to `get_warehouses`. |
 
 **Duplicate agent names:** The same agent name may appear more than once (e.g.,
 deployed in both prod and staging). Each entry is distinguished by its own
-`agentReference`, `traceTableMcon`, and `warehouse_uuid` — ask the user which one
-they want to monitor and pass that entry's `agentReference` verbatim. When you ask
-the user to choose, present warehouse **names** (via `get_warehouses`), never UUIDs.
+`agentReference`, `traceTableMcon`, and warehouse — ask the user which one they
+want to monitor and pass that entry's `agentReference` verbatim. When you ask the
+user to choose, present each entry's `warehouse_name`, never a UUID.
 
 ---
 
@@ -96,8 +97,8 @@ optional companions:
 ## Warehouse
 
 `warehouse` names the warehouse the agent's trace data lives in — pass it as a name
-or UUID. Use the agent entry's `warehouse_uuid` from `get_agent_metadata`; when it is
-null, or when you need to resolve a warehouse by display name, use `get_warehouses`.
+or UUID. Use the agent entry's `warehouse_uuid` from `get_agent_metadata` (and its
+`warehouse_name` when talking to the user); when both are null, use `get_warehouses`.
 Whether `warehouse` is required or optional depends on the monitor type — see the
 per-type reference.
 

--- a/skills/monitoring-advisor/references/agent-span-fields.md
+++ b/skills/monitoring-advisor/references/agent-span-fields.md
@@ -12,10 +12,15 @@ so you MUST use these field names when creating monitors.
 Do NOT run `SHOW COLUMNS` or `SELECT *` on the trace table to discover
 field names for monitors — the raw table has different columns (e.g.,
 `VALUE`, `FILENAME`, `INGEST_TS`, `DATE_PART`) that are NOT the fields
-monitors use. Instead, use the field names listed below. These are also the
-fields the read tools (`get_agent_traces`, `get_agent_segments`,
-`get_agent_trace`) surface, so the names below are exactly what you'll see when
-sampling.
+monitors use. Instead, use the field names listed below.
+
+> **The read tools use different names and units for some fields.** The names below
+> are the **monitor** field names. The tools you sample with do not all match them:
+> `get_agent_traces` returns `duration_seconds` and `count_llm_calls` (the monitor
+> fields are `duration_sec` and `llm_call_count`), and `get_agent_trace` reports
+> `duration` in **milliseconds** (the monitor field `duration_sec` is in seconds).
+> Always use the monitor field names below in monitor payloads — never copy a read
+> tool's column name or unit into a monitor.
 
 ## Span-level fields (default, per-span rows)
 
@@ -70,3 +75,19 @@ agents only):
 | `start_time` | TIMESTAMP | Earliest span start in the trace |
 | `end_time` | TIMESTAMP | Latest span end in the trace |
 | `ingest_ts` | TIMESTAMP | Ingestion timestamp |
+
+## Conversation-aggregation fields (is_agent_conversation_aggregation=True)
+
+Agent evaluation monitors can aggregate per conversation
+(`is_agent_conversation_aggregation=True`, OpenTelemetry agents only). At this grain,
+`alert_conditions.fields` may reference these raw conversation columns alongside any
+judge output field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `turn_count` | INTEGER | Number of turns in the conversation |
+| `duration_seconds` | FLOAT | Total conversation duration in seconds |
+| `status` | STRING | Conversation status |
+
+Plus the conversation-grain judge output fields (e.g. `relevance_score`,
+`task_completion_score`) — see `agent-evaluation-monitor.md`.

--- a/skills/monitoring-advisor/references/agent-span-fields.md
+++ b/skills/monitoring-advisor/references/agent-span-fields.md
@@ -12,7 +12,10 @@ so you MUST use these field names when creating monitors.
 Do NOT run `SHOW COLUMNS` or `SELECT *` on the trace table to discover
 field names for monitors — the raw table has different columns (e.g.,
 `VALUE`, `FILENAME`, `INGEST_TS`, `DATE_PART`) that are NOT the fields
-monitors use. Instead, use the field names listed below.
+monitors use. Instead, use the field names listed below. These are also the
+fields the read tools (`get_agent_traces`, `get_agent_segments`,
+`get_agent_trace`) surface, so the names below are exactly what you'll see when
+sampling.
 
 ## Span-level fields (default, per-span rows)
 
@@ -21,22 +24,38 @@ monitors use. Instead, use the field names listed below.
 | `agent` | STRING | Agent name |
 | `trace_id` | STRING | Trace identifier |
 | `span_id` | STRING | Span identifier |
+| `parent_span_id` | STRING | Parent span identifier |
 | `workflow` | STRING | Workflow name |
 | `task` | STRING | Task name |
 | `span_name` | STRING | Span operation name |
-| `prompts` | ARRAY | LLM prompt messages |
-| `completions` | ARRAY | LLM completion messages |
+| `model_name` | STRING | Model used |
+| `prompts` | ARRAY | LLM prompt messages (evaluation transforms) |
+| `completions` | ARRAY | LLM completion messages (evaluation transforms) |
 | `total_tokens` | INTEGER | Total token count (prompt + completion) |
 | `prompt_tokens` | INTEGER | Input/prompt token count |
 | `completion_tokens` | INTEGER | Output/completion token count |
+| `duration_sec` | FLOAT | Span duration in seconds |
+| `status_code` | INTEGER | Span status code (`2` = error) — numeric; compare with `"2"`, not `"ERROR"` |
+| `is_tool_call` | BOOLEAN | Whether the span is a tool call |
+| `is_llm_call` | BOOLEAN | Whether the span is an LLM call *(OTel/ClickHouse only)* |
+| `has_prompts` | BOOLEAN | Whether the span has prompt messages *(OTel/ClickHouse only)* |
+| `has_completions` | BOOLEAN | Whether the span has completion messages *(OTel/ClickHouse only)* |
 | `start_time` | TIMESTAMP | Span start timestamp |
 | `end_time` | TIMESTAMP | Span end timestamp |
-| `duration_sec` | FLOAT | Span duration in seconds |
 | `ingest_ts` | TIMESTAMP | Ingestion timestamp (use for time filters) |
+
+### Platform vs OpenTelemetry availability
+
+Platform (Snowflake Cortex / Databricks native) agents expose the core numeric and
+text fields — `duration_sec`, `total_tokens`, `prompt_tokens`, `completion_tokens`,
+`status_code`, `is_tool_call` — but **not** `is_llm_call`, `has_prompts`, or
+`has_completions`. Those presence/kind flags exist only for OTel/ClickHouse agents.
+Stick to the core fields unless you know the agent is OTel-instrumented.
 
 ## Trace-aggregation fields (is_agent_trace_aggregation=True)
 
-When `is_agent_trace_aggregation=True`, rows are aggregated per trace:
+When `is_agent_trace_aggregation=True`, rows are aggregated per trace (OpenTelemetry
+agents only):
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -47,7 +66,7 @@ When `is_agent_trace_aggregation=True`, rows are aggregated per trace:
 | `prompt_tokens` | INTEGER | Total prompt tokens across the trace |
 | `completion_tokens` | INTEGER | Total completion tokens across the trace |
 | `total_tokens` | INTEGER | Total tokens across the trace |
+| `duration_sec` | FLOAT | Total trace duration in seconds |
 | `start_time` | TIMESTAMP | Earliest span start in the trace |
 | `end_time` | TIMESTAMP | Latest span end in the trace |
-| `duration_sec` | FLOAT | Total trace duration in seconds |
 | `ingest_ts` | TIMESTAMP | Ingestion timestamp |

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -2,41 +2,54 @@
 
 ## When to use
 
-Alert on specific execution patterns or span sequences. Best for:
+Flag a whole trace by its execution pattern. Best for:
 
-- **Detecting excessive tool calls** — e.g., "search called more than 5 times"
-- **Alerting on missing steps** — expected span didn't occur
-- **Monitoring span relationships** — span A always followed by span B
-- **Catching runaway loops** — unexpected execution paths
+- **Detecting excessive tool/step calls** — e.g. "search called more than 5 times"
+- **Detecting too-few calls** — e.g. "the retry step ran fewer than 2 times"
+- **Catching runaway loops**
+- **Broken execution order or a missing follow-up** — e.g. "generation runs before
+  retrieval", "planning runs without validation"
+
+Do NOT use it to assert a rule on a single span's field values (token ceilings,
+non-null) — that's `create_or_update_agent_validation_monitor`. Do NOT use it to
+trend a numeric metric (mean latency, token counts) — that's
+`create_or_update_agent_metric_monitor`.
 
 ## Constraints
 
-> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
-> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
-> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
-> pass an MCON as `agent`.
+> **CRITICAL:** The monitor's source is the `agent` reference. Pass the
+> `agentReference` value from `get_agent_metadata` verbatim — a platform
+> `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
+> truncate, or reconstruct it, and never pass an MCON.
 
-> **CRITICAL:** Trajectory `agent_span_filters`: only the `agent` field is allowed.
-> Setting `workflow`, `task`, or `spanName` in `agent_span_filters` will cause a
-> "workflow should not be set" validation error. Use `spanField` in the
-> `agent_span_alert_condition` for workflow/task/spanName filtering instead.
+> **CRITICAL:** Conditions are OR-combined — a trace is flagged if ANY condition
+> matches. `operator` defaults to `OR`; **`operator: "AND"` is rejected.** To require
+> several patterns to all hold, use separate monitors.
 
-> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
-> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
+> **CRITICAL:** Trajectory `agent_span_filters` allow only the `agent` field — at
+> most one filter. Setting `workflow`, `task`, or `spanName` there causes a
+> validation error. Those go in the condition's `spanField` instead.
 
-> **IMPORTANT:** Always use `ingest_ts` as the `timeField`. The time filter must be
-> `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": <hours>}`. Using any other
-> time field will fail. `time_filter` is REQUIRED.
+> **CRITICAL:** A span that never appears produces no rows to count, so "occurs 0
+> times" (a missing span) cannot be expressed with SPAN_OCCURRENCE — `EXACTLY 0` and
+> `LESS_THAN 1` are rejected. Use a SPAN_RELATION with a negated predicate to check a
+> span is absent relative to another span (see the missing-step example).
+
+> **IMPORTANT:** `time_filter` is REQUIRED; `timeField` is always
+> `{"field": "ingest_ts"}`.
+
+> **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
+> `interval_minutes` defaults to `60` and must be at least 5 (sub-hourly allowed).
+
+> **IMPORTANT:** `warehouse` is OPTIONAL here — trajectory monitors fall back to the
+> account default. Pass it (name or UUID) when the agent reference doesn't pin the
+> warehouse; resolve via `get_warehouses`.
 
 ## Key characteristics
 
-- Uses `agent_span_alert_condition` (not `alert_conditions`) — span-specific predicates
+- Uses `agent_span_alert_condition` (not `alert_conditions`) — `{"operator": "OR", "conditions": [...]}`
+- Two condition types: `SPAN_OCCURRENCE` (count) and `SPAN_RELATION` (relate two spans)
 - Requires `time_filter` with `timeField` (object `{"field": "ingest_ts"}`) and `lookbackInHrs`
-- Returns a `CustomRule` with YAML preview
-- **`agent_span_filters` constraint:** Trajectory monitors can ONLY use the `agent` field in
-  `agent_span_filters`. Setting `workflow`, `task`, or `spanName` in `agent_span_filters` will
-  cause a validation error. Workflow/task/spanName filtering is done via the
-  `spanField` in the `agent_span_alert_condition`, NOT via `agent_span_filters`.
 
 ## Parameters
 
@@ -44,62 +57,109 @@ Alert on specific execution patterns or span sequences. Best for:
 |-----------|------|----------|-------------|
 | `description` | string | Yes | Human-readable monitor description (shown as display name) |
 | `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
-| `agent_span_alert_condition` | object | Yes | Span occurrence conditions (see below) |
+| `agent_span_alert_condition` | object | Yes | The span pattern that flags a trace (see below) |
 | `time_filter` | object | Yes | `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24}` |
-| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `warehouse` | string | No | Warehouse name or UUID; defaults to the account default |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
-| `agent_span_filters` | array | No | Optional — **only the `agent` field allowed** (no `workflow`, `task`, or `spanName`) |
-| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
-| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `agent_span_filters` | array | No | Optional — **only the `agent` field allowed** (no `workflow`/`task`/`spanName`); at most one |
+| `schedule_type` | string | No | `fixed` (default) or `manual` |
+| `interval_minutes` | int | No | Default `60`; at least 5 |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
-## agent_span_alert_condition format
+## agent_span_alert_condition structure
+
+`{"operator": "OR", "conditions": [...]}`. Supply at least one condition. Each is one
+of two types.
+
+### SPAN_OCCURRENCE — count how many times a span occurs
 
 ```json
 {
-    "operator": "AND",
-    "conditions": [
-        {
-            "type": "SPAN_OCCURRENCE",
-            "predicate": {"name": "occurs"},
-            "spanField": {
-                "spanName": {"literal": "ChatBedrockConverse.chat"},
-                "task": {"literal": "call_model"},
-                "workflow": {"literal": "Chat Agent"},
-                "type": "SPAN_FIELD"
-            },
-            "count": 5,
-            "comparisonOperator": "MORE_THAN"
-        }
-    ]
+  "type": "SPAN_OCCURRENCE",
+  "predicate": {"name": "occurs"},
+  "spanField": {
+    "spanName": {"literal": "ChatBedrockConverse.chat"},
+    "task": {"literal": "call_model"},
+    "workflow": {"literal": "Chat Agent"},
+    "type": "SPAN_FIELD"
+  },
+  "count": 5,
+  "comparisonOperator": "MORE_THAN"
 }
 ```
 
-### Field reference
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | `"SPAN_OCCURRENCE"`. |
+| `predicate` | Yes | Always `{"name": "occurs"}`. `occurs` **cannot** be negated. |
+| `spanField` | Yes | The span to count (see spanField below). |
+| `comparisonOperator` | Yes | `"MORE_THAN"`, `"LESS_THAN"`, or `"EXACTLY"`. |
+| `count` | Yes | Occurrences to compare against. `EXACTLY` requires count ≥ 1; `LESS_THAN` requires count ≥ 2; `MORE_THAN` requires count ≥ 0. |
 
-- `type`: Always `SPAN_OCCURRENCE`
-- `predicate.name`: `occurs` or `occurs_with`
-- `comparisonOperator`: `MORE_THAN`, `LESS_THAN`, `EXACTLY`
-- `spanField.type`: Always `SPAN_FIELD`
-- `spanField.spanName`, `spanField.task`, `spanField.workflow`: Each is `{"literal": "value"}`
+Use `LESS_THAN 2` for "occurred exactly once when it should occur more". Occurrences
+are counted per `(trace, parent span, span name)` group — pin the `task`/`workflow`
+in `spanField` to the step you mean.
 
-**IMPORTANT:** When `spanName` is set in `spanField`, `task` and `workflow` MUST also be set.
+### SPAN_RELATION — relate two spans in a trace
+
+```json
+{
+  "type": "SPAN_RELATION",
+  "predicate": {"name": "occurs_before"},
+  "spanField": {
+    "spanName": {"literal": "generate"},
+    "task": {"literal": "generate_answer"},
+    "workflow": {"literal": "RAG Agent"},
+    "type": "SPAN_FIELD"
+  },
+  "relatedSpanFields": [
+    {
+      "spanName": {"literal": "retrieve"},
+      "task": {"literal": "generate_answer"},
+      "workflow": {"literal": "RAG Agent"},
+      "type": "SPAN_FIELD"
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | `"SPAN_RELATION"`. |
+| `predicate` | Yes | `{"name": "occurs_with" \| "occurs_before" \| "occurs_after"}`. Add `"negated": true` for the inverse (e.g. `occurs_with` + negated = "occurs without"). |
+| `spanField` | Yes | The primary span (see spanField below). |
+| `relatedSpanFields` | Yes | One or more related spans. Each must share the same coarser `workflow` / `task` as `spanField` — a span-name comparison needs matching `task` and `workflow`; a task-level comparison needs matching `workflow`. |
+
+### spanField structure
+
+Identifies a span by workflow / task / span name. Fill in from coarse to fine.
+
+| Field | Required | Format |
+|-------|----------|--------|
+| `type` | No (defaults `"SPAN_FIELD"`) | `"SPAN_FIELD"` |
+| `workflow` | **Yes — always** | `{"literal": "workflow name"}` |
+| `task` | Yes when `spanName` is set | `{"literal": "task name"}` — requires `workflow` |
+| `spanName` | No | `{"literal": "span operation name"}` — requires `task` AND `workflow` |
+
+**`workflow` is the minimum.** If you set `spanName`, you MUST also set `task` and
+`workflow`. If you set `task`, you MUST also set `workflow`. All values use the
+`{"literal": "..."}` format. Discover the real names with `get_agent_segments` and
+`get_agent_trace`.
 
 ## Examples
 
-The `agent` value below comes from `get_agent_metadata`'s `agentReference` field — a
-platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Use whichever
-form `get_agent_metadata` returns for your agent.
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field —
+a platform `{database}:{schema}.{name}` reference or an OTel `service_name`.
 
-### Alert on excessive LLM calls (platform agent reference)
+### Alert when a specific span occurs more than 5 times
 
 ```
 create_or_update_agent_trajectory_monitor(
-    description="Alert on excessive LLM calls",
+    description="Alert when ChatBedrockConverse.chat exceeds 5 calls in a trace",
     agent="analytics:agents.support_bot",
     agent_span_alert_condition={
-        "operator": "AND",
+        "operator": "OR",
         "conditions": [
             {
                 "type": "SPAN_OCCURRENCE",
@@ -116,40 +176,118 @@ create_or_update_agent_trajectory_monitor(
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
-    ],
     dry_run=True
 )
 ```
 
-### Alert on missing expected step (OTel service_name)
+### Alert when a required step is missing (negated SPAN_RELATION)
+
+"occurs 0 times" can't be expressed with SPAN_OCCURRENCE. To catch a missing step,
+relate it to a step that always runs and negate the co-occurrence: alert when
+`generate` occurs **without** the `validate_output` step that should follow it.
 
 ```
 create_or_update_agent_trajectory_monitor(
-    description="Alert when validation step is missing",
+    description="Alert when generation runs without a validation step",
     agent="checkout-agent",
     agent_span_alert_condition={
-        "operator": "AND",
+        "operator": "OR",
+        "conditions": [
+            {
+                "type": "SPAN_RELATION",
+                "predicate": {"name": "occurs_with", "negated": true},
+                "spanField": {
+                    "spanName": {"literal": "generate"},
+                    "task": {"literal": "generate_answer"},
+                    "workflow": {"literal": "Chat Agent"},
+                    "type": "SPAN_FIELD"
+                },
+                "relatedSpanFields": [
+                    {
+                        "spanName": {"literal": "validate_output"},
+                        "task": {"literal": "generate_answer"},
+                        "workflow": {"literal": "Chat Agent"},
+                        "type": "SPAN_FIELD"
+                    }
+                ]
+            }
+        ]
+    },
+    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
+    dry_run=True
+)
+```
+
+### Alert when a step runs fewer than 2 times
+
+```
+create_or_update_agent_trajectory_monitor(
+    description="Alert when the safety_check step runs fewer than 2 times",
+    agent="analytics:agents.support_bot",
+    agent_span_alert_condition={
+        "operator": "OR",
         "conditions": [
             {
                 "type": "SPAN_OCCURRENCE",
                 "predicate": {"name": "occurs"},
                 "spanField": {
-                    "spanName": {"literal": "validate_output"},
-                    "task": {"literal": "post_process"},
+                    "spanName": {"literal": "safety_check"},
+                    "task": {"literal": "validate_output"},
                     "workflow": {"literal": "Chat Agent"},
                     "type": "SPAN_FIELD"
                 },
-                "count": 0,
-                "comparisonOperator": "EXACTLY"
+                "count": 2,
+                "comparisonOperator": "LESS_THAN"
             }
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}}
-    ],
+    dry_run=True
+)
+```
+
+### Combined conditions (OR): too many searches OR a broken order
+
+```
+create_or_update_agent_trajectory_monitor(
+    description="Alert when search exceeds 10 calls OR generate runs before retrieve",
+    agent="checkout-agent",
+    agent_span_alert_condition={
+        "operator": "OR",
+        "conditions": [
+            {
+                "type": "SPAN_OCCURRENCE",
+                "predicate": {"name": "occurs"},
+                "spanField": {
+                    "spanName": {"literal": "search_tool"},
+                    "task": {"literal": "execute_search"},
+                    "workflow": {"literal": "RAG Agent"},
+                    "type": "SPAN_FIELD"
+                },
+                "count": 10,
+                "comparisonOperator": "MORE_THAN"
+            },
+            {
+                "type": "SPAN_RELATION",
+                "predicate": {"name": "occurs_before"},
+                "spanField": {
+                    "spanName": {"literal": "generate"},
+                    "task": {"literal": "generate_answer"},
+                    "workflow": {"literal": "RAG Agent"},
+                    "type": "SPAN_FIELD"
+                },
+                "relatedSpanFields": [
+                    {
+                        "spanName": {"literal": "retrieve"},
+                        "task": {"literal": "generate_answer"},
+                        "workflow": {"literal": "RAG Agent"},
+                        "type": "SPAN_FIELD"
+                    }
+                ]
+            }
+        ]
+    },
+    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
     dry_run=True
 )
 ```
@@ -158,5 +296,8 @@ create_or_update_agent_trajectory_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
-| "workflow should not be set" in agentSpanFilters | Trajectory monitors only allow the `agent` field in `agent_span_filters` | Remove `workflow`, `task`, and `spanName` from `agent_span_filters`; use `spanField` in the `agent_span_alert_condition` instead |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
+| "workflow should not be set" in agentSpanFilters | Trajectory monitors only allow the `agent` field in `agent_span_filters` | Remove `workflow`/`task`/`spanName`; put them in the condition's `spanField` |
+| `AND` operator rejected | `agent_span_alert_condition.operator` set to `"AND"` | Use `"OR"` (or omit it); split an all-must-hold rule into separate monitors |
+| `EXACTLY 0` / `LESS_THAN 1` rejected | Tried to express "occurs 0 times" | Use a negated SPAN_RELATION for a missing span, or `LESS_THAN 2` for "occurred only once" |
+| spanField rejected | Set `spanName` without `task`+`workflow`, or `task` without `workflow` | Fill coarse-to-fine: `workflow` always; `task` needs `workflow`; `spanName` needs `task`+`workflow` |

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -43,9 +43,9 @@ trend a numeric metric (mean latency, token counts) — that's
 > **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
 > `interval_minutes` defaults to `60` and must be at least 5 (sub-hourly allowed).
 
-> **IMPORTANT:** `warehouse` is OPTIONAL here — trajectory monitors fall back to the
-> account default. Pass it (name or UUID) when the agent reference doesn't pin the
-> warehouse; resolve via `get_warehouses`.
+> **IMPORTANT:** `warehouse` is OPTIONAL here — when omitted, the backend falls back
+> to the account's default warehouse, which may not be where the agent's traces live.
+> Prefer passing the agent's `warehouse_uuid` from `get_agent_metadata` explicitly.
 
 ## Key characteristics
 

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -27,8 +27,10 @@ trend a numeric metric (mean latency, token counts) — that's
 > several patterns to all hold, use separate monitors.
 
 > **CRITICAL:** Trajectory `agent_span_filters` allow only the `agent` field — at
-> most one filter. Setting `workflow`, `task`, or `spanName` there causes a
-> validation error. Those go in the condition's `spanField` instead.
+> most one filter, e.g. `agent_span_filters=[{"agent": {"value": "My Agent"}}]`.
+> Setting `workflow`, `task`, or `spanName` there causes a validation error — those go
+> in the condition's `spanField` instead. For OpenTelemetry agents the filter's
+> `agent` value must equal the top-level `agent` reference.
 
 > **CRITICAL:** A span that never appears produces no rows to count, so "occurs 0
 > times" (a missing span) cannot be expressed with SPAN_OCCURRENCE — `EXACTLY 0` and
@@ -70,7 +72,8 @@ trend a numeric metric (mean latency, token counts) — that's
 ## agent_span_alert_condition structure
 
 `{"operator": "OR", "conditions": [...]}`. Supply at least one condition. Each is one
-of two types.
+of two types. To OR several patterns together, list them as multiple entries in
+`conditions` — a trace is flagged if any one matches.
 
 ### SPAN_OCCURRENCE — count how many times a span occurs
 
@@ -238,52 +241,6 @@ create_or_update_agent_trajectory_monitor(
                 },
                 "count": 2,
                 "comparisonOperator": "LESS_THAN"
-            }
-        ]
-    },
-    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    dry_run=True
-)
-```
-
-### Combined conditions (OR): too many searches OR a broken order
-
-```
-create_or_update_agent_trajectory_monitor(
-    description="Alert when search exceeds 10 calls OR generate runs before retrieve",
-    agent="checkout-agent",
-    agent_span_alert_condition={
-        "operator": "OR",
-        "conditions": [
-            {
-                "type": "SPAN_OCCURRENCE",
-                "predicate": {"name": "occurs"},
-                "spanField": {
-                    "spanName": {"literal": "search_tool"},
-                    "task": {"literal": "execute_search"},
-                    "workflow": {"literal": "RAG Agent"},
-                    "type": "SPAN_FIELD"
-                },
-                "count": 10,
-                "comparisonOperator": "MORE_THAN"
-            },
-            {
-                "type": "SPAN_RELATION",
-                "predicate": {"name": "occurs_before"},
-                "spanField": {
-                    "spanName": {"literal": "generate"},
-                    "task": {"literal": "generate_answer"},
-                    "workflow": {"literal": "RAG Agent"},
-                    "type": "SPAN_FIELD"
-                },
-                "relatedSpanFields": [
-                    {
-                        "spanName": {"literal": "retrieve"},
-                        "task": {"literal": "generate_answer"},
-                        "workflow": {"literal": "RAG Agent"},
-                        "type": "SPAN_FIELD"
-                    }
-                ]
             }
         ]
     },

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -2,36 +2,46 @@
 
 ## When to use
 
-Assert logical conditions on aggregated agent span data. Best for:
+Assert a logical condition on agent span data and alert on violations. Best for:
 
-- **Business rule assertions** — "total_tokens must be below threshold"
-- **Data quality checks on span attributes** — verify expected field values
-- **Compliance checks** — e.g., "PII detection must run on every trace"
-- **Custom predicate validations** on agent behavior
+- **Business rule assertions** — "total_tokens must be below 10000"
+- **Data quality checks on span attributes** — "completions must never be null"
+- **Compliance checks** — "PII detection must run on every trace"
+
+Do NOT use it to trend a numeric metric (use `create_or_update_agent_metric_monitor`)
+or to alert on span sequences / call counts (use
+`create_or_update_agent_trajectory_monitor`).
 
 ## Constraints
 
-> **CRITICAL:** The monitor's source is authored via the `agent` reference, NOT a
-> `dw_id` + `data_source`/MCON. Pass the `agentReference` value from `get_agent_metadata`
-> — a platform `{database}:{schema}.{name}` reference or an OTel `service_name`. Do NOT
-> pass an MCON as `agent`.
+> **CRITICAL:** The monitor's source is the `agent` reference. Pass the
+> `agentReference` value from `get_agent_metadata` verbatim — a platform
+> `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
+> truncate, or reconstruct it, and never pass an MCON.
 
-> **IMPORTANT:** `schedule_type` defaults to `fixed` (lowercase) and `interval_minutes`
-> defaults to `60`. Valid `schedule_type` values: `fixed`, `dynamic`, `manual`.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) the
+> agent's traces live in; resolve via `get_warehouses`.
 
-> **IMPORTANT:** Always use `ingest_ts` as the `timeField`. The time filter must be
-> `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": <hours>}`. Using any other
-> time field will fail. `time_filter` is REQUIRED.
+> **CRITICAL:** `alert_condition` matches the rows to ALERT on. A `null` predicate
+> alerts on spans where the field IS null. Express negation with the `negated` flag —
+> there is NO `not_equal` and NO `not_null` predicate.
 
-> **IMPORTANT:** `agent_span_filters` is an optional refinement; when used, include at
-> least the `agent` field.
+> **IMPORTANT:** BINARY conditions use `left`/`right`; UNARY conditions use `value`
+> (NOT `left`). Getting this wrong is the most common failure.
+
+> **IMPORTANT:** `time_filter` is REQUIRED and `timeField` is always
+> `{"field": "ingest_ts"}`. `time_filter` is `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": <hours>}`.
+
+> **IMPORTANT:** `schedule_type` is `fixed` (default) or `manual` — never dynamic.
+> `interval_minutes` defaults to `60` and must be at least 5 (sub-hourly is allowed;
+> no 60-minute alignment).
 
 ## Key characteristics
 
-- Uses `alert_condition` as a `FilterGroup` with `left`/`right` typed values
-- Requires `time_filter`
-- Optional `is_agent_trace_aggregation` for trace-level assertions
-- Returns a `CustomRule`
+- Uses `alert_condition` as a `FilterGroup` — an `operator` (`AND`/`OR`) plus a
+  `conditions` array of `BINARY` / `UNARY` / `SQL` / `GROUP` entries
+- Requires `time_filter` (time field is always `ingest_ts`)
+- Optional `is_agent_trace_aggregation` for trace-level assertions (OTel agents only)
 
 ## Parameters
 
@@ -39,85 +49,209 @@ Assert logical conditions on aggregated agent span data. Best for:
 |-----------|------|----------|-------------|
 | `description` | string | Yes | Human-readable monitor description (shown as display name) |
 | `agent` | string | Yes | Agent reference — `agentReference` from `get_agent_metadata` (`{db}:{schema}.{name}` or OTel `service_name`) |
-| `alert_condition` | object | Yes | FilterGroup with conditions (see below) |
+| `alert_condition` | object | Yes | FilterGroup — the condition that marks INVALID rows (see below) |
 | `time_filter` | object | Yes | `{"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24}` |
-| `warehouse` | string | No | Warehouse name or UUID — only when the agent reference doesn't pin it down |
+| `warehouse` | string | Yes | Warehouse name or UUID where the agent's traces live |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
-| `agent_span_filters` | array | No | Optional span-scope refinement (`agent`, `workflow`, `task`, `spanName`) |
-| `is_agent_trace_aggregation` | boolean | No | Aggregate per trace for trace-level assertions |
-| `schedule_type` | string | No | Defaults to `fixed`. `fixed`/`dynamic`/`manual` |
-| `interval_minutes` | int | No | Defaults to `60` for `fixed` |
+| `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object |
+| `is_agent_trace_aggregation` | boolean | No | Aggregate per trace for trace-level assertions (OTel only) |
+| `schedule_type` | string | No | `fixed` (default) or `manual` |
+| `interval_minutes` | int | No | Default `60`; at least 5 |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
-## alert_condition format
+## alert_condition structure (FilterGroup)
+
+The top level is a group: an `operator` (`AND`/`OR`) and a `conditions` array. Each
+condition is one of `BINARY`, `UNARY`, `SQL`, or `GROUP`.
+
+### BINARY (compare two values)
 
 ```json
 {
-    "operator": "AND",
-    "conditions": [
-        {
-            "type": "BINARY",
-            "predicate": {"name": "greater_than"},
-            "left": [{"field": "total_tokens", "type": "FIELD"}],
-            "right": [{"literal": "1000", "type": "LITERAL"}]
-        }
-    ]
+  "type": "BINARY",
+  "predicate": {"name": "greater_than"},
+  "left": [{"type": "FIELD", "field": "total_tokens"}],
+  "right": [{"type": "LITERAL", "literal": "10000"}]
 }
 ```
 
-### Field reference
+- `left`: exactly one `FIELD` value (the column being validated).
+- `right`: exactly one value — usually a `LITERAL` (a string, even for numbers). The
+  `in_set` predicate is the exception: it takes several `LITERAL`s in `right`.
 
-- `type`: `SQL`, `BINARY`, `UNARY`, `GROUP`
-- `predicate.name`: `equal`, `not_equal`, `greater_than`, `less_than`, `greater_than_or_equal`, `less_than_or_equal`, `null`, `not_null`
-- `left`/`right` entries: `{"field": "<name>", "type": "FIELD"}` or `{"literal": "<value>", "type": "LITERAL"}`
-- `operator` (for group-level): `AND`, `OR`
+### UNARY (single-value check)
+
+```json
+{
+  "type": "UNARY",
+  "predicate": {"name": "null"},
+  "value": [{"type": "FIELD", "field": "completions"}]
+}
+```
+
+- The field list is named **`value`** (NOT `left`), and holds exactly one `FIELD`.
+- The example above matches spans where `completions` **is null**. To alert on
+  non-null instead, add `"negated": true` (→ IS NOT NULL).
+
+### SQL (custom boolean expression)
+
+```json
+{"type": "SQL", "sql": "total_tokens > 1000 AND duration_sec < 60"}
+```
+
+Use only when the condition can't be expressed with a predicate.
+
+### GROUP (nested conditions)
+
+```json
+{
+  "type": "GROUP",
+  "operator": "OR",
+  "conditions": [
+    {"type": "BINARY", "...": "..."},
+    {"type": "UNARY", "...": "..."}
+  ]
+}
+```
+
+### Predicates
+
+Predicate names are matched by exact name — call `get_validation_predicates` to list
+the full set. Key rules:
+
+- **Express negation with the `negated` flag** — e.g. `{"name": "equal", "negated": true}`
+  or `{"name": "null", "negated": true}`. Do NOT prefix names with `not_`. There is
+  **no `not_equal` and no `not_null` predicate**.
+- **BINARY predicates** include `equal`, `in_set`, `greater_than`,
+  `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `contains`,
+  `starts_with`, `ends_with`, `matches_regex`. The four comparators (`greater_than` /
+  `less_than` / `*_or_equal`) cannot be negated — use the inverse comparator instead.
+- **UNARY predicates** include `null`, `empty_string`, `is_zero`, `is_negative`,
+  `is_nan`, `is_between_0_and_1`, `is_between_0_and_100`, `is_uuid`, plus many locale /
+  PII / timestamp checks. Fetch the full list with `get_validation_predicates`.
+
+### Value types
+
+| Type | Format |
+|------|--------|
+| `FIELD` | `{"type": "FIELD", "field": "column_name"}` — references a span field |
+| `LITERAL` | `{"type": "LITERAL", "literal": "value_string"}` — a static value, always a string even for numbers |
+| `SQL` | `{"type": "SQL", "sql": "..."}` — a SQL expression (used inside a BINARY `right`) |
+
+Condition/value/operator keywords are uppercase: `BINARY`, `UNARY`, `SQL`, `GROUP`;
+`FIELD`, `LITERAL`; `AND`, `OR`.
+
+## Field notes
+
+Use the span field names from `agent-span-fields.md` in `FIELD` values — not raw
+table columns. Note in particular:
+
+- `status_code` is **numeric** — the OTel span status code (`2` = error). Compare
+  with a numeric literal (e.g. `equal` / `"2"`), not `"ERROR"`.
+- The time field is always `ingest_ts`.
+
+## Trace aggregation
+
+`is_agent_trace_aggregation=True` is **OpenTelemetry-only.** For a platform agent
+(`{database}:{schema}.{name}`) the flag is silently ignored and the monitor runs at
+span grain, so target an OTel `service_name` (or pass `trace_table`). At trace grain,
+use trace-level fields (`span_count`, `llm_call_count`, `total_tokens`, …) and filter
+only by `agent`.
 
 ## Examples
 
-The `agent` value below comes from `get_agent_metadata`'s `agentReference` field. The
-first example uses a platform `{database}:{schema}.{name}` reference; the others use an
-OTel `service_name`. Use whichever form `get_agent_metadata` returns for your agent.
+The `agent` value below comes from `get_agent_metadata`'s `agentReference` field —
+a platform `{database}:{schema}.{name}` reference or an OTel `service_name`.
 
-### Assert token usage below threshold (platform agent reference)
+### Assert total_tokens stays below a threshold (platform agent reference)
 
 ```
 create_or_update_agent_validation_monitor(
-    description="Assert token usage below threshold",
+    description="Alert when total_tokens exceeds 10000",
     agent="analytics:agents.support_bot",
+    warehouse="Analytics WH",
     alert_condition={
         "operator": "AND",
         "conditions": [
             {
                 "type": "BINARY",
                 "predicate": {"name": "greater_than"},
-                "left": [{"field": "total_tokens", "type": "FIELD"}],
-                "right": [{"literal": "10000", "type": "LITERAL"}]
+                "left": [{"type": "FIELD", "field": "total_tokens"}],
+                "right": [{"type": "LITERAL", "literal": "10000"}]
             }
         ]
     },
     time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
-    ],
     dry_run=True
 )
 ```
 
-### Assert latency stays reasonable (trace-level, OTel service_name)
+### Alert when a required field is null (UNARY uses `value`)
+
+Business rule "completions must always be populated" → alert on the violating rows,
+i.e. spans where `completions` **is null**, so the condition is a plain `null`
+predicate.
 
 ```
 create_or_update_agent_validation_monitor(
-    description="Assert trace duration under 120 seconds",
-    agent="checkout-agent",
+    description="Alert when the completions field is null",
+    agent="analytics:agents.support_bot",
+    warehouse="Analytics WH",
+    alert_condition={
+        "operator": "AND",
+        "conditions": [
+            {
+                "type": "UNARY",
+                "predicate": {"name": "null"},
+                "value": [{"type": "FIELD", "field": "completions"}]
+            }
+        ]
+    },
+    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
+    dry_run=True
+)
+```
+
+### Span-level assertion scoped to a workflow
+
+```
+create_or_update_agent_validation_monitor(
+    description="Alert when Chat Agent spans exceed 120s",
+    agent="analytics:agents.support_bot",
+    warehouse="Analytics WH",
     alert_condition={
         "operator": "AND",
         "conditions": [
             {
                 "type": "BINARY",
                 "predicate": {"name": "greater_than"},
-                "left": [{"field": "duration_sec", "type": "FIELD"}],
-                "right": [{"literal": "120", "type": "LITERAL"}]
+                "left": [{"type": "FIELD", "field": "duration_sec"}],
+                "right": [{"type": "LITERAL", "literal": "120"}]
+            }
+        ]
+    },
+    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
+    agent_span_filters=[{"workflow": {"value": "Chat Agent"}}],
+    dry_run=True
+)
+```
+
+### Trace-level assertion (OTel agent)
+
+```
+create_or_update_agent_validation_monitor(
+    description="Alert when a trace has more than 50 spans",
+    agent="checkout-agent",
+    warehouse="OTel WH",
+    alert_condition={
+        "operator": "AND",
+        "conditions": [
+            {
+                "type": "BINARY",
+                "predicate": {"name": "greater_than"},
+                "left": [{"type": "FIELD", "field": "span_count"}],
+                "right": [{"type": "LITERAL", "literal": "50"}]
             }
         ]
     },
@@ -127,42 +261,12 @@ create_or_update_agent_validation_monitor(
 )
 ```
 
-### Compound condition — token usage AND latency
-
-```
-create_or_update_agent_validation_monitor(
-    description="Assert token and latency within bounds",
-    agent="checkout-agent",
-    alert_condition={
-        "operator": "OR",
-        "conditions": [
-            {
-                "type": "BINARY",
-                "predicate": {"name": "greater_than"},
-                "left": [{"field": "total_tokens", "type": "FIELD"}],
-                "right": [{"literal": "10000", "type": "LITERAL"}]
-            },
-            {
-                "type": "BINARY",
-                "predicate": {"name": "greater_than"},
-                "left": [{"field": "duration_sec", "type": "FIELD"}],
-                "right": [{"literal": "60", "type": "LITERAL"}]
-            }
-        ]
-    },
-    time_filter={"timeField": {"field": "ingest_ts"}, "lookbackInHrs": 24},
-    agent_span_filters=[
-        {"agent": {"value": "My Agent"}, "workflow": {"value": "Chat Agent"}}
-    ],
-    schedule_type="fixed",
-    interval_minutes=1440,
-    dry_run=True
-)
-```
-
 ## Common errors
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value from `get_agent_metadata` — do not construct it by hand |
-| "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md` for valid field names |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
+| unknown predicate `not_equal` / `not_null` | Used a `not_`-prefixed predicate | Use the base predicate (`equal` / `null`) with `"negated": true` |
+| UNARY condition rejected | Used `left` instead of `value` | UNARY conditions put the field in `value`; only BINARY uses `left`/`right` |
+| "Field X doesn't exist" | Field name not in the PARSED_SPANS schema | Check `agent-span-fields.md`; `status_code` is numeric (compare with `"2"`, not `"ERROR"`) |

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -153,9 +153,9 @@ table columns. Note in particular:
 
 ## Trace aggregation
 
-`is_agent_trace_aggregation=True` is **OpenTelemetry-only.** For a platform agent
-(`{database}:{schema}.{name}`) the flag is silently ignored and the monitor runs at
-span grain, so target an OTel `service_name` (or pass `trace_table`). At trace grain,
+`is_agent_trace_aggregation=True` is **OpenTelemetry-only.** A platform agent reference
+(`{database}:{schema}.{name}`) is rejected — target an OTel `service_name`, or pass an
+explicit `trace_table` to force the agent to be read as OpenTelemetry. At trace grain,
 use trace-level fields (`span_count`, `llm_call_count`, `total_tokens`, …) and filter
 only by `agent`.
 

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -19,8 +19,8 @@ or to alert on span sequences / call counts (use
 > `{database}:{schema}.{name}` reference or an OTel `service_name`. Never modify,
 > truncate, or reconstruct it, and never pass an MCON.
 
-> **CRITICAL:** `warehouse` is REQUIRED. Pass the warehouse (name or UUID) the
-> agent's traces live in; resolve via `get_warehouses`.
+> **CRITICAL:** `warehouse` is REQUIRED. Pass the agent's `warehouse_uuid` from
+> `get_agent_metadata`; use `get_warehouses` when it is null or to resolve by name.
 
 > **CRITICAL:** `alert_condition` matches the rows to ALERT on. A `null` predicate
 > alerts on spans where the field IS null. Express negation with the `negated` flag —
@@ -265,7 +265,7 @@ create_or_update_agent_validation_monitor(
 
 | Error message | Cause | Fix |
 |--------------|-------|-----|
-| Warehouse not found | `warehouse` omitted or wrong | Pass the warehouse (name or UUID) the agent's traces live in; list via `get_warehouses` |
+| Warehouse not found | `warehouse` omitted or wrong | Pass the agent's `warehouse_uuid` from `get_agent_metadata`; if null, list warehouses via `get_warehouses` |
 | invalid / unresolvable `agent` reference | The `agent` value wasn't taken from `get_agent_metadata` | Use the exact `agentReference` value — do not construct it by hand, and never pass an MCON |
 | unknown predicate `not_equal` / `not_null` | Used a `not_`-prefixed predicate | Use the base predicate (`equal` / `null`) with `"negated": true` |
 | UNARY condition rejected | Used `left` instead of `value` | UNARY conditions put the field in `value`; only BINARY uses `left`/`right` |


### PR DESCRIPTION
# Changes

Rewrites the `monitoring-advisor` agent-monitor reference docs to match the current `create_or_update_agent_*_monitor` MCP tool contract. An audit against the tool schemas found the previous docs described a pre-hardening API — nearly every worked example would be rejected by the tools today.

- **`references/agent-monitor-creation.md`** — single `agent` reference (the `agentReference` from `get_agent_metadata`, passed verbatim; never an MCON), `warehouse` required for metric/eval/validation and optional for trajectory, `schedule_type: "fixed"|"manual"` + `interval_minutes` with per-type floors (metric/eval ≥60 & multiple of 60; validation/trajectory ≥5), at most one span-filter object. Removes all `dw_id`/`data_source`/`schedule_config`/`DYNAMIC`/`LOOSE` content.
- **`references/agent-evaluation-monitor.md`** — correct predefined transform functions (`output_length`, `json_validity`, `keywords` — replacing nonexistent `word_count`/`content_safety`), typed `custom_prompt`/`custom_sql` requirements with camelCase wire keys (`outputType`, `sqlExpression`), boolean outputs alert via `TRUE_RATE`/`FALSE_RATE` only, drops the unsupported `classification`/`sentiment` recommendation.
- **`references/agent-metric-monitor.md`** — full agent metric catalog by field type, `NEQ` operator (was `NE`), anomaly/manual/range operator-threshold rules, `ROW_COUNT_CHANGE` table-level constraints, trace-aggregation constraints (OTel-only, agent-only filter, distinct field set).
- **`references/agent-validation-monitor.md`** — FilterGroup contract with BINARY `left`/`right` vs UNARY `value`, negation via the `negated` flag (no `not_equal`/`not_null` predicates), real predicate catalogs, numeric `status_code`, warehouse required.
- **`references/agent-trajectory-monitor.md`** — adds `SPAN_RELATION` (`occurs_with`/`occurs_before`/`occurs_after` + `relatedSpanFields`), OR-only condition combination, count floors (`EXACTLY`/`LESS_THAN` 0–1 rejected; `LESS_THAN` ≥2), `spanField` hierarchy, and replaces the invalid `EXACTLY 0` "missing step" example with a negated `occurs_with` relation.
- **`references/agent-span-fields.md`** — adds `parent_span_id`, `model_name`, `status_code`, `is_tool_call`, `is_llm_call`, `has_prompts`, `has_completions` and the platform-vs-OTel availability caveat.
- **`SKILL.md`** — adds the `get_agent_conversations`/`get_agent_traces`/`get_agent_segments` read tools to the agent monitoring tool table.
- Plugin version bumped to 1.14.0 across all editor plugins (repo convention for `skills/**` changes); plugin skill dirs are symlinks into `skills/`, so all plugins pick the rewrite up automatically.

Every worked example was cross-checked against the typed pydantic schemas (`agent_monitor_inputs.py`, `agent_transforms.py`) and tool signatures in the ai-agent repo.

## Context

Sibling of the ai-agent hardening series (monte-carlo-data/ai-agent#1573, #1575, #1578, #1580), which introduced the typed tool contracts these docs now document.

## Verification

- `.claude/skills/toolkit-skill-author/scripts/lint-skill.py monitoring-advisor skills` — exit 0 (two pre-existing warnings unrelated to this change).
- All six `plugins/*/skills/monitoring-advisor` symlinks verified untouched and resolving to the rewritten files.
- Stale-term sweep over `skills/monitoring-advisor/` (`create_agent_*`, `dw_id`, `schedule_config`, `DYNAMIC`, `not_equal`, `NE`, `word_count`, `content_safety`, `scheduleType`) — no hits outside sentences that explicitly warn against them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
