### PR TITLE
refactor(reinforce-agent): rename skill tool refs to reinforcement loop (ORB-444)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.1",
+    "version": "1.22.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.1",
+    "version": "1.22.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-07-27
+
+### Changed
+
+- reinforce-agent: renamed the Monte Carlo tools the skill calls to their reinforcement loop names — `get_agent_health_summaries` → `get_reinforcement_loop_summaries` and `get_agent_health` → `get_reinforcement_loop_report` — and rebranded the skill guidance from "agent-health" to "reinforcement loop" (ORB-444).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/reinforce-agent/SKILL.md
+++ b/skills/reinforce-agent/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: monte-carlo-reinforce-agent
 description: |
-  Reinforces an AI agent by turning Monte Carlo's agent-health diagnosis into code fixes.
-  Reads the daily health report for an agent's workflows, ranks the diagnosed issues, proposes
+  Reinforces an AI agent by turning Monte Carlo's reinforcement loop diagnosis into code fixes.
+  Reads the daily reinforcement loop report for an agent's workflows, ranks the diagnosed issues, proposes
   what to fix, and — with the user's approval at each step — opens a pull request. Activates on
   "fix my agent", "improve my agent's health", "reinforce my agent", "what should I fix in my
   agent". Not for investigating a specific agent alert or trace (monte-carlo-troubleshoot-agent-traces),
@@ -12,8 +12,8 @@ when_to_use: |
   Use when the user wants to act on an AI agent's diagnosed health problems and land fixes:
   "fix my agent", "reinforce my agent", "improve my agent's health", "what should I fix in
   <agent>", "open a PR for my agent's top issue". Expects the user to name the agent; if they
-  don't, it lists available agents and asks. The flow is user-gated: it surfaces the health
-  diagnosis and asks which workflow to dig into and which issue to fix before writing any code.
+  don't, it lists available agents and asks. The flow is user-gated: it surfaces the reinforcement
+  loop diagnosis and asks which workflow to dig into and which issue to fix before writing any code.
   Do NOT use for:
   - investigating a single agent alert or trace (eval drop, latency spike, one trace id) —
     use monte-carlo-troubleshoot-agent-traces
@@ -24,8 +24,8 @@ bucket: Incident Response
 
 # Monte Carlo Reinforce Agent Skill
 
-This skill turns Monte Carlo's **agent-health diagnosis** into landed code fixes. Monte Carlo runs a
-daily agent-health pipeline that analyzes an agent's traces and produces, per workflow, a report of
+This skill turns Monte Carlo's **reinforcement loop diagnosis** into landed code fixes. Monte Carlo runs a
+daily reinforcement loop pipeline that analyzes an agent's traces and produces, per workflow, a report of
 diagnosed issues — each with supporting evidence (trace deep-links, verifier checks) and recommended
 fixes. This skill reads that diagnosis, ranks it, proposes what to fix, and follows through with a
 pull request — pausing for the user's decision at each fan-out point.
@@ -33,17 +33,18 @@ pull request — pausing for the user's decision at each fan-out point.
 > **Monte Carlo tool routing (required):** Always call Monte Carlo MCP tools through this plugin's
 > bundled server, whose fully-qualified tool names are
 > `mcp__plugin_mc-agent-toolkit_monte-carlo-mcp__<tool>` (e.g.
-> `mcp__plugin_mc-agent-toolkit_monte-carlo-mcp__get_agent_health`). Bare tool names used in this
-> skill (`get_agent_metadata`, `get_agent_health_summaries`, `get_agent_health`) refer to that
-> bundled server. If the session also has a separately-configured `monte-carlo-mcp` server, do
+> `mcp__plugin_mc-agent-toolkit_monte-carlo-mcp__get_reinforcement_loop_report`). Bare tool names
+> used in this skill (`get_agent_metadata`, `get_reinforcement_loop_summaries`,
+> `get_reinforcement_loop_report`) refer to that bundled server. If the session also has a
+> separately-configured `monte-carlo-mcp` server, do
 > **not** route to it — it may point at a different endpoint or credentials.
 
 ## When to activate this skill
 
 Activate when the user:
 
-- Wants to fix or improve an AI agent based on its Monte Carlo health ("fix my agent", "reinforce
-  my agent", "improve my agent's health").
+- Wants to fix or improve an AI agent based on its Monte Carlo reinforcement loop ("fix my agent",
+  "reinforce my agent", "improve my agent's health").
 - Asks what to fix in an agent ("what are my agent's top issues", "what should I fix in <agent>").
 - Wants a PR that addresses an agent's diagnosed problems.
 
@@ -51,15 +52,15 @@ Activate when the user:
 
 - Investigating one agent **alert** or **trace** (eval-score drop, latency/token spike, a specific
   trace id) → use `monte-carlo-troubleshoot-agent-traces`. That skill investigates a single
-  incident; this one acts on the standing health diagnosis across a workflow and writes code.
+  incident; this one acts on the standing reinforcement loop diagnosis across a workflow and writes code.
 - Creating or tuning agent **monitors** → `monte-carlo-monitoring-advisor` / `tune-monitor`.
 - **Instrumenting** a new agent to emit traces → `monte-carlo-instrument-agent`.
 
 ## Prerequisites
 
 - Monte Carlo MCP server configured and authenticated, with agent observability enabled for the
-  account. If `get_agent_health_summaries` reports that agent health is not enabled, tell the user
-  the account isn't enrolled in the agent-health pipeline and stop.
+  account. If `get_reinforcement_loop_summaries` reports that the reinforcement loop is not enabled,
+  tell the user the account isn't enrolled in the reinforcement loop pipeline and stop.
 - A local checkout of the agent's codebase (this skill writes code and opens a PR against it). If
   the working directory isn't the agent's repo, ask the user for the path before Step 4.
 
@@ -67,20 +68,20 @@ Activate when the user:
 
 | Tool | Purpose |
 |------|---------|
-| `get_agent_metadata` | List AI agents with their canonical `agentName`, friendly `displayName`, `traceTableMcon`, source type, and warehouse. Used to **resolve the agent the user named** to the exact `agent_name` + `trace_table_mcon` the health tools require (match on canonical name *or* display name; disambiguate when several match) |
-| `get_agent_health_summaries` | Per-workflow health rollups for one agent — `issue_count` + worst-severity `health` + `detection_time` per workflow. The cheap triage layer; rank on this before expanding anything |
-| `get_agent_health` | The latest health report for **one** workflow, as a single actionable markdown brief — diagnosed issues with evidence (trace deep-links), recommended fixes, any existing Linear ticket, and any proposed monitor. The expensive call; fetch only for workflows the user chose |
+| `get_agent_metadata` | List AI agents with their canonical `agentName`, friendly `displayName`, `traceTableMcon`, source type, and warehouse. Used to **resolve the agent the user named** to the exact `agent_name` + `trace_table_mcon` the reinforcement loop tools require (match on canonical name *or* display name; disambiguate when several match) |
+| `get_reinforcement_loop_summaries` | Per-workflow health rollups for one agent — `issue_count` + worst-severity `health` + `detection_time` per workflow. The cheap triage layer; rank on this before expanding anything |
+| `get_reinforcement_loop_report` | The latest reinforcement loop report for **one** workflow, as a single actionable markdown brief — diagnosed issues with evidence (trace deep-links), recommended fixes, any existing Linear ticket, and any proposed monitor. The expensive call; fetch only for workflows the user chose |
 
 ## Workflow
 
 The flow is **user-gated at every fan-out** — never expand or act autonomously. The number of
-`get_agent_health` calls is bounded by what the user picks, not by how many workflows exist.
+`get_reinforcement_loop_report` calls is bounded by what the user picks, not by how many workflows exist.
 
 ### Step 1: Resolve the agent
 
 The user triggers this skill **with a specific agent in mind** — expect them to name it ("reinforce
 the chat agent", "fix `ai-agent`"). This step's job is to turn that name into the exact identifiers
-the health tools need.
+the reinforcement loop tools need.
 
 Call `get_agent_metadata` and match the user's name against each entry's `agentName` **and**
 `displayName` (users often use the friendly display name, not the canonical one). Use the matched
@@ -93,22 +94,22 @@ disambiguates agents that share a name.
   `trace_table_mcon`.
 - **No match:** tell the user and show the available agents.
 
-### Step 2: Triage the workflows (health overview)
+### Step 2: Triage the workflows (reinforcement loop overview)
 
-Call `get_agent_health_summaries(agent_name, trace_table_mcon)` — one cheap call covering every
+Call `get_reinforcement_loop_summaries(agent_name, trace_table_mcon)` — one cheap call covering every
 workflow. Then:
 
 - Drop workflows with `issue_count == 0` (clean reports).
 - Rank the rest by `health` severity (CRITICAL → HIGH → MEDIUM → LOW), then by `issue_count`.
 - Present the ranked list as a short table: workflow · health · issue count · last diagnosed.
 
-**Gate — ask the user which workflow(s) to dig into.** Do NOT call `get_agent_health` for every
+**Gate — ask the user which workflow(s) to dig into.** Do NOT call `get_reinforcement_loop_report` for every
 workflow. Default the suggestion to the single worst workflow; let the user pick one or a few. Only
 the chosen workflows get expanded in Step 3.
 
 ### Step 3: Deep-dive the chosen workflow(s)
 
-For each workflow the user chose, call `get_agent_health(agent_name, workflow_name, trace_table_mcon)`.
+For each workflow the user chose, call `get_reinforcement_loop_report(agent_name, workflow_name, trace_table_mcon)`.
 The response is a single markdown brief: a report header (health, coverage, window, and what changed
 since the last report) followed by one section per issue. Each issue section is self-contained — the
 summary, the evidence with clickable trace deep-links, and the recommended actions — so identifying
@@ -152,7 +153,7 @@ the next workflow).
 
 ## Important rules
 
-- **Never fan out eagerly.** `get_agent_health_summaries` is the triage layer; call `get_agent_health`
+- **Never fan out eagerly.** `get_reinforcement_loop_summaries` is the triage layer; call `get_reinforcement_loop_report`
   only for user-chosen workflows. Expanding every workflow wastes context on reports no one will act
   on.
 - **One issue → one PR.** Keep changes focused and reviewable; iterate rather than batch.


### PR DESCRIPTION
## Summary

The `reinforce-agent` skill calls the Monte Carlo agent-health MCP tools, which are being renamed to the **Reinforcement Loop** brand (ORB-444). This updates the skill to the new tool names and rebrands its guidance. Pairs with the MCP-server rename in [ai-agent#1940](https://github.com/monte-carlo-data/ai-agent/pull/1940).

| Before | After |
|--------|-------|
| `get_agent_health_summaries` | `get_reinforcement_loop_summaries` |
| `get_agent_health` | `get_reinforcement_loop_report` |

## Changes

- **`skills/reinforce-agent/SKILL.md`** — renamed every tool reference (tool table, workflow steps, the fully-qualified `mcp__plugin_…` name, prerequisites) and rebranded prose from "agent-health" to "reinforcement loop".
- **All 6 plugins** — bumped `1.22.1 → 1.22.2` with a changelog entry.

## Left as-is (intentional)

- The `health` response field and severity references (that field name is unchanged on the backend).
- Natural user trigger phrases like "improve my agent's health".
- The historical `1.22.0` changelog entries (Keep-a-Changelog — not rewritten).

## Coordination

The skill now calls the renamed tools, so it depends on ai-agent#1940 deploying to the MCP server. Until then the tools resolve under their old names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)