### PR TITLE
docs(monitoring-advisor): POBC proposal walkthrough in agent-monitor-creation (AI-645) — v1.16.0

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.16.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.16.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: POBC proposal walkthrough in the agent monitor creation
+  reference — open with the Performance/Output/Behavior/Context framing, walk
+  the user through the plan pillar by pillar (evidence → proposed monitors →
+  confirm), Context as a recommendation-only pillar until lineage wiring
+  lands. Global defaults: daily schedules (`interval_minutes=1440`) and
+  count-based eval sampling (`{"count": 100}`). (AI-645)
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -125,7 +125,7 @@ When the user's request comes in, determine which workflow to follow:
 | --- | --- |
 | Coverage analysis, use-case exploration, "what should I monitor?" | **Coverage workflow** (below) |
 | Create a specific data monitor for a known table | **Read `references/data-monitor-creation.md`** and follow its procedure |
-| Monitor AI agents, agent latency, agent quality, agent traces | **Read `references/agent-monitor-creation.md`** and follow its procedure |
+| Monitor AI agents, agent latency, agent quality, agent traces | **Read `references/agent-monitor-creation.md`** and follow its procedure — propose coverage across the four POBC pillars (Performance, Output, Behavior, Context) |
 | Coverage analysis leads to monitor creation | Complete coverage workflow, then **read `references/data-monitor-creation.md`** for creation |
 
 When reading reference files, always use the **Read tool** with the path relative to this skill file.

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -197,7 +197,7 @@ create_or_update_agent_evaluation_monitor(
         {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["relevance_score"],
          "thresholdValue": 2}
     ],
-    sampling_config={"percentage": 10.0},
+    sampling_config={"count": 100},
     dry_run=True
 )
 ```
@@ -274,7 +274,7 @@ create_or_update_agent_evaluation_monitor(
         {"metric": "NUMERIC_MEAN", "operator": "LT", "fields": ["answer_chars"],
          "thresholdValue": 40}
     ],
-    sampling_config={"percentage": 10.0},
+    sampling_config={"count": 100},
     dry_run=True
 )
 ```

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -158,7 +158,10 @@ What each pillar maps to:
 
 Mind the backend caveats from Step 1 (`backend_class`): no token or model
 metrics for Genie / Knowledge Assistant agents, and conversation-grain evals
-only on OTel/ClickHouse, Snowflake Cortex, and Genie.
+only on OTel/ClickHouse, Snowflake Cortex, and Genie. Aggregate (per-trace)
+validation assertions require `is_agent_trace_aggregation=True`, supported
+only on `ao_clickhouse_otel` / `customer_otel_trace_table` agents — on other
+backends, use per-span assertions instead.
 
 **Context is a recommendation for now** — creating data-quality monitors from
 the agent's lineage is not wired into this flow yet. Present the pillar rather
@@ -241,8 +244,9 @@ Schedule is set via two top-level args, not a nested object:
   monitor. The floor and alignment differ per monitor type — see each reference.
 
 No agent monitor accepts a dynamic schedule — use `fixed` or `manual`. Daily is
-the right cadence for most agents; go shorter (hourly) only for critical agents
-where a same-hour alert matters.
+the right cadence for most agents. If you judge an agent critical enough that a
+same-hour alert would matter, suggest hourly to the user and let them decide —
+the default stays daily unless they opt in.
 
 ---
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -83,6 +83,98 @@ front; anomaly-detection operators (`AUTO`) learn the baseline themselves.
 
 ---
 
+## Propose with the POBC framing (walk the user through all four pillars)
+
+When the user is setting up monitoring for an agent (rather than asking for one
+specific monitor), structure the proposal around the four pillars of agent
+observability — **Performance, Output, Behavior, Context (POBC)** — and walk
+through them one at a time. Do NOT dump every proposed monitor in one
+monolithic list.
+
+### 1. Open with the framing
+
+Before presenting any monitors, briefly explain the framework. Use this copy,
+adapting the agent's actual name into the prose where it reads naturally:
+
+> A quick word on how we think about agent observability. Agents fail in four
+> distinct ways, so we monitor four distinct things — **Performance, Output,
+> Behavior, and Context (POBC)**: how efficiently the agent answers, what it
+> says, how it gets there, and the data it stands on.
+>
+> **Performance** — is it fast and affordable? Latency, token cost, and error
+> monitoring catch drift in both the typical experience and the worst one.
+>
+> **Output** — is the agent giving good answers? Evals score response quality
+> (helpfulness, non-answers, user corrections) so quality regressions surface
+> as alerts, not user complaints.
+>
+> **Behavior** — is it working sensibly under the hood? Trajectory monitoring
+> flags runs that loop or take paths a healthy run never takes — including
+> failures the agent recovers from and hides.
+>
+> **Context** — is the data it relies on healthy? The agent's answers are only
+> as good as its upstream tables; we monitor those for freshness, schema
+> changes, and anomalies.
+>
+> Everything below maps to one of these four. Here's the plan:
+
+### 2. Walk through the plan pillar by pillar
+
+Present the pillars in order — Performance, Output, Behavior, Context — one
+short block each:
+
+1. **Evidence** — one or two sentences of what you observed in Step 2 that
+   motivates this pillar's monitors ("p95 latency is 40s with outliers over
+   three minutes", "several conversations show repeated user corrections").
+   If you found nothing notable for a pillar, say so and propose baseline
+   coverage anyway — monitoring exists to catch what hasn't happened yet.
+2. **Proposed monitors** — the specific monitors for this pillar, each with
+   its monitor type, field or judge, and alert condition.
+3. **Confirm** — ask whether to keep, adjust, or drop this pillar's monitors,
+   and fold the answer in before moving to the next pillar.
+
+A healthy agent usually warrants coverage in every pillar you can serve —
+keep proposals broad across pillars, not deep in one.
+
+**Global defaults for proposed monitors** (apply unless the user asks
+otherwise):
+
+- **Daily schedule** — pass `interval_minutes=1440` explicitly; the tools'
+  built-in default is hourly (see Schedule configuration below).
+- **Eval sampling** — `sampling_config={"count": 100}` (a fixed 100-sample
+  budget per run), not a percentage, so evaluation cost stays predictable as
+  traffic grows.
+- **Audience before creation** — never create a monitor without asking which
+  audience(s) should be notified (Step 4).
+
+What each pillar maps to:
+
+| Pillar | Monitor types | Reference |
+|---|---|---|
+| **Performance** | Metric (validation for hard limits) — latency (`duration_sec`), token cost (`total_tokens`), error rate (`status_code`), volume (`ROW_COUNT_CHANGE`) | `agent-metric-monitor.md` |
+| **Output** | Evaluation — predefined judges (`answer_relevance`, `helpfulness`, `task_completion`, `clarity`, `prompt_adherence`), rule checks (`output_length`, `json_validity`), and one custom eval per recurring user intent or failure mode you observed | `agent-evaluation-monitor.md` |
+| **Behavior** | Trajectory (validation for aggregate assertions) — runaway loops (`SPAN_OCCURRENCE`), missing or mis-ordered steps (`SPAN_RELATION`), token budgets | `agent-trajectory-monitor.md`, `agent-validation-monitor.md` |
+| **Context** | Data-quality monitors on the agent's upstream tables — see below | — |
+
+Mind the backend caveats from Step 1 (`backend_class`): no token or model
+metrics for Genie / Knowledge Assistant agents, and conversation-grain evals
+only on OTel/ClickHouse, Snowflake Cortex, and Genie.
+
+**Context is a recommendation for now** — creating data-quality monitors from
+the agent's lineage is not wired into this flow yet. Present the pillar rather
+than skipping it: name it in the plan, ask the user which upstream tables the
+agent depends on, and suggest Monte Carlo's standard data-quality monitoring
+(freshness, volume, schema changes, anomalies) on those tables as a follow-up
+(the data-monitor workflow in this skill covers them).
+
+### 3. Create the confirmed monitors
+
+Once the user has confirmed the pillars, continue to Step 3 (pick each
+monitor's reference doc) and Step 4 (dry-run preview, audience selection,
+creation on explicit confirmation) for each approved monitor.
+
+---
+
 ## The `agent` reference
 
 All four `create_or_update_agent_*_monitor` tools author the monitor's source from
@@ -141,14 +233,16 @@ per-type reference for the exact rule.
 
 ## Schedule configuration
 
+**Propose daily schedules by default** — pass `interval_minutes=1440` explicitly.
 Schedule is set via two top-level args, not a nested object:
 
 - `schedule_type` — defaults to `fixed`. Valid values: `fixed`, `manual`.
-- `interval_minutes` — defaults to `60`. The floor and alignment differ per monitor
-  type — see each reference.
+- `interval_minutes` — defaults to `60` (hourly), so omitting it creates an hourly
+  monitor. The floor and alignment differ per monitor type — see each reference.
 
-No agent monitor accepts a dynamic schedule — use `fixed` or `manual`. Use shorter
-intervals for critical agents, longer for less critical ones.
+No agent monitor accepts a dynamic schedule — use `fixed` or `manual`. Daily is
+the right cadence for most agents; go shorter (hourly) only for critical agents
+where a same-hour alert matters.
 
 ---
 


### PR DESCRIPTION
# Changes

Toolkit mirror of monte-carlo-data/ai-agent#1782 (AI-645) — the monitoring-advisor skill now proposes agent monitors with the **POBC** framing:

- Net-new **"Propose with the POBC framing"** section in `references/agent-monitor-creation.md` (inserted after Step 2): open with the Performance/Output/Behavior/Context framing copy, walk the user through the plan pillar by pillar (evidence → proposed monitors → confirm), pillar → monitor-type/reference mapping table. Context is a recommendation-only pillar (ask for upstream tables, suggest standard data-quality monitoring) until lineage wiring lands (AI-650).
- **Global defaults**: schedule section now says to propose daily (`interval_minutes=1440`) by default (tools' built-in default stays hourly); both eval examples in `references/agent-evaluation-monitor.md` switch `sampling_config` from `{"percentage": 10.0}` to `{"count": 100}` (within the documented 500/10,000 caps).
- One-line POBC pointer on the agent routing row in `SKILL.md`.
- `chore: bump version to 1.16.0` (6 plugin.json + 6 CHANGELOG.md via `scripts/bump-version.sh minor`).

## Merge order

- **Merge after** monte-carlo-data/ai-agent#1782 — the toolkit skill mirrors the in-product skill behavior (AI-635 precedent).
- Heads-up: open PR #107 (AI-647) also claims v1.16.0 off main=v1.15.2 — whichever of the two merges second should rebase and re-bump.

## Context

- [AI-645](https://linear.app/montecarlodata/issue/AI-645) — POBC framing: OA explains the framework and walks the user through the plan (master AI-644, Bob v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)