### PR TITLE
AI-650: Context pillar — manual golden tables → tagged DQ monitors → optional Context DP in monitoring-advisor (v1.20.0)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.19.0",
+    "version": "1.20.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.19.0",
+    "version": "1.20.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-07-22
+
+### Changed
+
+- monitoring-advisor: Context pillar upgraded from a recommendation to an executable flow — user-named upstream tables → tagged freshness/schema/volume table monitors → optional `Context for {AGENT_NAME}` data product wrapper (dry-run footprint preview first; Data Mesh rejection keeps the monitors) → field-level depth via the data-monitor references; `create_or_update_data_product` added to the skill tool tables (AI-650)
+
 ## [1.19.0] - 2026-07-21
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/SKILL.md
+++ b/skills/monitoring-advisor/SKILL.md
@@ -101,6 +101,12 @@ All five tools follow a **two-call preview-then-confirm pattern**: the first cal
 | `create_or_update_sql_monitor` | Create or update a custom SQL monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 | `create_or_update_comparison_monitor` | Create or update a comparison monitor (preview YAML on `dry_run=True`, deploy on `dry_run=False`) |
 
+### Data product tool
+
+| Tool | Purpose |
+| --- | --- |
+| `create_or_update_data_product` | Create or update a data product — a named grouping of warehouse assets with reliability tracking (asset-footprint preview on `dry_run=True`, live create on `dry_run=False`). Used by the agent Context pillar to wrap an agent's upstream tables (see `references/agent-monitor-creation.md`) |
+
 ### Agent monitoring tools
 
 | Tool | Purpose |

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -243,14 +243,18 @@ tables:
    tables' `mcons` (from `search` / `get_table` — do not guess them) and a
    `description` naming the agent. Keep the default `dry_run=True` to show
    the asset-footprint preview; set `dry_run=False` only on explicit
-   confirmation. Two caveats: data products take `audience_ids` — UUIDs
-   from `get_audiences` — unlike monitors, which take audience names; and
-   the data product itself carries no `agent` tag (the footprint contract
-   rides on the monitors). If the live create is rejected because the
-   account lacks the Data Mesh module, that is terminal for the wrapper:
-   say so in one line (their Monte Carlo representative can enable it) and
-   keep the table monitors — the data product is packaging; the monitors
-   are the pillar.
+   confirmation. The preview's asset count can exceed the tables you
+   named — the tool's backend automatically expands the footprint to
+   include their upstream dependencies. When the count is notably larger
+   than the named set, explain to the user what is being added before
+   asking them to confirm the live create. Two caveats: data products
+   take `audience_ids` — UUIDs from `get_audiences` — unlike monitors,
+   which take audience names; and the data product itself carries no
+   `agent` tag (the footprint contract rides on the monitors). If the
+   live create is rejected because the account lacks the Data Mesh
+   module, that is terminal for the wrapper: say so in one line (their
+   Monte Carlo representative can enable it) and keep the table monitors
+   — the data product is packaging; the monitors are the pillar.
 3. **Add field-level depth** where the user wants specific field checks
    (null rates, distributions, custom rules) on an upstream table: use the
    data-monitor workflow's field-level references (`data-metric-monitor.md`,

--- a/skills/monitoring-advisor/references/agent-monitor-creation.md
+++ b/skills/monitoring-advisor/references/agent-monitor-creation.md
@@ -212,7 +212,7 @@ What each pillar maps to:
 | **Performance** | Metric (validation for hard limits) — latency (`duration_sec`), token cost (`total_tokens`), error rate (`status_code`), volume (`ROW_COUNT_CHANGE`) | `agent-metric-monitor.md` |
 | **Output** | Evaluation — lead with the Output-pillar starting packs (see Step 3): baseline pack for every agent, analytics pack for Cortex/Genie. Add predefined judges (`answer_relevance`, `task_completion`, `clarity`, `prompt_adherence`), rule checks (`output_length`, `json_validity`), and one custom eval per recurring user intent or failure mode you observed | `agent-evaluation-monitor.md` |
 | **Behavior** | Trajectory (validation for aggregate assertions) — runaway loops (`SPAN_OCCURRENCE`), missing or mis-ordered steps (`SPAN_RELATION`), token budgets | `agent-trajectory-monitor.md`, `agent-validation-monitor.md` |
-| **Context** | Data-quality monitors on the agent's upstream tables — see below | — |
+| **Context** | Table monitors (freshness / schema changes / volume) on the agent's upstream tables, plus an optional `Context for {AGENT_NAME}` data product wrapper — see below | `data-table-monitor.md` |
 
 Mind the backend caveats from Step 1 (`backend_class`): no token or model
 metrics for Genie / Knowledge Assistant agents, and conversation-grain evals
@@ -221,12 +221,45 @@ validation assertions require `is_agent_trace_aggregation=True`, supported
 only on `ao_clickhouse_otel` / `customer_otel_trace_table` agents — on other
 backends, use per-span assertions instead.
 
-**Context is a recommendation for now** — creating data-quality monitors from
-the agent's lineage is not wired into this flow yet. Present the pillar rather
-than skipping it: name it in the plan, ask the user which upstream tables the
-agent depends on, and suggest Monte Carlo's standard data-quality monitoring
-(freshness, volume, schema changes, anomalies) on those tables as a follow-up
-(the data-monitor workflow in this skill covers them).
+**Context — monitor the tables the agent reads.** Unlike the other pillars,
+Context coverage lives on warehouse tables, not spans. Automatic
+lineage-derived table discovery is not available on this surface, so ask the
+user which upstream tables the agent depends on (the tables its SQL tools
+query, its knowledge bases are built from, or its features are loaded from) —
+never guess table names, and never drop the pillar silently. On the named
+tables:
+
+1. **Create the table monitors** with `create_or_update_table_monitor`,
+   following `data-table-monitor.md` for warehouse resolution and asset
+   selection (scope as narrowly as that reference allows). The tool's
+   default alert conditions are exactly the Context coverage — freshness,
+   schema changes, and volume — so omit `alert_conditions` unless the user
+   asks for more. Apply the Monitor conventions above on every create: the
+   `agent` tag, the playbook `audiences`, and `domain_uuids`. Dry-run
+   preview first, deploy on explicit confirmation, like every other create
+   in this playbook.
+2. **Optionally wrap the tables in a data product** named
+   `Context for {AGENT_NAME}` via `create_or_update_data_product`: pass the
+   tables' `mcons` (from `search` / `get_table` — do not guess them) and a
+   `description` naming the agent. Keep the default `dry_run=True` to show
+   the asset-footprint preview; set `dry_run=False` only on explicit
+   confirmation. Two caveats: data products take `audience_ids` — UUIDs
+   from `get_audiences` — unlike monitors, which take audience names; and
+   the data product itself carries no `agent` tag (the footprint contract
+   rides on the monitors). If the live create is rejected because the
+   account lacks the Data Mesh module, that is terminal for the wrapper:
+   say so in one line (their Monte Carlo representative can enable it) and
+   keep the table monitors — the data product is packaging; the monitors
+   are the pillar.
+3. **Add field-level depth** where the user wants specific field checks
+   (null rates, distributions, custom rules) on an upstream table: use the
+   data-monitor workflow's field-level references (`data-metric-monitor.md`,
+   `data-validation-monitor.md`, `data-custom-sql-monitor.md`), carrying
+   the same tag, audiences, and domain on every create.
+
+If the user cannot name any upstream tables, present the pillar as a
+recommendation — name what you would monitor and why — rather than failing
+or silently dropping it.
 
 ### 3. Create the confirmed monitors
 


### PR DESCRIPTION
# Changes

Toolkit mirror of monte-carlo-data/ai-agent#1813 (AI-650) — the monitoring-advisor skill's Context pillar upgraded from "a recommendation for now" to an executable flow, bumped to **v1.20.0**.

- **`agent-monitor-creation.md`**: the Context pillar block now walks the flow on this surface — ask the user which upstream tables the agent depends on (automatic lineage-derived discovery is not available here: `get_agent_lineage` is internal-only and invisible on the public MCP toolset), then (1) tagged freshness/schema/volume table monitors via `create_or_update_table_monitor` (deferring to `data-table-monitor.md` for warehouse resolution and asset selection, which carries the K2-269 filters limitation), (2) an optional `Context for {AGENT_NAME}` data product via `create_or_update_data_product` (dry-run footprint preview first; `audience_ids` are UUIDs unlike monitors' audience names; Data Mesh rejection is terminal for the wrapper — keep the monitors), (3) field-level depth via the data-monitor field references. Empty table list → present the pillar as a recommendation, never drop it silently. Pillar table row updated to match.
- **`SKILL.md`**: new "Data product tool" table entry for `create_or_update_data_product` (default-toolset, toolkit-visible).
- **`chore: bump version to 1.20.0`** across all 6 plugin manifests + CHANGELOGs via `scripts/bump-version.sh minor`.

## Merge ordering

Merge **after** monte-carlo-data/ai-agent#1813 (established sibling-pillar pattern — the ai-agent skill is the source of truth this mirrors).

## Context

[AI-650](https://linear.app/montecarloai/issue/AI-650) — Context pillar (parent AI-644 POBC playbook); follows the AI-651 conventions block (#111) and the AI-645/646/647/648 sibling-pillar mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Ran `/code-review`
