### PR TITLE
docs: direct-path backend resolution via get_agent_metadata backend_class (AI-635) — v1.15.1

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.0",
+    "version": "1.15.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.0",
+    "version": "1.15.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-20
+
+### Changed
+
+- troubleshoot-agent-traces: the direct (no-alert) path resolves the exact backend from `get_agent_metadata`'s new `backend_class` field instead of asking the user / splitting on `sourceType` (AI-635; a null `backend_class` — older server or unclassifiable agent — still falls back to asking)
+- monitoring-advisor, troubleshoot-agent-traces, instrument-agent: `get_agent_metadata` field docs gain `backend_class`
+
 ## [1.15.0] - 2026-07-19
 
 ### Added

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/instrument-agent/references/verify-traces.md
+++ b/skills/instrument-agent/references/verify-traces.md
@@ -27,8 +27,8 @@ The response shape:
 
 ```json
 [
-  {"agentName": "customer-support", "traceTableMcon": "MCON://...", "sourceType": "TRACE_TABLE"},
-  {"agentName": "monitoring-agent", "traceTableMcon": "MCON://...", "sourceType": "PLATFORM_AGENT"}
+  {"agentName": "customer-support", "traceTableMcon": "MCON://...", "sourceType": "TRACE_TABLE", "backend_class": "customer_otel_trace_table"},
+  {"agentName": "monitoring-agent", "traceTableMcon": "MCON://...", "sourceType": "PLATFORM_AGENT", "backend_class": "platform_agent"}
 ]
 ```
 

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -104,7 +104,7 @@ All five tools follow a **two-call preview-then-confirm pattern**: the first cal
 
 | Tool | Purpose |
 | --- | --- |
-| `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types, and each agent's `warehouse_uuid`/`warehouse_name` (the `warehouse` arg -- show the name, pass the uuid) |
+| `get_agent_metadata` | List AI agents -- returns agent names, `agentReference` values (the `agent` arg for monitor creation), trace table MCONs, source types, backend classes (`backend_class`), and each agent's `warehouse_uuid`/`warehouse_name` (the `warehouse` arg -- show the name, pass the uuid) |
 | `get_agent_conversations` | List recent conversations for an agent (newest first; filter by errors/status/turns/tokens/duration; optional inline transcripts) |
 | `get_agent_conversation` | Retrieve one conversation's full prompt/completion thread by `conversation_id` |
 | `get_agent_traces` | List traces with per-trace workflows, tasks, models, LLM-call counts, tokens, duration, and error counts |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -22,6 +22,7 @@ Key fields in the response:
 | `agentReference` | The value to pass as the `agent` arg when creating monitors — a platform `{database}:{schema}.{name}` reference (Snowflake Cortex / Databricks) or an OpenTelemetry `service_name`. May be null for agents that cannot be referenced. |
 | `traceTableMcon` | Trace table MCON — used as the `trace_table_mcon` input for the read tools (`get_agent_conversations`, `get_agent_conversation`, `get_agent_traces`, `get_agent_segments`; the parameter is named `mcon` on `get_agent_trace`) |
 | `sourceType` | `TRACE_TABLE` (custom) or `PLATFORM_AGENT` (Monte Carlo native) |
+| `backend_class` | Which backend the agent's traces live in — `ao_clickhouse_otel`, `platform_agent`, `customer_otel_trace_table`, `databricks_genie`, `databricks_mlflow_sdk`, or `databricks_mlflow_ka`. Null when the server could not classify the agent (or predates the field). |
 | `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when the warehouse was deleted or cannot be resolved; fall back to `get_warehouses` (see Warehouse below). |
 | `warehouse_name` | Display name of that warehouse — what you show the user. Null alongside `warehouse_uuid`; fall back to `get_warehouses`. |
 

--- a/skills/troubleshoot-agent-traces/README.md
+++ b/skills/troubleshoot-agent-traces/README.md
@@ -21,7 +21,7 @@ Connect to Monte Carlo's MCP server (`integrations.getmontecarlo.com/mcp`). The 
 | `get_alerts` | Fetch alert details; list recent alerts (agent alert categories in `alert_types`) |
 | `get_alert_agent_classification` | Classify one alert: agent or not, alert shape, and the agent's backend class |
 | `alert_assessment` | Optional ~2-min triage of an alert (HIGH/MEDIUM/LOW confidence + impact) |
-| `get_agent_metadata` | List AI agents — names, trace tables, source types, warehouses |
+| `get_agent_metadata` | List AI agents — names, trace tables, backend classes, source types, warehouses |
 | `get_agent_traces` | List traces with workflows, tasks, models, tokens, duration, error counts |
 | `get_agent_trace` | Inspect one execution trace's full span tree |
 | `get_agent_conversations` | List recent conversations for an agent (filterable) |

--- a/skills/troubleshoot-agent-traces/SKILL.md
+++ b/skills/troubleshoot-agent-traces/SKILL.md
@@ -96,7 +96,7 @@ The Step 2 gate uses the `get_alert_agent_classification` tool. If that tool is 
 3. Proceed to Step 1.5.
 
 **If the user brings a trace ID, conversation ID, or a plain problem description with no alert:**
-Read `references/agent-direct-trace.md` and follow its intake flow. In short: identify the agent (`get_agent_metadata`), determine its backend (the reference explains how without an alert), anchor strictly on the supplied trace(s)/conversation(s) — or find candidates via `get_agent_traces` / `get_agent_conversations` — and read the matching backend guide before investigating. There is no incident UUID on this path, so skip Step 1.5 and Step 2's classification; pick up at Step 4's investigation shape. If the intake later identifies a matching agent alert, return to Step 1 with its UUID — Step 1.5 then applies normally.
+Read `references/agent-direct-trace.md` and follow its intake flow. In short: identify the agent (`get_agent_metadata`), determine its backend from that response's `backend_class`, anchor strictly on the supplied trace(s)/conversation(s) — or find candidates via `get_agent_traces` / `get_agent_conversations` — and read the matching backend guide before investigating. There is no incident UUID on this path, so skip Step 1.5 and Step 2's classification; pick up at Step 4's investigation shape. If the intake later identifies a matching agent alert, return to Step 1 with its UUID — Step 1.5 then applies normally.
 
 ### Step 1.5: Auto-invoke TTSA (when applicable)
 

--- a/skills/troubleshoot-agent-traces/SKILL.md
+++ b/skills/troubleshoot-agent-traces/SKILL.md
@@ -68,7 +68,7 @@ The Step 2 gate uses the `get_alert_agent_classification` tool. If that tool is 
 
 | Tool | Purpose |
 |------|---------|
-| `get_agent_metadata` | List AI agents — names, trace tables, source types, warehouses |
+| `get_agent_metadata` | List AI agents — names, trace tables, backend classes, source types, warehouses |
 | `get_agent_traces` | List traces with per-trace workflows, tasks, models, LLM-call counts, tokens, duration, and error counts |
 | `get_agent_trace` | Inspect one execution trace's full span tree |
 | `get_agent_conversations` | List recent conversations for an agent (filter by errors/status/turns/tokens/duration; optional inline transcripts) |

--- a/skills/troubleshoot-agent-traces/references/agent-direct-trace.md
+++ b/skills/troubleshoot-agent-traces/references/agent-direct-trace.md
@@ -20,12 +20,12 @@ this** — and only then investigate the specific traces.
 Call `get_agent_metadata` and match the user's agent by name or reference. If more than
 one agent plausibly matches, **ask the user which one** — do not pick.
 
-> **NEVER** guess the backend from an agent's name. The router's classification tool
-> (`get_alert_agent_classification`) is alert-scoped — it takes an alert UUID, so it
-> cannot be used here. On this path the backend comes from asking the user, or from
-> `get_agent_metadata`'s `sourceType` field — which only splits platform-managed agents
-> from trace-table agents, not the six backend classes. If the split plus the user's
-> answer still leaves it ambiguous, say so rather than assuming.
+> **NEVER** guess the backend from an agent's name. On this path the backend comes from
+> the agent's `backend_class` in the `get_agent_metadata` response — the same server-side
+> classification the alert path gets from `get_alert_agent_classification` (which is
+> alert-scoped and cannot be used here). If `backend_class` is null (an agent the server
+> could not classify, or an older Monte Carlo server), ask the user which backend applies
+> rather than assuming.
 
 ### 2. Search for a matching agent alert
 
@@ -94,7 +94,7 @@ start, and what changed at the onset (prompt, model, config, deploy)?
 | Mistake | Why it fails / what to do instead |
 |---|---|
 | Passing a trace/conversation ID to `run_troubleshooting_agent` | It requires an alert/incident UUID; this path is manual-only |
-| Guessing the backend from the agent's name | Ask the user, or use `sourceType`'s platform/trace-table split — never name heuristics |
+| Guessing the backend from the agent's name | Read `backend_class` from `get_agent_metadata` — never name heuristics |
 | Skipping the `get_alerts` check | A matching alert gives you the resolved breaching set, classification, and automated troubleshooting |
 | Judging a single trace in isolation | Always compare against its cohort before concluding |
 | Running a full root-cause pipeline for a lookup | Match depth to the question |


### PR DESCRIPTION
# Changes

`get_agent_metadata` now returns each agent's server-computed `backend_class` (AO-891 / ai-agent [#1751](https://github.com/monte-carlo-data/ai-agent/pull/1751)), so:

- **troubleshoot-agent-traces, direct (no-alert) path** (`references/agent-direct-trace.md`): the backend-resolution step reads `backend_class` from `get_agent_metadata` instead of asking the user / splitting on the binary `sourceType`. The **NEVER guess the backend from an agent's name** rule stays; the Common-mistakes row's remedy cell now points at `backend_class` (kept, not dropped, so the rule stays visible in the table); a null `backend_class` (older server or unclassifiable agent) still falls back to asking the user. The router `SKILL.md`'s direct-path summary is tightened to match.
- **Field docs**: monitoring-advisor's key-fields table + inline tool row, the troubleshoot-agent-traces tool tables (SKILL.md + README), and instrument-agent's response-shape example gain `backend_class` (six classes or null).
- **v1.15.1** via `bump-version.sh patch` — 6 plugin manifests + 6 CHANGELOGs (skills are symlinked into the plugins, so the canonical `skills/` edits are live in all six).

## Context

- Linear: [AI-635](https://linear.app/montecarloai/issue/AI-635) (part 3 of 3); the toolkit follow-on named in [AO-891](https://linear.app/montecarloai/issue/AO-891)'s acceptance criteria and left open by AI-633 (#104).
- **Merge ordering:** land after ai-agent#1751 deploys, so these docs don't describe a field the tool doesn't return yet. The null-fallback sentence keeps older servers safe regardless.
- Unblocks AI-633's remaining live-verification item on the no-alert path.

## Verification

1. After ai-agent#1751 deploys: on the direct path (`/monte-carlo-troubleshoot-agent-traces` with a trace id, no alert), the skill resolves the exact backend from `backend_class` without asking the user.
2. `grep -rn sourceType skills/troubleshoot-agent-traces/references/agent-direct-trace.md` → no hits; all 6 plugin manifests read 1.15.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)