### PR TITLE
docs(monitoring-advisor): conversation-grain evals for Cortex + Genie; Genie token caveats (AI-636) — v1.15.2

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-07-20
+
+### Changed
+
+- monitoring-advisor: conversation-grain evaluation guidance updated for the AI-636 backend change — Snowflake Cortex and Databricks Genie agents now support `is_agent_conversation_aggregation` (Databricks MLflow agents remain span-only); added Genie no-token/model caveats to the metric guidance and a `backend_class` capability note to agent-monitor-creation
+
 ## [1.15.1] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -52,7 +52,8 @@ transforms, which those don't need.
 - Supports a top-level `transforms` array — the evaluation logic
 - Transform output field names are what `alert_conditions.fields` reference
 - Optional `is_agent_conversation_aggregation=True` aggregates per conversation
-  (see the conversation-grain section — OTel agents only)
+  (see the conversation-grain section — OTel/ClickHouse, Snowflake Cortex, and
+  Databricks Genie agents; Databricks MLflow agents are span-only)
 
 ## Parameters
 
@@ -64,7 +65,7 @@ transforms, which those don't need.
 | `alert_conditions` | array | Yes | Alert conditions using transform output field names |
 | `sampling_config` | object | Yes | `{"percentage": 10.0}`, `{"count": 100}`, or both |
 | `transforms` | array | No | Evaluation transforms (predefined or custom); top-level |
-| `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation (OTel agents only) |
+| `is_agent_conversation_aggregation` | boolean | No | Aggregate evaluation per conversation (OTel/ClickHouse, Cortex, and Genie agents; MLflow agents are span-only) |
 | `trace_table` | string | No | Explicit trace table — only for non-ClickHouse OTel agents |
 | `agent_span_filters` | array | No | Optional span-scope refinement; at most ONE filter object. At conversation grain (`is_agent_conversation_aggregation=True`) only `agent`/`workflow` are allowed — not `task`/`spanName` |
 | `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators (`low`/`medium`/`high`) |
@@ -128,9 +129,9 @@ Each writes an output column named by its `alias`, and that alias is what
 
 Each LLM judge has a `*_conversation` variant that evaluates a whole conversation
 instead of a single span. These require `is_agent_conversation_aggregation: true`
-**AND an OpenTelemetry agent** (platform agents like Snowflake Cortex reject
-conversation aggregation). The output/score column is not always the span judge's
-name:
+**AND a conversation-capable agent** — OpenTelemetry/ClickHouse, Snowflake Cortex,
+or Databricks Genie (Databricks MLflow agents reject conversation aggregation).
+The output/score column is not always the span judge's name:
 
 | Conversation function | Output/score field |
 |-----------------------|--------------------|

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -117,6 +117,10 @@ Common numeric fields: `duration_sec`, `total_tokens`, `prompt_tokens`,
 token totals, `duration_sec` (trace grain). Do NOT use `duration_ms` or raw table
 column names.
 
+**Databricks Genie agents (`backend_class: databricks_genie`) emit no token or
+model data** — token-usage metrics on them are permanently silent. Propose
+latency (`duration_sec`), volume, and error/outcome metrics instead.
+
 ## Trace aggregation
 
 `is_agent_trace_aggregation=True` rolls spans up per trace. Constraints:

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -26,6 +26,14 @@ Key fields in the response:
 | `warehouse_uuid` | Warehouse holding the agent's trace data — the value to pass as the `warehouse` arg when creating monitors. Null when the warehouse was deleted or cannot be resolved; fall back to `get_warehouses` (see Warehouse below). |
 | `warehouse_name` | Display name of that warehouse — what you show the user. Null alongside `warehouse_uuid`; fall back to `get_warehouses`. |
 
+**What `backend_class` tells you about capabilities:** conversation-grain
+evaluation monitors (`is_agent_conversation_aggregation=True`) are supported for
+`ao_clickhouse_otel`, `platform_agent` (Snowflake Cortex), and `databricks_genie`;
+the MLflow classes are span-only (the backend rejects conversation aggregation for
+them). `databricks_genie` agents emit no token or model data — skip token-usage
+metrics for them (see `agent-metric-monitor.md`). A null `backend_class` means the
+server couldn't classify the agent — default to span-grain proposals.
+
 **Duplicate agent names:** The same agent name may appear more than once (e.g.,
 deployed in both prod and staging). Each entry is distinguished by its own
 `agentReference`, `traceTableMcon`, and warehouse — ask the user which one they

--- a/skills/monitoring-advisor/references/agent-span-fields.md
+++ b/skills/monitoring-advisor/references/agent-span-fields.md
@@ -57,6 +57,11 @@ text fields — `duration_sec`, `total_tokens`, `prompt_tokens`, `completion_tok
 `has_completions`. Those presence/kind flags exist only for OTel/ClickHouse agents.
 Stick to the core fields unless you know the agent is OTel-instrumented.
 
+**Databricks Genie agents (`backend_class: databricks_genie`) emit NO token or
+model data** — `total_tokens` / `prompt_tokens` / `completion_tokens` are always
+empty, so don't build token-usage metrics for them; prefer latency
+(`duration_sec`), volume, and error/outcome signals.
+
 ## Trace-aggregation fields (is_agent_trace_aggregation=True)
 
 When `is_agent_trace_aggregation=True`, rows are aggregated per trace (OpenTelemetry
@@ -79,7 +84,9 @@ agents only):
 ## Conversation-aggregation fields (is_agent_conversation_aggregation=True)
 
 Agent evaluation monitors can aggregate per conversation
-(`is_agent_conversation_aggregation=True`, OpenTelemetry agents only). At this grain,
+(`is_agent_conversation_aggregation=True` — supported for OpenTelemetry/ClickHouse,
+Snowflake Cortex, and Databricks Genie agents; Databricks MLflow agents are
+span-only). At this grain,
 `alert_conditions.fields` may reference these raw conversation columns alongside any
 judge output field:
 


### PR DESCRIPTION
## Changes

Syncs the monitoring-advisor skill (the pinned snapshot of the coverage agent's behavior) with ai-agent AI-636:

- **Conversation-grain rule updated**: `is_agent_conversation_aggregation` is supported for OTel/ClickHouse, **Snowflake Cortex**, and **Databricks Genie** agents; Databricks MLflow agents remain span-only. Replaces the stale "OTel agents only" claims in `agent-evaluation-monitor.md` and `agent-span-fields.md` (the AO-766-era rule — Cortex conversation aggregation shipped via AO-825, Genie in the July conv-eval work).
- **Genie token caveats**: Genie is NL2SQL and emits no token/model data — token-usage metrics are permanently silent. Added guidance to `agent-metric-monitor.md` and `agent-span-fields.md` steering to latency/volume/outcome signals.
- **`backend_class` capability note** in `agent-monitor-creation.md`: which classes are conversation-capable, the Genie token caveat, and the null-degrade default.
- Version bump **v1.15.2** across all 6 plugins.

Trace-level aggregation (`is_agent_trace_aggregation`) remains OTel-only — deliberately untouched.

## Stacking

~~Based on #105~~ — #105 merged 2026-07-20; this branch is rebased onto main and the PR retargeted. The paired ai-agent change is PR ai-agent#1755 (rebased onto its main after ai-agent#1751 merged).

## Context

- Linear: [AI-636](https://linear.app/montecarloai/issue/AI-636/coverage-agent-adopt-the-ao-891-getagentmetadatav2-classification)
- Guard change this documents: mcp-server `create_or_update_agent_evaluation_monitor` no longer pre-flight-rejects conversation aggregation for platform references; the monolith's `CONVERSATION_PLATFORM_AGENT_TYPES` gate decides and the rejection is translated actionably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
