### PR TITLE
docs(troubleshoot-agent-traces): symmetric flag-eval polarity + cortex side-resolution (AI-629 follow-up) — v1.20.2

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.20.1",
+    "version": "1.20.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.20.1",
+    "version": "1.20.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: follow-up to the AI-629 breaching-side guidance — the flag-eval side-resolution rule is now symmetric across `true_*`/`false_*` metrics and both breach directions (a rising `false_rate`, e.g. `content_safe`, breaches at the BOTTOM of the score range), quality scores breaching high are enumerated explicitly, and the Cortex backend reference defers to the shared side resolution instead of "worst-first" sampling.
+
 ## [1.20.1] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
@@ -56,13 +56,19 @@ says so. If the backend is not `ao_clickhouse_otel`, it is span/trace grain.
 3. **Identify the breaching set** — the items on the BREACHING side of the score inside
    the breach window. Resolve the side from the metric + breach direction first:
    - Quality scores breaching low (the common case): the lowest-scoring items.
-   - Boolean/flag evals (`true_*`/`false_*` aggregations — e.g. `escalation_suggested`
-     breaching on a `true_count`/`true_rate` rise): the items carrying the FAILING
-     value. For a true-family metric breaching high that is the flagged items
-     (score 1.0 / `true`) — the TOP of the score range. "Worst-scoring / bottom 10"
-     selects exactly the wrong side here.
+   - Quality scores breaching high (the score spiked above expected levels): the
+     highest-scoring items.
+   - Boolean/flag evals (`true_*`/`false_*` aggregations): the breaching items carry
+     the value whose share ROSE — the metric's tracked value when breaching high, its
+     complement when breaching low. `true` items sit at the TOP of the score range
+     (score 1.0), `false` items at the BOTTOM (score 0.0). So `escalation_suggested`
+     rising on a `true_count`/`true_rate` breaches at the TOP, while `content_safe`
+     breaching on a rising `false_rate` breaches at the BOTTOM — "worst-scoring /
+     bottom 10" selects exactly the wrong side for the former.
    - Inverted numerics (`mismatch_score`-style, breaching high): the highest scores.
+
    Then pull the items:
+
    - Trace grain: `get_agent_traces` filtered to the agent plus the alert's segment,
      within each anomalous bucket window.
    - Conversation grain: `get_agent_conversations` for the agent over the breach
@@ -71,10 +77,12 @@ says so. If the backend is not `ao_clickhouse_otel`, it is span/trace grain.
 
    > **CRITICAL:** Sampling seams can hand you non-breaching items. Check every item's
    > score against the alert's threshold before treating it as evidence. A known failure
-   > mode: a flag eval breaching on a true-count, sampled score-ascending "worst-first" —
-   > the flagged rows sit at the TOP scores, so the page's limit cut them off and seeded
-   > the investigation with perfectly-scoring conversations; the investigator then
-   > "confirmed normal behavior" while reading the wrong conversations entirely.
+   > mode: a flag eval breaching HIGH on a true-count, sampled score-ascending
+   > "worst-first" — its flagged rows sat at the TOP scores, so the page's limit cut
+   > them off and seeded the investigation with perfectly-scoring conversations; the
+   > investigator then "confirmed normal behavior" while reading the wrong conversations
+   > entirely. Any sample sorted toward the non-breaching side (step 3) fails the same
+   > way.
 
 5. **Read the judge's scores and stored reasoning first.** The persisted judgment is the
    truth for this alert. The stored reasoning (often a paragraph per item) frequently
@@ -123,7 +131,7 @@ evidence timeline. Merge rather than duplicate.
 
 | Mistake | Why it fails / what to do instead |
 |---|---|
-| Assuming breaching = lowest scores | The breaching side follows metric + direction: flag evals breaching on a true-count breach at the TOP scores — resolve the side before sampling |
+| Assuming breaching = lowest scores | The breaching side follows metric + direction (step 3): a flag eval breaching high on a true-count breaches at the TOP scores; a rising `false_rate` (e.g. `content_safe`) breaches at the BOTTOM — resolve the side before sampling |
 | Concluding from one conversation | Cluster several breaching items; one item proves nothing about the population |
 | Treating sampled items as breaching without checking scores | Sampling seams return non-breaching items; verify each score against the threshold |
 | Expecting conversation grain on a platform backend | Conversation-grain evaluation is `ao_clickhouse_otel`-only today |

--- a/skills/troubleshoot-agent-traces/references/agent-backend-cortex.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-cortex.md
@@ -51,8 +51,9 @@ config change broke it" question usually does.**
    aggregation. Did the breached metric *step* on a specific day (points at a config
    change that day) or drift? Never describe only the bad window.
 4. **Look at WHAT breached — and rule out a false positive.** Pull the flagged
-   conversations (`get_agent_conversations`, worst-first by the breached dimension) and
-   read them (`get_agent_conversation`). Decide: genuine problem (runaway tool loop,
+   conversations (`get_agent_conversations`, sampled from the breaching side of the score
+   per the metric + breach direction — see `agent-alert-evaluation.md` step 3) and read
+   them (`get_agent_conversation`). Decide: genuine problem (runaway tool loop,
    bloated answer, error spike) vs false positive (a legitimately long-but-correct
    conversation, an expected seasonal spike, a too-tight threshold). A breach the sample
    shows to be benign **is a finding** — say so and recommend adjusting the monitor.


### PR DESCRIPTION
# Changes

Code-review follow-up to #113 (AI-629 breaching-side guidance). The `/code-review` cycle on #113 found 3 issues + 1 suggestion, but the PR was merged just before the fix commit was pushed to its branch — so the fixes land here, cherry-picked onto main, with a fresh **v1.20.2** bump (the published 1.20.1 changelog entries are left untouched).

What the fixes do:

- **Symmetric flag-eval polarity (review F1, found independently by both correctness passes):** step 3 previously worked out only true-family-breaching-high → TOP. It now states the general rule — the breaching items carry the value whose share ROSE (tracked value on a high breach, its complement on a low breach; `true` = TOP / score 1.0, `false` = BOTTOM / score 0.0) — with `content_safe` breaching on a rising `false_rate` (BOTTOM) as the counter-example alongside `escalation_suggested` (TOP). That exact FALSE_RATE monitor is recommended by monitoring-advisor, so the asymmetric wording would have steered an agent to sample the wrong side. Step 4's CRITICAL and the common-mistakes row now carry the qualified rule too.
- **Quality scores breaching high (F2):** explicit bullet added — the doc's intro already acknowledged spike-above breaches but the side-resolution list had no case for them.
- **Cortex backend reference (F3):** `agent-backend-cortex.md` still said "worst-first by the breached dimension" — now defers to the shared side resolution in `agent-alert-evaluation.md` step 3, removing the contradiction #113 created within the skill.
- **CommonMark nesting (F4):** blank lines around "Then pull the items:" so the step-3 list renders as two groups instead of collapsing (verified with a pandoc render).

Version bumped to **v1.20.2** (all 6 plugin configs + changelogs via `bump-version.sh`).

## Context

- Review doc: `.work/ai-629-eval-doc-breaching-side/reviews/` (local); review ran on #113 head 406262e — reviewers devdocs/security/versioning/skills/correctness ×2 passes, security + versioning clean.
- [AI-629](https://linear.app/montecarloai/issue/AI-629/ttsa-conversation-grain-seed-must-select-the-breaching-side-of-eval)
- [x] Ran `/code-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
