### PR TITLE
docs(troubleshoot-agent-traces): get_agent_trace is managed-store-only (AI-710) — v1.22.1

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+
+- troubleshoot-agent-traces: document that `get_agent_trace` (single-trace span tree)
+  reads only the Monte Carlo–managed OTel store (`ao_clickhouse_otel`) and errors on
+  the Cortex, Genie, customer-OTel, and MLflow backends. Backend guides, alert
+  playbooks, direct-trace intake, and the tool tables now route span-grain drill-down
+  on those backends through `run_troubleshooting_agent` (AI-710).
+
 ## [1.21.0] - 2026-07-22
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/troubleshoot-agent-traces/README.md
+++ b/skills/troubleshoot-agent-traces/README.md
@@ -23,7 +23,7 @@ Connect to Monte Carlo's MCP server (`integrations.getmontecarlo.com/mcp`). The 
 | `alert_assessment` | Optional ~2-min triage of an alert (HIGH/MEDIUM/LOW confidence + impact) |
 | `get_agent_metadata` | List AI agents — names, trace tables, backend classes, source types, warehouses |
 | `get_agent_traces` | List traces with workflows, tasks, models, tokens, duration, error counts |
-| `get_agent_trace` | Inspect one execution trace's full span tree |
+| `get_agent_trace` | Inspect one execution trace's full span tree (managed OTel store agents only — errors on other backends) |
 | `get_agent_conversations` | List recent conversations for an agent (filterable) |
 | `get_agent_conversation` | One conversation's full prompt/completion thread |
 | `get_agent_segments` | Distinct workflow / task / model values for segment isolation |

--- a/skills/troubleshoot-agent-traces/SKILL.md
+++ b/skills/troubleshoot-agent-traces/SKILL.md
@@ -70,7 +70,7 @@ The Step 2 gate uses the `get_alert_agent_classification` tool. If that tool is 
 |------|---------|
 | `get_agent_metadata` | List AI agents — names, trace tables, backend classes, source types, warehouses |
 | `get_agent_traces` | List traces with per-trace workflows, tasks, models, LLM-call counts, tokens, duration, and error counts |
-| `get_agent_trace` | Inspect one execution trace's full span tree |
+| `get_agent_trace` | Inspect one execution trace's full span tree — **managed OTel store (`ao_clickhouse_otel`) agents only**; on other backends the call errors. Span-grain depth there comes from `run_troubleshooting_agent`; manual reads stop at trace grain (`get_agent_traces`) |
 | `get_agent_conversations` | List recent conversations for an agent (filter by errors/status/turns/tokens/duration; optional inline transcripts) |
 | `get_agent_conversation` | Retrieve one conversation's full prompt/completion thread |
 | `get_agent_segments` | Enumerate the distinct `workflow` / `task` / `model` values — the segment axes for isolating a regression |

--- a/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-evaluation.md
@@ -91,7 +91,8 @@ grain.
    names the failure mode outright — when it already explains the regression, capture it
    and stop drilling.
 6. **Read the actual items.** `get_agent_conversation` per conversation (conversation
-   grain) or `get_agent_trace` per trace (trace grain). Read the breaching items AND a
+   grain) or `get_agent_trace` per trace (trace grain; managed-store (`ao_clickhouse_otel`)
+   agents only — on other backends it errors, see the backend guide). Read the breaching items AND a
    few healthy items from before the breach began — the comparison is what isolates what
    changed. Note: raw content (prompts, completions, transcripts) is gated on the
    account's data-sampling consent; without it, reason from structure (span taxonomy,

--- a/skills/troubleshoot-agent-traces/references/agent-alert-metric.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-metric.md
@@ -66,7 +66,9 @@ investigation should start scoped to it.
 7. **Drill into exemplar traces.** `get_agent_trace` on two or three of the worst
    traces from the breach window and one or two healthy traces from before the onset.
    Compare span by span: where does the time go, where do the tokens go, which span
-   grew or started failing.
+   grew or started failing. (`get_agent_trace` reads managed-store (`ao_clickhouse_otel`)
+   agents only — on other backends it errors; get span-grain depth from
+   `run_troubleshooting_agent`, per the backend guide.)
 
 ## Reading the results
 

--- a/skills/troubleshoot-agent-traces/references/agent-alert-trajectory.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-trajectory.md
@@ -60,8 +60,10 @@ decision path changed.
    > now".
 
 6. **Diff violating vs compliant.** `get_agent_trace` on candidate violating traces AND
-   on a compliant trace from the same workflow. Answer concretely: WHICH expected span
-   is missing, out of order, or repeated too many/few times?
+   on a compliant trace from the same workflow (managed-store (`ao_clickhouse_otel`)
+   agents only — on other backends it errors; get the span-shape view from
+   `run_troubleshooting_agent`, per the backend guide). Answer concretely: WHICH
+   expected span is missing, out of order, or repeated too many/few times?
 7. **Commonality and onset.** What do the violating traces share (workflow, task, input
    kind, user) that compliant traces don't? Since WHEN do violations appear — compare
    against earlier traces of the same workflow to date the onset.

--- a/skills/troubleshoot-agent-traces/references/agent-alert-validation.md
+++ b/skills/troubleshoot-agent-traces/references/agent-alert-validation.md
@@ -53,7 +53,9 @@ the rule looks back **about one hour** from each run, not a whole day.
    assertion's signal — error status, span name, workflow/task, token or duration
    thresholds — over the window ending at the alert's timestamp (default lookback about
    one hour). Anchor to the alert's own time, not to "now".
-5. **Identify the span-level cause.** `get_agent_trace` per offending trace:
+5. **Identify the span-level cause.** `get_agent_trace` per offending trace
+   (managed-store (`ao_clickhouse_otel`) agents only — on other backends it errors;
+   get span-grain detail from `run_troubleshooting_agent`, per the backend guide):
    - Hard failure: locate the failed spans in the tree; in a cascade of failures the
      root cause is usually the **earliest or innermost** failing span.
    - Content assertion: read what the breaching spans' outputs actually contain that

--- a/skills/troubleshoot-agent-traces/references/agent-backend-customer-otel.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-customer-otel.md
@@ -4,10 +4,12 @@
 
 A **customer-owned Snowflake table** holding raw OpenTelemetry export from a
 code agent the customer instrumented themselves. Monte Carlo normalizes it to the same
-standard span vocabulary as the managed OTel store, so the standard reads
-(`get_agent_traces`, `get_agent_trace`, conversations, segments) all work the same way.
-Investigation shape is essentially the managed-OTel playbook — what differs is where the
-data lives and who feeds it.
+standard span vocabulary as the managed OTel store, so the standard list/aggregate reads
+(`get_agent_traces`, conversations, segments) all work the same way. The exception is
+`get_agent_trace`: the single-trace span-tree read resolves only against the Monte
+Carlo–managed OTel store, so it errors on this backend — span-grain depth comes from
+`run_troubleshooting_agent` instead. Investigation shape is essentially the managed-OTel
+playbook — what differs is where the data lives and who feeds it.
 
 **CRITICAL: the trace table is the customer's — ingestion gaps on their side (a stalled
 export job, missing hours, a frozen latest-timestamp) can masquerade as agent
@@ -16,7 +18,10 @@ regressions. Rule out a feed gap before calling anything an agent problem.**
 ## Signal available here
 
 - **Full, real span tree** with parent/child structure, timing, and error detail
-  (including exception type/message) — via `get_agent_trace`.
+  (including exception type/message) — captured in the normalized data. There is no
+  direct MCP span-tree read here (`get_agent_trace` is managed-store-only): span-grain
+  drill-down goes through `run_troubleshooting_agent`, which queries the trace table
+  server-side.
 - **Model per span and token counts** — model-swap, cost, and context-overflow questions
   have answers.
 - **Workflow / task / model segmentation** — `get_agent_segments`, `get_agent_traces`.
@@ -27,8 +32,9 @@ regressions. Rule out a feed gap before calling anything an agent problem.**
 
 ## Absent by design — do not chase
 
-- **Nothing structural vs the managed OTel store** — the normalized vocabulary is the
-  same; the difference is the store, not the signal.
+- **Nothing structural vs the managed OTel store in the data** — the normalized
+  vocabulary is the same; the difference is the store, not the signal. (Tooling does
+  differ in one way: `get_agent_trace` reads only the managed store — see above.)
 - **Conversation-grain eval breaches and conversation clustering** exist only on the
   Monte Carlo–managed store and the Cortex/Genie platform backends — eval alerts here
   resolve at trace/span grain.
@@ -47,8 +53,11 @@ regressions. Rule out a feed gap before calling anything an agent problem.**
    decide step vs drift.
 4. **Classify errors before hypothesizing** — provider rejection, timeout, fast-fail,
    parse failure, code exception, slow-but-healthy.
-5. **On a known-bad trace**, list its failed spans in order with `get_agent_trace`; the
-   root cause is usually the earliest or innermost failure. Read the actual error text.
+5. **On a known-bad trace**, get the failed-spans-in-order view from the automated run
+   (`run_troubleshooting_agent` — `get_agent_trace` errors on this backend); the root
+   cause is usually the earliest or innermost failure. Read the actual error text.
+   Manual MCP reads stop at trace grain (`get_agent_traces` — per-trace status and
+   error counts).
 6. **Compare content across cohorts** when the account's data-sampling settings allow —
    breaching vs pre-onset.
 7. **Correlate with changes** — PRs merged before the onset (wide margins for deploy

--- a/skills/troubleshoot-agent-traces/references/agent-backend-genie.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-genie.md
@@ -14,8 +14,9 @@ findings.**
 ## Signal available here
 
 - **Turn-grain records** shaped as a shallow two-level tree: a root turn span (the NL
-  question and the answer) with one child per generated SQL statement. `get_agent_trace`
-  shows this shape — it is the whole story for a turn.
+  question and the answer) with one child per generated SQL statement — the whole story
+  for a turn. Read turns through the conversation tools (`get_agent_trace` does not
+  read this backend — it is a managed-store-only tool and errors here).
 - **Native conversation grouping** — every span carries a real conversation id;
   `get_agent_conversations` / `get_agent_conversation` reconstruct multi-turn threads.
   **Conversation-grain evaluation monitors** run on this backend, so a breached eval

--- a/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-ka.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-ka.md
@@ -14,8 +14,10 @@ model-swap question has no answer on this backend. Never chase token anomalies.*
 
 ## Signal available here
 
-- **Per-turn traces** — `get_agent_trace` shows the turn: a root span with the question
-  and final answer, chain steps, and retriever tool-call spans.
+- **Per-turn traces** — each trace is one turn: a root span with the question and final
+  answer, chain steps, and retriever tool-call spans. (`get_agent_trace` does not read
+  this backend — it errors; span-grain detail comes from `run_troubleshooting_agent`,
+  and manual reads work at turn grain via `get_agent_traces`.)
 - **Retrieval grounding (the differentiator)** — the retriever spans' tool-call output
   holds the retrieved document chunks. What was asked, what was retrieved, and whether
   the answer was grounded in it is THE signal on this backend. Chunk content is
@@ -34,8 +36,7 @@ model-swap question has no answer on this backend. Never chase token anomalies.*
 - **Conversation grouping is usually absent** — `conversation_id` is frequently null;
   each trace is then a standalone turn. Do not rely on conversation reads
   (`get_agent_conversations` / `get_agent_conversation` may come back empty — that is
-  expected, not a data problem; work at turn grain with `get_agent_traces` /
-  `get_agent_trace` instead).
+  expected, not a data problem; work at turn grain with `get_agent_traces` instead).
 - **Eval scores are not in the spans** — quality scores are Monte Carlo–computed and
   live on the monitor/alert.
 - **No SQL and no lineage** — a Knowledge Assistant generates no SQL, so there are no

--- a/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-sdk.md
+++ b/skills/troubleshoot-agent-traces/references/agent-backend-mlflow-sdk.md
@@ -16,7 +16,10 @@ table yourself.**
 ## Signal available here
 
 - **Real multi-span trace tree** with parent/child structure, per-span timing, and
-  status — via `get_agent_trace`.
+  status — captured in the normalized data. There is no direct MCP span-tree read here
+  (`get_agent_trace` is managed-store-only and errors on this backend): span-grain
+  drill-down goes through `run_troubleshooting_agent`; manual reads work at trace
+  grain via `get_agent_traces`.
 - **Model and token counts per span** — model-swap, cost, and context-growth questions
   have answers here (unlike Genie and the Knowledge Assistant).
 - **Workflow / task segmentation** — customer-set attributes broadcast trace-wide;
@@ -49,8 +52,10 @@ table yourself.**
    (`get_agent_segments`); a regression confined to one node or one model is a
    different root cause than a fleet-wide one.
 4. **Classify errors before hypothesizing** — provider rejection, timeout, fast-fail,
-   parse failure, code exception, slow-but-healthy — and on a known-bad trace list its
-   failed spans in order with `get_agent_trace` (earliest/innermost failure first).
+   parse failure, code exception, slow-but-healthy — and get a known-bad trace's
+   failed-spans-in-order view from the automated run (`run_troubleshooting_agent`;
+   earliest/innermost failure first). `get_agent_trace` errors on this backend —
+   manual MCP reads stop at trace grain.
 5. **Compare content across cohorts** when consent allows — breaching vs pre-onset
    prompts and completions.
 6. **Correlate with changes** — PRs merged before the onset, provider status pages,

--- a/skills/troubleshoot-agent-traces/references/agent-direct-trace.md
+++ b/skills/troubleshoot-agent-traces/references/agent-direct-trace.md
@@ -48,10 +48,13 @@ No matching alert — manual investigation, strictly scoped to what the user bro
 - **`trace_id`** → `get_agent_trace`: read the span tree. Failed spans first — in a
   cascade of failures the root cause is usually the earliest or innermost failing span.
   Then timing (where the duration goes), token counts per span, and the model on each
-  LLM span.
+  LLM span. (Managed-store (`ao_clickhouse_otel`) agents only — on other backends
+  `get_agent_trace` errors; work from `get_agent_traces` — per-trace status, error
+  counts, tokens, duration — and the conversation reads. This path has no automated
+  run to lean on.)
 - **`conversation_id`** → `get_agent_conversation`: read the thread turn by turn, find
   the turn where things went wrong, then `get_agent_trace` on that turn's trace for the
-  span-level view.
+  span-level view (managed-store agents only — see above).
 - **Description only** → `get_agent_traces` filtered by the described symptom (errors,
   latency, the time window the user gives) to find candidate traces first, then drill
   in as above.


### PR DESCRIPTION
## What

Corrects the `troubleshoot-agent-traces` skill's claims about `get_agent_trace` (the single-trace span-tree MCP tool): it resolves via the AO trace store, which serves only MC-ingested ClickHouse spans, so it **errors on every backend other than `ao_clickhouse_otel`** (Cortex, Genie, customer-OTel, MLflow SDK, MLflow KA). The skill previously told agents to call it on all of those backends.

- Backend guides (`agent-backend-customer-otel/genie/mlflow-sdk/mlflow-ka.md`): span-tree signal re-attributed to the normalized data; span-grain drill-down routed through `run_troubleshooting_agent` (TTSA queries the trace store server-side); manual MCP reads documented as trace-grain (`get_agent_traces`).
- Alert playbooks (`agent-alert-metric/evaluation/trajectory/validation.md`) + `agent-direct-trace.md`: `get_agent_trace` steps qualified as managed-store-only with the backend-guide redirect (direct-trace path notes it has no automated run to lean on).
- `SKILL.md` / `README.md` tool tables: backend qualification on the `get_agent_trace` row.
- Patch bump → v1.22.1 (all 6 plugin manifests + changelogs; re-versioned from v1.21.1 after main took v1.22.0 for reinforce-agent).

`agent-backend-clickhouse.md` and all `get_agent_traces` (plural) usages are untouched — they remain correct.

## Context

Toolkit follow-up to ai-agent AI-710 item 1, which gates TTSA's own binding of `get_agent_trace` on the same fact (the AI-696 turn audit caught the tool 400ing off-ClickHouse). Linear: [AI-710](https://linear.app/montecarlodata/issue/AI-710).

**Merge after** monte-carlo-data/ai-agent#1875 (merge-after convention for agent/toolkit doc sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
