### PR TITLE
docs(monitoring-advisor): Behavior pillar — runaway-loop threshold derivation + ungrounded-in-data draft (AI-648) — v1.18.1

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.15.3",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.15.3",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Behavior pillar (AI-648) — agent-understanding investigation summary before proposing monitors (purpose, dominant tool span, healthy trajectory shape, intents, failure modes); runaway-loop trajectory playbook with thresholds derived from observed trace history (max observed + headroom; zero historical matches by design — a regression guardrail); ungrounded-in-data pattern created as a draft with a breach preview and an LLM-judge upgrade path; `preview` / `tags` / `is_draft` documented on the trajectory reference with the `agent:<AGENT_NAME>` tag convention and daily schedule default
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -215,8 +215,11 @@ Grounded in the Step 2c summary, propose these two patterns whenever they apply
    span, threshold derived from the observed per-trace occurrence distribution:
    max observed + headroom, never a stock number. The proposal's evidence must
    show the dominant span, the distribution, and the derived threshold with its
-   headroom rationale. Zero historical matches is the point — it is a regression
-   guardrail that stays silent until the agent's behavior regresses.
+   headroom rationale — plus a pre-create breach `preview` (dry run) proving zero
+   historical matches; if the preview breaches, the sample missed the heavy tail
+   (e.g. multi-turn accumulation in one trace) — re-derive from a wider window.
+   Zero historical matches is the point — it is a regression guardrail that stays
+   silent until the agent's behavior regresses.
 2. **Ungrounded-in-data — create as a DRAFT** (only for agents that answer
    questions from data). Negated `occurs_with` SPAN_RELATION: an answer was
    produced without the agent's data-access tool span. Show a breach `preview`

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -81,6 +81,30 @@ so you can scope a monitor to a real segment. Then pick a trace id and call
 You are identifying **what** to monitor — you don't need exact percentiles up
 front; anomaly-detection operators (`AUTO`) learn the baseline themselves.
 
+### 2c. Summarize the agent before proposing
+
+Condense the investigation into a short agent understanding and show it to the
+user — every monitor you propose should trace back to an item in it:
+
+- **Purpose** — 1–2 sentences on what this agent does, grounded in the sampled
+  transcripts (e.g. "a revenue-analytics assistant that answers questions about
+  bookings").
+- **Conversational?** — multi-turn user conversations (eval-worthy for
+  satisfaction / task completion) vs. a batch / single-shot pipeline where
+  structural and span checks fit better.
+- **Tools and the dominant span** — which tool spans the agent runs, and which
+  one does its core work (the SQL execution tool for an analytics agent,
+  retrieval for a RAG agent).
+- **Healthy trajectory shape** — how many times the dominant span runs per answer
+  in healthy traces (the per-trace distribution and its max), typical turn counts,
+  and latency/token magnitudes. This is the basis for every derived threshold.
+- **Recurring intents** — what users repeatedly ask (from the transcripts) —
+  seeds for custom conversation evals.
+- **Observed failure modes** — what actually went wrong in the sample — seeds for
+  evals and structural monitors.
+- **Existing monitors** — from `get_monitors`, so proposals don't duplicate
+  coverage.
+
 ---
 
 ## The `agent` reference
@@ -181,6 +205,35 @@ corresponding reference doc for the detailed creation guide.
 
 After selecting the monitor type, **read the reference doc** for that type to
 get the detailed parameter guide, examples, constraints, and creation workflow.
+
+### Behavior monitors — two trajectory proposals for (almost) every agent
+
+Grounded in the Step 2c summary, propose these two patterns whenever they apply
+(`agent-trajectory-monitor.md` has the full playbooks and payload shapes):
+
+1. **Runaway loop — create live.** SPAN_OCCURRENCE on the agent's dominant tool
+   span, threshold derived from the observed per-trace occurrence distribution:
+   max observed + headroom, never a stock number. The proposal's evidence must
+   show the dominant span, the distribution, and the derived threshold with its
+   headroom rationale. Zero historical matches is the point — it is a regression
+   guardrail that stays silent until the agent's behavior regresses.
+2. **Ungrounded-in-data — create as a DRAFT** (only for agents that answer
+   questions from data). Negated `occurs_with` SPAN_RELATION: an answer was
+   produced without the agent's data-access tool span. Show a breach `preview`
+   (dry run) as evidence, then create with `is_draft=True` — generic questions
+   legitimately skip the data tool, and the LLM-judge filter needed to separate
+   them from real data questions cannot be combined with a trajectory condition
+   yet.
+
+Tag both with the agent's name (`tags=[{"name": "agent", "value": "<AGENT_NAME>"}]`)
+and schedule them daily (`interval_minutes=1440`).
+
+Beyond these two, propose **agent-tailored behavioral custom prompts** for
+behaviors a span pattern can't see — e.g. "did the agent claim it ran a query it
+never executed?", "did the agent re-ask for information the user already gave?".
+One boolean `custom_prompt` per behavior, alerting on `TRUE_RATE` / `FALSE_RATE`,
+at conversation grain where the backend supports it (see `backend_class` in
+Step 1 and `agent-evaluation-monitor.md`).
 
 ---
 

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -179,6 +179,13 @@ healthy run ever needed. Derive the threshold; never hardcode one:
    distributions) keeps ordinary variance from alerting while still catching a loop.
 4. **Show the evidence** when proposing: the dominant span, the occurrence
    distribution, and the derived threshold with its headroom rationale.
+5. **Prove zero matches with a preview before creating.** Run `dry_run=True,
+   preview=True` with the derived condition: the preview must report NOT breaching.
+   If it reports breaching traces, your sample missed the heavy tail (long agentic
+   sessions, multi-turn conversations accumulating in one trace) — re-derive from a
+   wider window. Preview probes at increasing counts (e.g. more than 20/30/40 on a
+   7-day `lookbackInHrs`) find the true historical max cheaply without pulling
+   traces.
 
 A well-derived runaway-loop monitor matches **zero historical traces** — that is
 the point, not a defect. It is a regression guardrail: it stays silent until the

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -68,6 +68,14 @@ trend a numeric metric (mean latency, token counts) — that's
 | `interval_minutes` | int | No | Default `60`; at least 5 |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
+| `preview` | boolean | No | Only together with `dry_run=True`: also runs the monitor's query and returns a pre-create breach preview — whether the conditions would fire right now, a small sample of the underlying data, and the sample row count. Ignored on a real create (`dry_run=False`) |
+| `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "Support Bot"}]`. Tag every agent monitor with its agent's name — `{"name": "agent", "value": "<AGENT_NAME>"}` — so all of one agent's monitors are filterable as a group |
+| `is_draft` | boolean | No | Default `False`. Save the monitor as a draft — visible in the UI but not running. **On edit, omitting this un-drafts an existing draft** — pass `is_draft=True` explicitly to keep a draft a draft |
+
+Because `preview` only works on a dry run, evidence and creation are **two separate
+calls**: first `dry_run=True, preview=True` to show the user what would fire, then
+(after they confirm) `dry_run=False` — with `is_draft=True` if the monitor should
+land as a draft.
 
 ## agent_span_alert_condition structure
 
@@ -149,6 +157,64 @@ Identifies a span by workflow / task / span name. Fill in from coarse to fine.
 `workflow`. If you set `task`, you MUST also set `workflow`. All values use the
 `{"literal": "..."}` format. Discover the real names with `get_agent_segments` and
 `get_agent_trace`.
+
+## Behavior playbooks
+
+Two trajectory-monitor patterns that apply to almost every agent. Both must be
+grounded in what THIS agent actually does — never propose them with stock values.
+
+### Runaway loop — threshold derived from trace history
+
+Flags traces where the agent's dominant tool span repeats more times than any
+healthy run ever needed. Derive the threshold; never hardcode one:
+
+1. **Find the dominant tool span** — the span that does the agent's core work (the
+   SQL execution tool for an analytics agent, retrieval for a RAG agent). Use
+   `get_agent_traces` for per-trace shape and `get_agent_trace` on a few trace ids
+   to see the span tree and which tool span dominates.
+2. **Build its per-trace occurrence distribution** from the sampled traces — e.g.
+   "in 20 recent traces the SQL tool ran 1–3 times per trace; max observed: 3".
+3. **Set the threshold to max observed + headroom** — e.g. max 3 → `MORE_THAN`
+   with `count: 5`. The headroom (roughly max + 2, or ~2× max for very tight
+   distributions) keeps ordinary variance from alerting while still catching a loop.
+4. **Show the evidence** when proposing: the dominant span, the occurrence
+   distribution, and the derived threshold with its headroom rationale.
+
+A well-derived runaway-loop monitor matches **zero historical traces** — that is
+the point, not a defect. It is a regression guardrail: it stays silent until the
+agent's behavior actually regresses. At a design partner, exactly this monitor
+caught a silent-retry regression — a run that looped its dominant tool for ~3
+minutes with zero logged errors — within a week of being created, invisible to
+every error-based monitor.
+
+Create it live (`dry_run=False` after user confirmation), tagged
+`{"name": "agent", "value": "<AGENT_NAME>"}`, on a daily schedule
+(`interval_minutes=1440`, `lookbackInHrs: 24`).
+
+### Ungrounded-in-data — create as a DRAFT with an evidence preview
+
+For agents that answer questions from data (analytics, RAG): flag traces where the
+agent produced an answer **without** executing its data-access tool — it likely
+answered from priors instead of the data. The shape is SPAN_RELATION `occurs_with`
++ `"negated": true` (the answer/LLM span occurs WITHOUT the data-tool span) —
+SPAN_OCCURRENCE cannot express "occurs 0 times".
+
+This naive pattern **also flags legitimate traffic**: generic questions ("what can
+you do?", "help") don't need a data query, so an active version alerts on healthy
+runs. Telling those apart needs an LLM-as-a-judge signal ("was this a data
+question?") combined with the trajectory condition, and that composition is not
+available yet. Therefore:
+
+- Run the evidence call first (`dry_run=True, preview=True`) and show the user
+  what would currently fire and at what rate.
+- Create it as a **draft** (`dry_run=False, is_draft=True`) — same `agent` tag,
+  same daily schedule — so the pattern is captured and reviewable without alerting
+  on healthy runs.
+- Note the upgrade path: when trajectory monitors can be combined with an
+  LLM-as-a-judge filter, add the "user asked a data question" judge and enable the
+  monitor.
+- When later editing the monitor, keep passing `is_draft=True` — omitting it
+  un-drafts.
 
 ## Examples
 


### PR DESCRIPTION
Mirrors [ai-agent#1781](https://github.com/monte-carlo-data/ai-agent/pull/1781) (AI-648, POBC Behavior pillar) into the toolkit's monitoring-advisor skill.

**`references/agent-monitor-creation.md`:**
- Step 2c — agent-understanding summary before proposing (purpose, dominant tool span, healthy trajectory shape, intents, failure modes, existing monitors).
- Behavior monitors subsection: runaway-loop (create live, threshold = max observed + headroom from trace history, zero-match regression-guardrail rationale) + ungrounded-in-data (create as draft with breach preview; LLM-judge upgrade path), plus agent-tailored behavioral `custom_prompt` guidance.

**`references/agent-trajectory-monitor.md`:**
- Behavior playbooks section with the full derivation procedure and draft/preview flow.
- `preview` / `tags` / `is_draft` parameter rows, the two-call evidence-then-create flow (`preview` only works with `dry_run=True`), the un-draft-on-edit gotcha, the `agent:<AGENT_NAME>` tag convention, and the daily schedule default.

Version bump → **1.18.1** (rebased over the merged AI-645/646/647 mirrors, v1.16.0–v1.18.0; Behavior proposals folded into the POBC walkthrough main introduced) across all 6 plugin configs + changelogs via `scripts/bump-version.sh patch`.

**Merge ordering:** merge after ai-agent#1781 (AI-633/635/636 precedent — the toolkit docs describe behavior the ai-agent skill chain ships).

- Ticket: [AI-648](https://linear.app/montecarlodata/issue/AI-648) (part of AI-644 POBC playbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)