### PR TITLE
AI-651: agent-footprint monitor conventions in monitoring-advisor (v1.19.0)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-07-21
+
+### Changed
+
+- monitoring-advisor: agent-onboarding monitor conventions (AI-651) — every
+  monitor in the POBC playbook (agent monitors and Context-pillar data-quality
+  monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
+  once and applied to every create (with `failure_audiences` defaulting to the
+  same selection); one domain across the footprint; audit/teardown via
+  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+- agent-validation-monitor reference: documented the `tags` parameter
+- data-monitor-creation reference: agent-onboarding conditional for tagging
+  warehouse DQ monitors created for an agent
+
 ## [1.18.1] - 2026-07-21
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -14,7 +14,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   monitors) carries the `agent:{AGENT_NAME}` footprint tag; audiences are asked
   once and applied to every create (with `failure_audiences` defaulting to the
   same selection); one domain across the footprint; audit/teardown via
-  `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`
 - agent-validation-monitor reference: documented the `tags` parameter
 - data-monitor-creation reference: agent-onboarding conditional for tagging
   warehouse DQ monitors created for an agent

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -73,6 +73,7 @@ transforms, which those don't need.
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
 | `interval_minutes` | int | No | Default `60`; at least 60 and a multiple of 60 |
 | `tags` | array | No | Key-value tags on the monitor. Each tag is `{"name": "<key>", "value": "<value>"}` — the key field is `name` (NOT `key`), and unknown fields are rejected. **Default: tag every agent monitor with its agent** — `[{"name": "agent", "value": "<AGENT_NAME>"}]` (the `agentName` from `get_agent_metadata`) — so one agent's monitors can be filtered as a group |
+| `domain_uuids` | array | No | Domain UUIDs to assign this monitor to — the agent-onboarding playbook passes the footprint's single resolved domain on every create (see agent-monitor-creation.md conventions) |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -61,6 +61,7 @@ Do NOT use this for LLM-evaluated quality (relevance, correctness, tone) — tha
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
 | `interval_minutes` | int | No | Default `60`; at least 60 and a multiple of 60 |
 | `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "<AGENT_NAME>"}]`. Tag every monitor you create for an agent with its name so they're groupable (see Performance pillar) |
+| `domain_uuids` | array | No | Domain UUIDs to assign this monitor to — the agent-onboarding playbook passes the footprint's single resolved domain on every create (see agent-monitor-creation.md conventions) |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `is_draft` | boolean | No | Save as a draft (not active). **On edit, omitting this un-drafts an existing draft** — re-pass `is_draft=True` when updating a draft that should stay a draft |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -155,11 +155,12 @@ on the agent's upstream tables; see `data-monitor-creation.md`):
   (trimmed, case preserved — do not slugify or rename). This single tag is the
   footprint contract: one filter retrieves everything the playbook created for
   this agent.
-- **Audit / teardown contract.** `get_monitors(tags=["agent:<AGENT_NAME>"])`
-  (or the UI monitors tag filter) returns the agent's full monitoring
-  footprint — use it to audit what exists, tune, or tear down everything for
-  an agent. This is why a create call without the tag is a defect: it silently
-  drops the monitor out of the footprint.
+- **Audit / teardown contract.**
+  `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])` (or the UI monitors tag
+  filter) returns the agent's full monitoring footprint — use it to audit
+  what exists, tune, or tear down everything for an agent. This is why a
+  create call without the tag is a defect: it silently drops the monitor out
+  of the footprint.
 - **Audience — ask once, apply everywhere.** Before the FIRST create call of
   the playbook (not per monitor), ask the user once which audiences should be
   notified when these monitors fire — call `get_audiences` to list the
@@ -200,8 +201,9 @@ otherwise):
 - **Eval sampling** — `sampling_config={"count": 100}` (a fixed 100-sample
   budget per run), not a percentage, so evaluation cost stays predictable as
   traffic grows.
-- **Audience before creation** — never create a monitor without asking which
-  audience(s) should be notified (Step 4).
+- **Audience on every create** — apply the playbook-level audience selection
+  (see "Monitor conventions — every monitor in this playbook" above); never
+  create a monitor without that once-asked selection applied (Step 4).
 
 What each pillar maps to:
 
@@ -229,8 +231,9 @@ agent depends on, and suggest Monte Carlo's standard data-quality monitoring
 ### 3. Create the confirmed monitors
 
 Once the user has confirmed the pillars, continue to Step 3 (pick each
-monitor's reference doc) and Step 4 (dry-run preview, audience selection,
-creation on explicit confirmation) for each approved monitor.
+monitor's reference doc) and Step 4 (dry-run preview, applying the
+already-collected audience selection, creation on explicit confirmation) for
+each approved monitor.
 
 ---
 

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -142,6 +142,38 @@ adapting the agent's actual name into the prose where it reads naturally:
 >
 > Everything below maps to one of these four. Here's the plan:
 
+### Monitor conventions — every monitor in this playbook
+
+Four conventions apply to EVERY monitor created in this playbook — the agent
+monitors (metric, evaluation, trajectory, validation) AND any warehouse
+data-quality monitor created for the Context pillar (table or field monitors
+on the agent's upstream tables; see `data-monitor-creation.md`):
+
+- **Agent tag on every create.** Pass
+  `tags=[{"name": "agent", "value": "<AGENT_NAME>"}]`, where `<AGENT_NAME>` is
+  the agent's display name exactly as returned by `get_agent_metadata`
+  (trimmed, case preserved — do not slugify or rename). This single tag is the
+  footprint contract: one filter retrieves everything the playbook created for
+  this agent.
+- **Audit / teardown contract.** `get_monitors(tags=["agent:<AGENT_NAME>"])`
+  (or the UI monitors tag filter) returns the agent's full monitoring
+  footprint — use it to audit what exists, tune, or tear down everything for
+  an agent. This is why a create call without the tag is a defect: it silently
+  drops the monitor out of the footprint.
+- **Audience — ask once, apply everywhere.** Before the FIRST create call of
+  the playbook (not per monitor), ask the user once which audiences should be
+  notified when these monitors fire — call `get_audiences` to list the
+  options; the user can pick one, several, or none. Pass the chosen audience
+  **names** (labels, never UUIDs) as `audiences` on EVERY monitor created in
+  the playbook, and set `failure_audiences` to the same selection unless the
+  user asks for a different failure-notification audience. Do not re-ask per
+  pillar or per monitor; if the user declines, omit `audiences`.
+- **Domain — same for every monitor.** If the account uses domains, resolve
+  one domain for the agent's footprint and pass the same `domain_uuids` on
+  every monitor — including the Context-pillar DQ monitors (resolve via the
+  domain-assignment steps in `data-monitor-creation.md`) — so the whole
+  footprint lives in one domain.
+
 ### 2. Walk through the plan pillar by pillar
 
 Present the pillars in order — Performance, Output, Behavior, Context — one
@@ -369,9 +401,14 @@ you want to keep, since omitted fields revert to defaults).
 
 1. **Always start with `dry_run=True`** (the default). Show the user the
    configuration preview (the rendered YAML).
-2. Call `get_audiences` to list available notification audiences. Suggest the
-   most relevant one(s) and ask the user to pick — they can choose one or several.
-   Pass audience **names** (not UUIDs) as the `audiences` list.
+2. **Apply the playbook-level audience selection** (see "Monitor conventions —
+   every monitor in this playbook"): the audience question was already asked
+   once before the playbook's first create — pass that same selection of
+   audience **names** (not UUIDs) as the `audiences` list, and default
+   `failure_audiences` to the same selection. Fall back to asking here (one
+   question, `get_audiences` for options) only when the playbook-level ask has
+   not happened (e.g. the user jumped straight to a single monitor outside the
+   walkthrough).
 3. After showing the preview, offer to create or adjust settings.
 4. Only set `dry_run=False` when the user explicitly confirms creation.
 

--- a/skills/monitoring-advisor/references/agent-trajectory-monitor.md
+++ b/skills/monitoring-advisor/references/agent-trajectory-monitor.md
@@ -70,6 +70,7 @@ trend a numeric metric (mean latency, token counts) — that's
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 | `preview` | boolean | No | Only together with `dry_run=True`: also runs the monitor's query and returns a pre-create breach preview — whether the conditions would fire right now, a small sample of the underlying data, and the sample row count. Ignored on a real create (`dry_run=False`) |
 | `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "Support Bot"}]`. Tag every agent monitor with its agent's name — `{"name": "agent", "value": "<AGENT_NAME>"}` — so all of one agent's monitors are filterable as a group |
+| `domain_uuids` | array | No | Domain UUIDs to assign this monitor to — the agent-onboarding playbook passes the footprint's single resolved domain on every create (see agent-monitor-creation.md conventions) |
 | `is_draft` | boolean | No | Default `False`. Save the monitor as a draft — visible in the UI but not running. **On edit, omitting this un-drafts an existing draft** — pass `is_draft=True` explicitly to keep a draft a draft |
 
 Because `preview` only works on a dry run, evidence and creation are **two separate

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -58,6 +58,7 @@ or to alert on span sequences / call counts (use
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
 | `interval_minutes` | int | No | Default `60`; at least 5 |
 | `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "Support Bot"}]`. Tag every agent monitor with its agent's name — `{"name": "agent", "value": "<AGENT_NAME>"}` — so all of one agent's monitors are filterable as a group |
+| `domain_uuids` | array | No | Domain UUIDs to assign this monitor to — the agent-onboarding playbook passes the footprint's single resolved domain on every create (see agent-monitor-creation.md conventions) |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 

--- a/skills/monitoring-advisor/references/agent-validation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-validation-monitor.md
@@ -57,6 +57,7 @@ or to alert on span sequences / call counts (use
 | `is_agent_trace_aggregation` | boolean | No | Aggregate per trace for trace-level assertions (OTel only) |
 | `schedule_type` | string | No | `fixed` (default) or `manual` |
 | `interval_minutes` | int | No | Default `60`; at least 5 |
+| `tags` | array | No | Key-value tags, e.g. `[{"name": "agent", "value": "Support Bot"}]`. Tag every agent monitor with its agent's name — `{"name": "agent", "value": "<AGENT_NAME>"}` — so all of one agent's monitors are filterable as a group |
 | `monitor_uuid` | string | No | UUID of an existing monitor to update in place (PUT semantics) |
 | `dry_run` | boolean | No | Default `True` — preview YAML; set `False` to deploy |
 
@@ -171,6 +172,7 @@ create_or_update_agent_validation_monitor(
     description="Alert when total_tokens exceeds 10000",
     agent="analytics:agents.support_bot",
     warehouse="Analytics WH",
+    tags=[{"name": "agent", "value": "Support Bot"}],
     alert_condition={
         "operator": "AND",
         "conditions": [

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -66,6 +66,8 @@ Use the `domains` list on the `get_table` response (each entry has `uuid` and `n
 
 Do NOT present all account domains as options when the table already has domains listed -- prefer domains that contain the table.
 
+**Agent-onboarding context.** If this create is part of an agent-onboarding flow (the table is a customer agent's upstream/golden table and an agent is in scope — e.g. you arrived here from the Context pillar of `agent-monitor-creation.md`), every monitor you create must carry that agent's footprint tag `tags=[{"name": "agent", "value": "<AGENT_NAME>"}]` (display name from the onboarding flow, verbatim) and reuse the same `audiences` and `domain_uuids` the agent's monitors use — this keeps the agent's whole footprint retrievable with a single tag filter (`get_monitors(tags=["agent:<AGENT_NAME>"])`). Outside an agent-onboarding flow, do NOT add an `agent` tag.
+
 ### Step 3b: Ground thresholds and predicates in real data (profiling)
 
 Verified column names are not enough. Schema alone does not tell you whether a column is mostly-null, whether a status code is truly a closed set, or whether a numeric range is stable enough to alert on. Profiling once up front is the difference between a useful monitor and a noisy one the user mutes the next day.

--- a/skills/monitoring-advisor/references/data-monitor-creation.md
+++ b/skills/monitoring-advisor/references/data-monitor-creation.md
@@ -66,7 +66,7 @@ Use the `domains` list on the `get_table` response (each entry has `uuid` and `n
 
 Do NOT present all account domains as options when the table already has domains listed -- prefer domains that contain the table.
 
-**Agent-onboarding context.** If this create is part of an agent-onboarding flow (the table is a customer agent's upstream/golden table and an agent is in scope — e.g. you arrived here from the Context pillar of `agent-monitor-creation.md`), every monitor you create must carry that agent's footprint tag `tags=[{"name": "agent", "value": "<AGENT_NAME>"}]` (display name from the onboarding flow, verbatim) and reuse the same `audiences` and `domain_uuids` the agent's monitors use — this keeps the agent's whole footprint retrievable with a single tag filter (`get_monitors(tags=["agent:<AGENT_NAME>"])`). Outside an agent-onboarding flow, do NOT add an `agent` tag.
+**Agent-onboarding context.** If this create is part of an agent-onboarding flow (the table is a customer agent's upstream/golden table and an agent is in scope — e.g. you arrived here from the Context pillar of `agent-monitor-creation.md`), every monitor you create must carry that agent's footprint tag `tags=[{"name": "agent", "value": "<AGENT_NAME>"}]` (display name from the onboarding flow, verbatim) and reuse the same `audiences` and `domain_uuids` the agent's monitors use — this keeps the agent's whole footprint retrievable with a single tag filter (`get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`). Outside an agent-onboarding flow, do NOT add an `agent` tag.
 
 ### Step 3b: Ground thresholds and predicates in real data (profiling)
 


### PR DESCRIPTION
# Changes

Toolkit mirror of monte-carlo-data/ai-agent#1797 (AI-651) — agent-onboarding monitor conventions for the monitoring-advisor skill, bumped to **v1.19.0**.

- **`agent-monitor-creation.md`**: new "Monitor conventions — every monitor in this playbook" block — every monitor the POBC playbook creates (agent monitors AND Context-pillar warehouse DQ monitors) carries the `agent:{AGENT_NAME}` footprint tag (display name from `get_agent_metadata`, verbatim); audit/teardown via `get_monitors(monitor_tags=["agent:<AGENT_NAME>"])`; audiences asked ONCE before the first create (`get_audiences` for options, names not UUIDs) and applied to every monitor with `failure_audiences` defaulting to the same selection; one domain across the footprint. Step 4's audience item now applies the playbook-level selection instead of re-asking per monitor.
- **`agent-validation-monitor.md`**: missing `tags` parameter row + tag in the first example (metric/evaluation/trajectory already had rows via #107/#108).
- **`data-monitor-creation.md`**: agent-onboarding conditional — DQ monitors created for an agent's upstream tables carry the agent tag + shared audiences/domain; outside an onboarding flow, do NOT add an `agent` tag.

Toolkit adaptations vs the ai-agent source: the audience ask is conversational (no `ask_user` picker in the toolkit), and domain resolution defers to `data-monitor-creation.md`'s existing domain-assignment steps.

## Context

- Linear: [AI-651](https://linear.app/montecarlodata/issue/AI-651) — part of the AI-644 POBC onboarding playbook
- Source of truth: monte-carlo-data/ai-agent#1797 — **merge this PR after that one** so the toolkit never documents conventions the agent doesn't follow yet

## Verification

- validate.yml checks pass locally (no symlinks under hooks; shared libs in sync)
- `bump-version.sh minor` — clean 1.18.1 → 1.19.0, all 6 plugin configs + changelogs updated
- [x] Ran `/code-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

