### PR TITLE
docs(monitoring-advisor): judge model selection via modelName; modelConnectionId is BigQuery-only (AI-771) — v1.22.3

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.2",
+    "version": "1.22.3",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.2",
+    "version": "1.22.3",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2026-07-29
+
+### Changed
+
+- monitoring-advisor: judge model selection via `modelName` on LLM-based eval transforms; `modelConnectionId` is BigQuery-only (AI-771)
+
 ## [1.22.2] - 2026-07-27
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -137,13 +137,16 @@ offer models from the wrong pool:
 
 | Agent's warehouse | Judge models (default first) |
 |-------------------|------------------------------|
-| Snowflake (Cortex) | `llama3.1-70b`, `llama3.1-405b`, `llama3.1-8b`, `mistral-large`, `mixtral-8x7b`, `jamba-1.5-large`, `jamba-1.5-mini`, `jamba-instruct`, `snowflake-arctic` — **no Claude models on Snowflake** |
+| Snowflake (Cortex) | Cortex model names: `llama3.1-70b`, `llama3.1-8b`, `llama3.3-70b`, `llama4-maverick`, `mixtral-8x7b`, `mistral-large2`, `mistral-large3`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-7`, `claude-opus-4-8`, `openai-gpt-5.1`, `openai-gpt-5`, `openai-gpt-5-mini`, `openai-gpt-5-nano`, `openai-gpt-4.1`, `gemini-3.1-pro` |
 | Databricks | `databricks-meta-llama-3-3-70b-instruct`, plus other `databricks-*` endpoints |
 | BigQuery | `gemini-2.5-flash`, `gemini-2.5-pro` |
-| OpenTelemetry (ClickHouse/Athena traces) | `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-opus-4-1-20250805-v1:0` |
+| OpenTelemetry (ClickHouse/Athena traces), AWS-hosted deployment (most accounts) | `us.anthropic.claude-sonnet-5`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-opus-4-8` |
+| OpenTelemetry, GCP/Azure-hosted deployment | short names: `claude-sonnet-5`, `claude-haiku-4-5` (GCP: `claude-haiku-4-5@20251001`), `claude-opus-4-8` |
 
 A known catalog model on the wrong warehouse is rejected at dry-run; unrecognized
-names pass through to the warehouse as-is.
+names pass through to the warehouse as-is. The catalog changes over time — when a
+user asks for a model not listed here, try it in a dry-run rather than declaring it
+unavailable.
 
 **`modelConnectionId`** is **BigQuery-only** (and required there) — the BigQuery
 Cloud resource connection in the customer's own GCP project that runs the judge. It

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -114,7 +114,7 @@ Each writes an output column named by its `alias`, and that alias is what
 
 | Function | Set these | Do NOT set | Output type |
 |----------|-----------|------------|-------------|
-| `custom_prompt` | `prompt` (with a `{{variable}}`), `alias`, `outputType` | `field`, `sqlExpression` | number / string / boolean |
+| `custom_prompt` | `prompt` (with a `{{variable}}`), `alias`, `outputType`, + optional `modelName` (see Judge model selection) | `field`, `sqlExpression` | number / string / boolean |
 | `custom_sql` | `sqlExpression`, `alias`, `outputType` | `field`, `prompt`, `modelConnectionId`, `modelName` | number / string / boolean |
 
 - **`custom_prompt` prompts MUST reference at least one template variable** —
@@ -132,21 +132,35 @@ Each writes an output column named by its `alias`, and that alias is what
 
 **`modelName`** pins the judge model for LLM-based transforms (predefined judges and
 `custom_prompt`). Optional — omit it to use the warehouse default. **Models are
-warehouse-specific** because the judge runs inside the agent's warehouse — never
-offer models from the wrong pool:
+warehouse-specific** because the judge runs inside the warehouse hosting the agent's
+**trace table** — never offer models from the wrong pool:
 
-| Agent's warehouse | Judge models (default first) |
+| Trace table's warehouse | Judge models (default first) |
 |-------------------|------------------------------|
-| Snowflake (Cortex) | Cortex model names: `llama3.1-70b`, `llama3.1-8b`, `llama3.3-70b`, `llama4-maverick`, `mixtral-8x7b`, `mistral-large2`, `mistral-large3`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-7`, `claude-opus-4-8`, `openai-gpt-5.1`, `openai-gpt-5`, `openai-gpt-5-mini`, `openai-gpt-5-nano`, `openai-gpt-4.1`, `gemini-3.1-pro` |
-| Databricks | `databricks-meta-llama-3-3-70b-instruct`, plus other `databricks-*` endpoints |
+| Snowflake (Cortex) | `llama3.1-70b`, `llama3.1-8b`, `llama3.3-70b`, `llama4-maverick`, `mixtral-8x7b`, `mistral-large2`, `mistral-large3`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-7`, `claude-opus-4-8`, `openai-gpt-5.1`, `openai-gpt-5`, `openai-gpt-5-mini`, `openai-gpt-5-nano`, `openai-gpt-4.1`, `gemini-3.1-pro` |
+| Databricks | `databricks-meta-llama-3-3-70b-instruct`, `databricks-meta-llama-3-1-8b-instruct`, `databricks-gpt-5`, `databricks-gpt-5-mini`, `databricks-gpt-5-nano`, `databricks-gpt-oss-20b`, `databricks-gpt-oss-120b`, `databricks-gemma-3-12b`, `databricks-llama-4-maverick` |
 | BigQuery | `gemini-2.5-flash`, `gemini-2.5-pro` |
-| OpenTelemetry (ClickHouse/Athena traces), AWS-hosted deployment (most accounts) | `us.anthropic.claude-sonnet-5`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-opus-4-8` |
-| OpenTelemetry, GCP/Azure-hosted deployment | short names: `claude-sonnet-5`, `claude-haiku-4-5` (GCP: `claude-haiku-4-5@20251001`), `claude-opus-4-8` |
+| Athena trace tables (any cloud), or ClickHouse trace tables on an AWS-hosted deployment (most accounts) | `us.anthropic.claude-sonnet-5`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-opus-4-8`, `us.anthropic.claude-opus-4-1-20250805-v1:0` |
+| ClickHouse trace tables on a GCP/Azure-hosted deployment | short names — `claude-sonnet-5`, `claude-haiku-4-5` (GCP: `claude-haiku-4-5@20251001`), `claude-opus-4-8`. Athena trace tables always use the AWS `us.anthropic.*` ids (not cloud-resolved). |
 
-A known catalog model on the wrong warehouse is rejected at dry-run; unrecognized
-names pass through to the warehouse as-is. The catalog changes over time — when a
-user asks for a model not listed here, try it in a dry-run rather than declaring it
-unavailable.
+The pool follows the warehouse the agent's traces live in (`warehouse_uuid`/
+`warehouse_name` from `get_agent_metadata`), not the agent's `backend_class` — a
+customer OTel trace table on Snowflake uses the Snowflake pool.
+
+Snapshot as of 2026-07-29 (source: monolith `validations/llm_models.yaml`) —
+re-verify before quoting as exhaustive.
+
+On Snowflake, everything except `llama3.1-*`, `llama3.3-70b`, `mixtral-8x7b` and
+`mistral-large2` requires Cortex cross-region inference enabled
+(`CORTEX_ENABLED_CROSS_REGION`); the dry-run does NOT check this — flag it to the
+user before pinning.
+
+A known catalog model on the wrong warehouse is rejected at dry-run. An unrecognized
+name is NOT validated — it is accepted as a custom model and fails at evaluation
+time if the warehouse doesn't host it; a passing dry-run is not evidence the model
+exists. Prefer a listed model; if the user insists on an unlisted one, pin it but
+tell them it could not be verified and to check that the monitor's first run
+produced scores.
 
 **`modelConnectionId`** is **BigQuery-only** (and required there) — the BigQuery
 Cloud resource connection in the customer's own GCP project that runs the judge. It

--- a/skills/monitoring-advisor/references/agent-evaluation-monitor.md
+++ b/skills/monitoring-advisor/references/agent-evaluation-monitor.md
@@ -79,10 +79,11 @@ transforms, which those don't need.
 
 ## Predefined LLM transforms
 
-Pass only `function` (and an optional `alias`, plus `modelConnectionId` on
-BigQuery). Do NOT set `prompt`, `sqlExpression`, `outputType`, or `field` — the tool
-rejects them. Each writes a numeric score (1–5, except `semantic_similarity` which is
-0–5) to its built-in output field:
+Pass only `function` (plus an optional `alias`, an optional `modelName` to pin the
+judge model — see **Judge model selection** below — and `modelConnectionId` on
+BigQuery only). Do NOT set `prompt`, `sqlExpression`, `outputType`, or `field` — the
+tool rejects them. Each writes a numeric score (1–5, except `semantic_similarity`
+which is 0–5) to its built-in output field:
 
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
@@ -97,7 +98,7 @@ rejects them. Each writes a numeric score (1–5, except `semantic_similarity` w
 ## Predefined SQL transforms (rule-based, no LLM needed)
 
 Same rule: pass only `function` (and an optional `alias`); do NOT set `prompt`,
-`sqlExpression`, `outputType`, `modelConnectionId`, or `field`.
+`sqlExpression`, `outputType`, `modelConnectionId`, `modelName`, or `field`.
 
 | Transform function | Output field | Output type | Description |
 |-------------------|-------------|-------------|-------------|
@@ -114,7 +115,7 @@ Each writes an output column named by its `alias`, and that alias is what
 | Function | Set these | Do NOT set | Output type |
 |----------|-----------|------------|-------------|
 | `custom_prompt` | `prompt` (with a `{{variable}}`), `alias`, `outputType` | `field`, `sqlExpression` | number / string / boolean |
-| `custom_sql` | `sqlExpression`, `alias`, `outputType` | `field`, `prompt`, `modelConnectionId` | number / string / boolean |
+| `custom_sql` | `sqlExpression`, `alias`, `outputType` | `field`, `prompt`, `modelConnectionId`, `modelName` | number / string / boolean |
 
 - **`custom_prompt` prompts MUST reference at least one template variable** —
   `{{prompts}}`, `{{completions}}`, or `{{expected_output}}` for a per-span monitor,
@@ -127,8 +128,29 @@ Each writes an output column named by its `alias`, and that alias is what
   `prompts`/`completions` are arrays — reference the string columns
   `first_completion` / `full_completion` / `first_prompt` instead. The dry-run does
   not evaluate the SQL, so a bad column surfaces only at run time.
-- **`modelConnectionId`** is optional for LLM-based transforms (predefined judges and
-  `custom_prompt`) and REQUIRED on BigQuery warehouses. Omit it elsewhere.
+## Judge model selection (`modelName`)
+
+**`modelName`** pins the judge model for LLM-based transforms (predefined judges and
+`custom_prompt`). Optional — omit it to use the warehouse default. **Models are
+warehouse-specific** because the judge runs inside the agent's warehouse — never
+offer models from the wrong pool:
+
+| Agent's warehouse | Judge models (default first) |
+|-------------------|------------------------------|
+| Snowflake (Cortex) | `llama3.1-70b`, `llama3.1-405b`, `llama3.1-8b`, `mistral-large`, `mixtral-8x7b`, `jamba-1.5-large`, `jamba-1.5-mini`, `jamba-instruct`, `snowflake-arctic` — **no Claude models on Snowflake** |
+| Databricks | `databricks-meta-llama-3-3-70b-instruct`, plus other `databricks-*` endpoints |
+| BigQuery | `gemini-2.5-flash`, `gemini-2.5-pro` |
+| OpenTelemetry (ClickHouse/Athena traces) | `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-opus-4-1-20250805-v1:0` |
+
+A known catalog model on the wrong warehouse is rejected at dry-run; unrecognized
+names pass through to the warehouse as-is.
+
+**`modelConnectionId`** is **BigQuery-only** (and required there) — the BigQuery
+Cloud resource connection in the customer's own GCP project that runs the judge. It
+is NOT a Monte Carlo setting or integration and Monte Carlo cannot list it; on
+BigQuery, ask the user for their BigQuery connection ID. **On every other warehouse,
+omit it entirely and never ask the user for it.** To choose the judge model, use
+`modelName` — there is no "model connection" to configure outside BigQuery.
 
 ## Conversation-grain judges
 


### PR DESCRIPTION
## Summary

Mirrors the mcp-server `AgentTransform` schema change from [AI-771](https://linear.app/montecarloai/issue/AI-771) into the toolkit's monitoring-advisor reference doc:

- **`modelName`** — new optional field on LLM-based eval transforms (predefined judges + `custom_prompt`) to pin the judge model. Added a **Judge model selection** section with the per-warehouse model pools and defaults, verified live against prod via `getWarehouseSupportedLlmModels` (2026-07-29): Snowflake Cortex names (llama/mixtral/mistral plus Claude, GPT, and Gemini — e.g. `claude-haiku-4-5`, `openai-gpt-5.1`), Databricks endpoints, BigQuery Gemini, and OpenTelemetry Claude (`us.anthropic.claude-sonnet-5` default on AWS-hosted deployments; GCP/Azure pools use short names).
- **`modelConnectionId` hardened** — it is the customer's BigQuery Cloud resource connection (in their own GCP project), NOT a Monte Carlo setting or integration. Agents must never ask for it outside BigQuery. This is the wording fix for the hallucinated "Settings → Integrations" flow Sam reported.
- `modelName` added to the "Do NOT set" lists for `custom_sql` and the predefined SQL checks (they call no LLM).
- `scripts/bump-version.sh patch` → **v1.22.3**.

## Context

Sam asked the eval-monitor flow to use specific judge models on a Snowflake Cortex agent; the agent invented a "model connection ID in Settings → Integrations" flow. The mcp-server side (monte-carlo-data/ai-agent#1983) exposes `modelName` on the tool schema; this PR syncs the toolkit skill reference.

The judge catalog drifted materially in ~2 weeks (Claude/GPT/Gemini added to Snowflake, mistral-large removed, new OTel default), so the doc carries a dated snapshot line and states exactly what a dry-run proves: a known wrong-pool model is rejected, but an unlisted name is NOT validated (pass-through) — pin it and warn the user rather than declaring it unavailable or calling it verified. Code-review fixes from ai-agent#1983 (round 51e8662) are mirrored here: pool table keyed on the trace table's warehouse, Snowflake cross-region-inference caveat, full Bedrock/Databricks pool enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
