### PR TITLE
docs(monitoring-advisor): Performance pillar baseline monitor set (AI-646) — v1.17.0

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.16.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.15.2",
+    "version": "1.16.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.16.0] - 2026-07-21
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-21
+
+### Added
+
+- monitoring-advisor: Performance pillar baseline monitor set in the agent-metric-monitor reference — p50+p95 latency anomaly, p50+p95 token anomaly, daily token SUM, status_code error-level anomaly, and a measured-p95 latency SLO threshold, with per-backend gating and shared defaults (daily schedule, agent tag, draft-capable) (AI-646)
+- monitoring-advisor: documented `tags` and `is_draft` (un-draft-on-edit footgun) on create_or_update_agent_metric_monitor; routing rows for performance-coverage asks
+
 ## [1.15.2] - 2026-07-20
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -41,7 +41,8 @@ Activate when the user:
 - Wants to add monitoring after new transformation logic (when the prevent skill is not active)
 - Asks about monitoring AI agents, agent latency, agent token usage, or agent quality
 - Wants to set up alerts on agent behavior or execution patterns
-- Says things like "monitor my agent", "track agent latency", "alert on agent errors"
+- Says things like "monitor my agent", "track agent latency", "alert on agent errors",
+  "set up performance monitoring for my agent", or asks for an agent latency SLO
 - Asks about agent evaluation monitors, trajectory monitors, or validation monitors
 - Mentions agent observability or agent monitoring
 

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -161,8 +161,8 @@ The set:
 
 | # | Monitor | `alert_conditions` | Notes |
 |---|---------|--------------------|-------|
-| 1 | Latency anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `duration_sec`, both `AUTO` | One monitor, two conditions — catches drift in the typical and the worst experience. Distinct metrics on the same field are fine; only duplicate metric+field pairs are rejected. |
-| 2 | Token anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `total_tokens`, both `AUTO` | Per-interaction cost drift. |
+| 1 | Latency anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `duration_sec`, both `AUTO` | ONE monitor, TWO conditions (do not split) — catches drift in the typical and the worst experience. Distinct metrics on the same field are fine; only duplicate metric+field pairs are rejected. p50 = `NUMERIC_MEDIAN`: there is no `PERCENTILE_50` metric — never substitute `PERCENTILE_40`. |
+| 2 | Token anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `total_tokens`, both `AUTO` | Per-interaction cost drift; same one-monitor-two-conditions shape. |
 | 3 | Daily token spend | `SUM` on `total_tokens`, `AUTO`, with `aggregate_by="day"` | Aggregate cost creep. `aggregate_by` buckets the datapoints; `interval_minutes` only sets the run cadence — set both. |
 | 4 | Error-level anomaly | `NUMERIC_MEAN` on `status_code`, `AUTO_HIGH` | Error-rate proxy — see rationale below. |
 | 5 | Latency SLO | `PERCENTILE_95` on `duration_sec`, `GT`, `thresholdValue` = measured p95 × 1.2 | Separate monitor, measure-then-propose — see below. |

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -156,6 +156,8 @@ Shared defaults for every monitor in the set:
   backends use the span-grain default. Monitors 3 and 4 stay span-grain everywhere
   (`SUM` of tokens is the same total either way, and `status_code` is not a
   trace-aggregation field).
+- **Cap-constrained surfaces** — if the consuming surface limits how many monitors may be
+  proposed, keep priority order 1 → 4 → 3 → 2 → 5 and say which monitors were cut for the cap.
 
 The set:
 

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -60,7 +60,9 @@ Do NOT use this for LLM-evaluated quality (relevance, correctness, tone) — tha
 | `sensitivity` | string | No | Anomaly detection sensitivity for AUTO operators |
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
 | `interval_minutes` | int | No | Default `60`; at least 60 and a multiple of 60 |
+| `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "<AGENT_NAME>"}]`. Tag every monitor you create for an agent with its name so they're groupable (see Performance pillar) |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
+| `is_draft` | boolean | No | Save as a draft (not active). **On edit, omitting this un-drafts an existing draft** — re-pass `is_draft=True` when updating a draft that should stay a draft |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
 ## Alert conditions
@@ -132,6 +134,76 @@ latency (`duration_sec`), volume, and error/outcome metrics instead.
   `spanName` from `agent_span_filters`, since the per-trace result has no such column.
 - Use the trace-aggregation field names (`span_count`, `llm_call_count`, trace-summed
   tokens, total `duration_sec`). See `agent-span-fields.md`.
+
+## Performance pillar (baseline monitor set)
+
+When the user asks for performance monitoring on a named agent — latency, token cost,
+errors, or a latency SLO ("set up performance monitoring for X", "alert me when X gets
+slow or expensive") — propose this exact monitor set rather than inventing one-offs.
+Discover the agent first (`get_agent_metadata` → `agentReference`, `backend_class`,
+`warehouse_uuid`), apply the backend gating below, then present the whole set with
+`dry_run=True` previews.
+
+Shared defaults for every monitor in the set:
+
+- **Daily schedule** — `interval_minutes=1440`.
+- **Tag the agent** — `tags=[{"name": "agent", "value": "<AGENT_NAME>"}]` on every
+  monitor, so the pillar's monitors are groupable per agent.
+- **Draft-first when the user wants review** — pass `is_draft=True` to stage the set
+  without activating it (and remember the un-draft-on-edit footgun in Parameters).
+- **Grain** — on OTel agents create monitors 1, 2, and 5 with
+  `is_agent_trace_aggregation=True` so they track end-to-end interactions; other
+  backends use the span-grain default. Monitors 3 and 4 stay span-grain everywhere
+  (`SUM` of tokens is the same total either way, and `status_code` is not a
+  trace-aggregation field).
+
+The set:
+
+| # | Monitor | `alert_conditions` | Notes |
+|---|---------|--------------------|-------|
+| 1 | Latency anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `duration_sec`, both `AUTO` | One monitor, two conditions — catches drift in the typical and the worst experience. Distinct metrics on the same field are fine; only duplicate metric+field pairs are rejected. |
+| 2 | Token anomaly | `NUMERIC_MEDIAN` + `PERCENTILE_95` on `total_tokens`, both `AUTO` | Per-interaction cost drift. |
+| 3 | Daily token spend | `SUM` on `total_tokens`, `AUTO`, with `aggregate_by="day"` | Aggregate cost creep. `aggregate_by` buckets the datapoints; `interval_minutes` only sets the run cadence — set both. |
+| 4 | Error-level anomaly | `NUMERIC_MEAN` on `status_code`, `AUTO_HIGH` | Error-rate proxy — see rationale below. |
+| 5 | Latency SLO | `PERCENTILE_95` on `duration_sec`, `GT`, `thresholdValue` = measured p95 × 1.2 | Separate monitor, measure-then-propose — see below. |
+
+**Why monitor 4 is `NUMERIC_MEAN` on `status_code`:** `status_code` is the one error
+signal available on every backend (OTel semantics: 0 = unset, 1 = ok, 2 = error).
+Healthy spans sit at 0/1 and errored spans at 2, so the mean rises with the
+errored-span share — `AUTO_HIGH` on the mean fires when errors spike. Say so in the
+proposal: this is a *proxy* for error rate built from built-in metrics, not a true
+rate. Do NOT use `TRUE_RATE` (no backend has a boolean error field) or
+`exception_type` (not available on all backends). Monte Carlo may already have
+auto-created a dedicated error-rate monitor for the agent — check `get_monitors`
+first, and if one exists present it as the error coverage instead of duplicating it.
+
+**Monitor 5 is measure-then-propose — never invent an SLO threshold:**
+
+1. Sample recent traces: `get_agent_traces` for the agent (default 14-day lookback),
+   `first=50`, paging with `after`/`end_cursor` up to ~3 pages (≤150 traces).
+2. Compute the 95th percentile of the sampled `duration_seconds`.
+3. Propose `thresholdValue` = p95 × 1.2 (20% headroom), rounded to a clean number.
+4. Show the evidence: measured p95, sample size and window, and the proposed
+   threshold — stating explicitly that the headroom and threshold are the user's to
+   adjust.
+
+Keep the SLO in its own monitor — adding a second `PERCENTILE_95` + `duration_sec`
+condition to monitor 1 is rejected as a duplicate metric+field pair. Propose it for
+OTel agents only (trace grain, so the trace-level measurement matches the monitored
+metric); on other backends skip it — a span-grain p95 tracks individual steps, not
+end-to-end latency, so a trace-based threshold would never fire — and note that
+monitor 1's anomaly conditions cover latency drift.
+
+**Backend gating** (from `backend_class`; explain each skip in one line in the
+proposal):
+
+| `backend_class` | Monitors | Adjustments |
+|---|---|---|
+| `ao_clickhouse_otel` / `customer_otel_trace_table` | 1–5 | 1, 2, 5 at trace grain |
+| `databricks_mlflow_sdk` | 1–4 | span grain; no trace aggregation, so no SLO monitor |
+| `platform_agent` (Cortex) | 1–4 | span grain; no trace aggregation, so no SLO monitor |
+| `databricks_mlflow_ka` | 1, 4 | token fields are NULL — skip 2–3 |
+| `databricks_genie` | 1 (median only), 4 | no token data — skip 2–3; latency percentiles are not meaningful on Genie's fabricated span tree, so drop the `PERCENTILE_95` condition from 1 and skip 5 |
 
 ## Examples
 
@@ -210,6 +282,25 @@ create_or_update_agent_metric_monitor(
         {"metric": "TRUE_RATE", "operator": "LT", "fields": ["is_tool_call"],
          "thresholdValue": 0.1}
     ],
+    dry_run=True
+)
+```
+
+### Latency SLO threshold (Performance pillar monitor 5 — OTel agent, trace grain, draft)
+
+```
+create_or_update_agent_metric_monitor(
+    description="checkout-agent latency SLO — trace p95 under 42s (measured p95 35s + 20% headroom)",
+    agent="checkout-agent",
+    warehouse="Prod Warehouse",
+    alert_conditions=[
+        {"metric": "PERCENTILE_95", "operator": "GT", "fields": ["duration_sec"],
+         "thresholdValue": 42}
+    ],
+    is_agent_trace_aggregation=True,
+    interval_minutes=1440,
+    tags=[{"name": "agent", "value": "checkout-agent"}],
+    is_draft=True,
     dry_run=True
 )
 ```

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -171,6 +171,7 @@ corresponding reference doc for the detailed creation guide.
 | I want to... | Monitor type | Reference file |
 |-------------|-------------|----------------|
 | Track a numeric metric trend (latency, tokens) | Agent Metric | `agent-metric-monitor.md` |
+| Set up performance coverage (latency, token cost, errors, SLO) | Agent Metric — Performance pillar | `agent-metric-monitor.md` |
 | Score output quality with LLM evaluation | Agent Evaluation | `agent-evaluation-monitor.md` |
 | Alert on execution patterns or span sequences | Agent Trajectory | `agent-trajectory-monitor.md` |
 | Assert a logical rule on span data | Agent Validation | `agent-validation-monitor.md` |
@@ -181,6 +182,8 @@ corresponding reference doc for the detailed creation guide.
 
 After selecting the monitor type, **read the reference doc** for that type to
 get the detailed parameter guide, examples, constraints, and creation workflow.
+For a blanket "performance monitoring" ask, follow the **Performance pillar**
+baseline set in `agent-metric-monitor.md` rather than assembling one-offs.
 
 ---
 


### PR DESCRIPTION
# Changes

Mirrors ai-agent AI-646 (monte-carlo-data/ai-agent#1784) into the `monitoring-advisor` skill: a deterministic **Performance pillar** baseline in `references/agent-metric-monitor.md` —

1. Latency anomaly: one monitor, `NUMERIC_MEDIAN` + `PERCENTILE_95` on `duration_sec`, `AUTO` (p50 = `NUMERIC_MEDIAN`; there is no `PERCENTILE_50` metric)
2. Token anomaly: same pair on `total_tokens`
3. Daily token spend: `SUM` + `aggregate_by="day"`
4. Error-level anomaly: `NUMERIC_MEAN` on `status_code` + `AUTO_HIGH` (the only all-backend error signal; documented as a proxy)
5. Latency SLO: measure-then-propose (`get_agent_traces` sample → p95 × 1.2), separate monitor, OTel/trace-grain only

Plus per-backend gating (Genie/KA token skips, non-OTel SLO skip), shared defaults (daily, `agent:<NAME>` tag, draft-first), the previously undocumented `tags` / `is_draft` (un-draft-on-edit footgun) parameters, a worked SLO example, and routing rows in `agent-monitor-creation.md` / `SKILL.md`. Version bumped to **1.17.0** (1.16.0 was taken by AI-645 #109; merged main and re-bumped) across all plugins.

## Context

- [AI-646](https://linear.app/montecarloai/issue/AI-646/performance-pillar-latency-token-cost-errors-and-slo-proposal); source of truth is the ai-agent skill docs (monte-carlo-data/ai-agent#1784 — merge that first)
- Live prod acceptance on the ai-agent side: OTel leg exact-set PASS (SLO evidence: measured p95 107s × 1.2 → 128s), Genie leg gating PASS (tokens/p95/SLO skipped with explanations; `status_code` monitor dry-run validated on Genie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
