### PR TITLE
docs(troubleshoot-agent-traces): platform-agent conversation clustering (AI-677)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-22
+
+### Changed
+
+- troubleshoot-agent-traces: platform-agent conversation clustering (AI-677) — backend references updated for the server's Cortex/Genie clustering coverage: ClickHouse "only backend with conversation-grain eval monitors" drift fixed, clustering signal bullets + cluster-first localization steps added to Cortex/Genie, customer-OTel/MLflow-SDK "managed-store-only" claims rescoped, eval-alert grain rules now name Cortex/Genie as conversation-grain capable
+
 ## [1.20.2] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
@@ -36,14 +36,16 @@ dimension you are investigating (e.g. `helpfulness_score`).
   depends on the metric and breach direction (step 3) — it is NOT always the lowest
   scores.
 
-> **CRITICAL:** Conversation-grain evaluation currently exists only for agents on Monte
-> Carlo's managed trace store (backend class `ao_clickhouse_otel`). On every other
-> backend, evaluation alerts are span/trace grain — do not go looking for breaching
+> **CRITICAL:** Conversation-grain evaluation exists for agents on Monte Carlo's managed
+> trace store (backend class `ao_clickhouse_otel`) and on the Snowflake Cortex /
+> Databricks Genie platform backends. On the other backends (MLflow SDK/KA, customer
+> OTel tables), evaluation alerts are span/trace grain — do not go looking for breaching
 > conversations there.
 
 To tell the grains apart: the monitor definition uses `*_conversation` judge variants
 and conversation aggregation at conversation grain, and the monitor description usually
-says so. If the backend is not `ao_clickhouse_otel`, it is span/trace grain.
+says so. If the backend is MLflow SDK/KA or a customer OTel table, it is span/trace
+grain.
 
 ## Investigation playbook
 
@@ -134,7 +136,7 @@ evidence timeline. Merge rather than duplicate.
 | Assuming breaching = lowest scores | The breaching side follows metric + direction (step 3): a flag eval breaching high on a true-count breaches at the TOP scores; a rising `false_rate` (e.g. `content_safe`) breaches at the BOTTOM — resolve the side before sampling |
 | Concluding from one conversation | Cluster several breaching items; one item proves nothing about the population |
 | Treating sampled items as breaching without checking scores | Sampling seams return non-breaching items; verify each score against the threshold |
-| Expecting conversation grain on a platform backend | Conversation-grain evaluation is `ao_clickhouse_otel`-only today |
+| Expecting conversation grain on MLflow or customer-OTel backends | Conversation-grain evaluation runs on the managed store and Cortex/Genie only — elsewhere alerts are span/trace grain |
 | Selecting an eval score from trace data on Genie/MLflow | The score lives on the alert/monitor, not in the spans |
 | Misreading `mismatch_score` | It is inverted — higher is worse |
 | Only reading breaching items | Always compare against pre-onset healthy items to isolate what changed |

--- a/skills/troubleshoot-agent-traces/references/agent-backend-clickhouse.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-clickhouse.md
@@ -22,9 +22,16 @@ a regression.**
 - **Workflow / task / model segmentation** — enumerate real segment values with
   `get_agent_segments`; group and sort traces with `get_agent_traces`.
 - **Conversations** — `get_agent_conversations` / `get_agent_conversation`, with
-  transcripts when the account's data-sampling settings allow content. This is the only
-  backend that supports **conversation-grain evaluation monitors**, so a breached eval
-  alert here may name whole conversations rather than traces.
+  transcripts when the account's data-sampling settings allow content.
+  **Conversation-grain evaluation monitors** run here (and on the Snowflake Cortex and
+  Databricks Genie platform backends), so a breached eval alert may name whole
+  conversations rather than traces.
+- **Conversation clustering** — when the account has clustering enabled for this agent,
+  Monte Carlo groups its conversations into an intent-cluster taxonomy, shown alongside
+  the agent's conversations in the Monte Carlo UI. No toolkit tool reads clusters
+  directly: point the user at the cluster view to see which *kind* of conversations a
+  regression concentrates in, or hand off to `run_troubleshooting_agent`, which uses
+  cluster-share shifts as evidence.
 - **Change correlation** — this is a code agent: when the customer has GitHub connected,
   correlate the onset with merged PRs and deploys.
 

--- a/skills/troubleshoot-agent-traces/references/agent-backend-cortex.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-cortex.md
@@ -21,7 +21,14 @@ config change broke it" question usually does.**
   history and the primary change-correlation signal.
 - **Conversations** — `get_agent_conversations` (rank by tokens/duration/errors to find
   the expensive or failing ones) and `get_agent_conversation` for a full thread.
-  Transcript content is consent-gated (see Gotchas).
+  Transcript content is consent-gated (see Gotchas). **Conversation-grain evaluation
+  monitors** run on this backend, so a breached eval alert may name whole conversations.
+- **Conversation clustering** — when the account has clustering enabled for this agent,
+  Monte Carlo groups its conversations into an intent-cluster taxonomy, shown alongside
+  the agent's conversations in the Monte Carlo UI. No toolkit tool reads clusters
+  directly: point the user at the cluster view to see which *kind* of conversations a
+  regression concentrates in, or hand off to `run_troubleshooting_agent`, which uses
+  cluster-share shifts as evidence.
 - **Data lineage bridge** — the agent's generated SQL queries real source tables; a
   freshness/volume/schema incident on a source table (check `get_alerts`) is a data
   root cause only Monte Carlo can surface.
@@ -57,6 +64,9 @@ config change broke it" question usually does.**
    bloated answer, error spike) vs false positive (a legitimately long-but-correct
    conversation, an expected seasonal spike, a too-tight threshold). A breach the sample
    shows to be benign **is a finding** — say so and recommend adjusting the monitor.
+   When clustering is enabled for the agent, localize first: a cluster whose share moved
+   in the breach window tells you which kind of conversations to sample (cluster view in
+   the UI, or the automated run's cluster evidence).
 5. **Bridge to the data.** Identify the source tables the agent queried and check
    `get_alerts` for incidents on them — a data incident upstream explains a quality drop
    better than anything in the agent itself.

--- a/skills/troubleshoot-agent-traces/references/agent-backend-customer-otel.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-customer-otel.md
@@ -30,7 +30,8 @@ regressions. Rule out a feed gap before calling anything an agent problem.**
 - **Nothing structural vs the managed OTel store** — the normalized vocabulary is the
   same; the difference is the store, not the signal.
 - **Conversation-grain eval breaches and conversation clustering** exist only on the
-  Monte Carlo–managed store — eval alerts here resolve at trace/span grain.
+  Monte Carlo–managed store and the Cortex/Genie platform backends — eval alerts here
+  resolve at trace/span grain.
 - **No built-in previous-period baseline** — construct your own before/after comparison
   window, exactly as on the managed store.
 

--- a/skills/troubleshoot-agent-traces/references/agent-backend-genie.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-genie.md
@@ -18,6 +18,14 @@ findings.**
   shows this shape — it is the whole story for a turn.
 - **Native conversation grouping** — every span carries a real conversation id;
   `get_agent_conversations` / `get_agent_conversation` reconstruct multi-turn threads.
+  **Conversation-grain evaluation monitors** run on this backend, so a breached eval
+  alert may name whole conversations.
+- **Conversation clustering** — when the account has clustering enabled for this space,
+  Monte Carlo groups its conversations into an intent-cluster taxonomy, shown alongside
+  the space's conversations in the Monte Carlo UI. No toolkit tool reads clusters
+  directly: point the user at the cluster view to see which *kind* of questions a
+  regression concentrates in, or hand off to `run_troubleshooting_agent`, which uses
+  cluster-share shifts as evidence.
 - **Per-turn failure status**, and for failed turns the **recorded Genie error** (a real
   error type and message captured by the collector) surfaced in the span's attributes —
   not just a generic failure wrapper.
@@ -57,7 +65,10 @@ findings.**
    flagged conversation's question / answer / generated SQL with
    `get_agent_conversation` (content is consent-gated). Genuine problem (wrong NL2SQL
    translation, unfiltered scan, error spike) vs false positive (a legitimately hard
-   question, an expected spike, a too-tight threshold).
+   question, an expected spike, a too-tight threshold). When clustering is enabled for
+   the space, localize first: a cluster whose share moved in the breach window tells
+   you which kind of questions to sample (cluster view in the UI, or the automated
+   run's cluster evidence).
 5. **For FAILED turns, read the recorded error before hypothesizing.** The recorded
    error type/message in the failed turn's span attributes IS the literal root-cause
    signal (e.g. a schema-access error). Fall back to structural reasoning only when no

--- a/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-sdk.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-sdk.md
@@ -33,7 +33,7 @@ table yourself.**
 - **Eval scores are not in the spans** — quality scores are Monte Carlo–computed and
   live on the monitor/alert, not in trace data.
 - **Conversation clustering and conversation-grain eval breaches** exist only on the
-  Monte Carlo–managed OTel store.
+  Monte Carlo–managed OTel store and the Cortex/Genie platform backends.
 - **Raw content is consent-gated** — without the account's data-sampling consent,
   reason from span taxonomy, status, token distribution, and per-node latency.
 


### PR DESCRIPTION
# Changes

Doc sync for [AI-677](https://linear.app/montecarloai/issue/AI-677): the server now supports Conversation Clustering for platform agents (AO-855/859/861), and TTSA attaches its clustering evidence tools on Cortex/Genie conversation-grain runs (monte-carlo-data/ai-agent companion PR). The troubleshoot-agent-traces backend references still claimed conversation-grain evaluation and clustering were managed-store (ClickHouse) only.

- `agent-backend-cortex.md` / `agent-backend-genie.md`: conversation-grain evaluation monitors noted on the Conversations bullet; new **Conversation clustering** bullet (intent-cluster taxonomy in the MC UI; no toolkit tool reads clusters — point the user at the cluster view or hand off to `run_troubleshooting_agent`, which uses cluster-share shifts as evidence); investigation step 4 gains a "localize first via cluster shares" sentence.
- `agent-backend-clickhouse.md`: conversation-grain bullet rescoped ("and on the Snowflake Cortex and Databricks Genie platform backends"); same clustering bullet added.
- `agent-backend-customer-otel.md` / `agent-backend-mlflow-sdk.md`: conversation-grain existence claim rescoped to managed store **and Cortex/Genie**.
- `agent-alert-evaluation.md`: CRITICAL grain callout + grain-detection paragraph + common-mistakes row updated to the same backend set (this file had drifted from AI-606 too and would have contradicted the new backend refs).
- Version bump to 1.20.3 (all 6 plugin manifests + changelogs).

No tool named: verified NO clustering MCP tool exists in mcp-server on any toolset — the docs deliberately describe the UI cluster view + TTSA hand-off only.

## Merge ordering

Merge AFTER monte-carlo-data/ai-agent#1832 — these docs describe the TTSA behavior that PR ships.

## Verification

- All 6 `plugin.json` + 6 `CHANGELOG.md` at 1.20.3; diff reviewed.
- Stale-claim grep clean (no remaining "ClickHouse-only" clustering/conversation-grain claims in troubleshoot-agent-traces references).
