### PR TITLE
docs(tune-monitor): agent-metric-monitor reference + dispatch (AI-780)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.3",
+    "version": "1.23.0",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.22.3",
+    "version": "1.23.0",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-07-29
+
+### Added
+
+- tune-monitor: agent metric monitor support — new `references/agent-metric-monitor.md` (agent-reference verbatim rule, span-filter write-shape traps, trace-aggregation exclusivity), Phase 1.5 dispatch row, and the `create_or_update_agent_metric_monitor` apply flow (AI-780)
+
 ## [1.22.3] - 2026-07-29
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/monitoring-advisor/references/agent-metric-monitor.md
+++ b/skills/monitoring-advisor/references/agent-metric-monitor.md
@@ -131,8 +131,9 @@ latency (`duration_sec`), volume, and error/outcome metrics instead.
 - **OTel agents only.** Platform agent references (`{database}:{schema}.{name}`) are
   rejected — the per-trace query isn't built for them. Target an OTel `service_name`,
   or pass an explicit `trace_table`.
-- **Only the `agent` span filter is allowed** — remove `workflow` / `task` /
-  `spanName` from `agent_span_filters`, since the per-trace result has no such column.
+- **No span filters are supported** — remove `agent_span_filters` entirely (including
+  `agent`). The monitor's agent is identified by the top-level `agent` parameter, not a
+  span filter; the per-trace result has no columns a span filter could match against.
 - Use the trace-aggregation field names (`span_count`, `llm_call_count`, trace-summed
   tokens, total `duration_sec`). See `agent-span-fields.md`.
 

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune-monitor
-description: Analyze a Monte Carlo monitor and recommend config changes to reduce alert noise. Supports metric, custom SQL, validation, and table monitors. Fetches the report, identifies patterns, and suggests tuning.
+description: Analyze a Monte Carlo monitor and recommend config changes to reduce alert noise. Supports metric, custom SQL, validation, table, and agent metric monitors. Fetches the report, identifies patterns, and suggests tuning.
 when_to_use: |
   Invoke when the user wants to tune, reduce noise on, or adjust sensitivity for a Monte Carlo monitor.
   Example triggers: "tune monitor <uuid>", "this monitor is too noisy", "reduce alerts on this monitor", "adjust sensitivity for <uuid>".
@@ -31,6 +31,7 @@ them:
 - Custom SQL monitor tuning: `references/custom-sql-monitor.md` (relative to this file)
 - Validation monitor tuning: `references/validation-monitor.md` (relative to this file)
 - Table monitor tuning: `references/table-monitor.md` (relative to this file)
+- Agent metric monitor tuning: `references/agent-metric-monitor.md` (relative to this file)
 
 ---
 
@@ -50,8 +51,9 @@ them:
 | `create_or_update_sql_monitor` | Update a custom SQL monitor in place (pass `monitor_uuid`; used in Phase 5) |
 | `create_or_update_validation_monitor` | Update a validation monitor in place (pass `monitor_uuid`; used in Phase 5) |
 | `create_or_update_table_monitor_asset_rule` | Tune freshness / volume change / unchanged size for a single table; pick the per-metric variant via `rule_type` (`last_updated_on` / `total_row_count` / `total_row_count_last_changed_on`). One call per `(table, metric)` pair (used in Phase 5). |
+| `create_or_update_agent_metric_monitor` | Update an agent metric monitor in place (pass `monitor_uuid`; used in Phase 5) |
 
-All three `create_or_update_*_monitor` tools follow a **two-call preview-then-confirm pattern**: the first call (with the default `dry_run=True`) returns the rendered MaC YAML for review in `result.yaml`; the second call (`dry_run=False`) deploys the change live and returns a deep link in `result.instructions`. **Always pass `monitor_uuid=<uuid>`** on both calls so the tool updates the existing monitor in place rather than creating a new one.
+All the `create_or_update_*` tools follow a **two-call preview-then-confirm pattern**: the first call (with the default `dry_run=True`) returns the rendered MaC YAML for review in `result.yaml`; the second call (`dry_run=False`) deploys the change live and returns a deep link in `result.instructions`. **Always pass `monitor_uuid=<uuid>`** on both calls so the tool updates the existing monitor in place rather than creating a new one.
 
 ---
 
@@ -92,15 +94,17 @@ From the `get_monitors` config response, determine the monitor type:
 | Monitor type is a custom SQL rule / custom monitor | Custom SQL | `references/custom-sql-monitor.md` |
 | Monitor type is a validation rule / validation monitor | Validation | `references/validation-monitor.md` |
 | Monitor type is a table monitor (freshness, volume, schema across tables) | Table | `references/table-monitor.md` |
+| Monitor type is an agent metric monitor (metric over an AI agent's trace table) | Agent metric | `references/agent-metric-monitor.md` |
 
 **Read** the appropriate reference file using the Read tool with the path relative to this skill
 file. The reference contains type-specific config fields to extract, recommendation guidance, and
 apply-changes instructions.
 
-If the monitor type is not metric, custom SQL, validation, or table, stop and tell the user:
+If the monitor type is not metric, custom SQL, validation, table, or agent metric, stop and
+tell the user:
 
-> This skill supports tuning metric, custom SQL, validation, and table monitors. This monitor
-> is a {type} monitor, which is not supported.
+> This skill supports tuning metric, custom SQL, validation, table, and agent metric monitors.
+> This monitor is a {type} monitor, which is not supported.
 
 ---
 
@@ -188,7 +192,7 @@ Output a structured analysis. **This is the primary output — include it in ful
 ## Monitor Tune Report: {monitor_uuid}
 
 **Monitor:** {display_name or mac_name}
-**Type:** {monitor type — metric, custom SQL, validation, or table}
+**Type:** {monitor type — metric, custom SQL, validation, table, or agent metric}
 **Table:** {table}
 **What it monitors:** {metric and segments, SQL query summary, validation conditions, or table/metric coverage}
 **Current sensitivity:** {sensitivity or "AUTO (default)" or "N/A (explicit thresholds)"}

--- a/skills/tune-monitor/references/agent-metric-monitor.md
+++ b/skills/tune-monitor/references/agent-metric-monitor.md
@@ -72,6 +72,12 @@ preview-then-confirm rules from the metric monitor reference apply (always pass
   the agent was likely deleted, renamed, or moved, and the monitor can't be updated until that's
   resolved.
 - **NEVER** put an `agent` entry inside `agent_span_filters` (see above).
+- **`trace_table` is conditional on the store.** For a non-ClickHouse OTel agent (e.g. a
+  Snowflake trace table), pass the monitor's trace table (fullTableId form, e.g.
+  `ingest:opentelemetry.traces`) as `trace_table` on **every** edit — the API rejects the edit
+  without it. For an agent on the Monte Carlo-managed ClickHouse store
+  (`...otel_traces:otel_traces.spans_normalized`), **never** pass `trace_table` — the API
+  rejects an explicit reference to its own store (it resolves it from the agent automatically).
 - **PUT semantics** — same as all monitor types: omitted fields revert to defaults. Re-pass
   everything you want to keep, and note two easy-to-miss fields:
   - `is_draft` — omitting it both un-drafts AND un-pauses a paused monitor.

--- a/skills/tune-monitor/references/agent-metric-monitor.md
+++ b/skills/tune-monitor/references/agent-metric-monitor.md
@@ -1,0 +1,82 @@
+# Tuning Agent Metric Monitors
+
+This reference covers type-specific tuning guidance for agent metric monitors — monitors that
+track a metric (row count, latency, error rate, token usage, ...) over an AI agent's trace
+table. Read this file after determining the monitor type in Phase 1.5.
+
+## Config fields to extract
+
+Extract these from the `get_monitors` config response for your Phase 2 analysis:
+
+- Agent name and **Agent reference** (from the report's `- Agent:` and `- Agent reference:` lines)
+- Trace table (the warehouse table holding the agent's spans)
+- Comparisons (metric + operator; `AUTO` means ML thresholds)
+- Span filters (`agent_span_filters`: workflow / task / span name narrowing)
+- Trace aggregation (`is_agent_trace_aggregation`: metric computed per whole trace vs per span)
+- Time axis (`time_axis_field_name` + aggregation bucket)
+- Schedule (`FIXED` interval or `MANUAL`)
+
+---
+
+## Threshold adjustment
+
+For explicit-threshold comparisons (`GT`, `LT`, etc.), follow the same rules as metric monitors:
+explain what the threshold means for the agent metric ("error rate GT 0.05 means alert when more
+than 5% of spans error"), and never recommend a change without citing observed anomaly values
+from the report. For `AUTO` (ML) comparisons, use the general sensitivity guidance in the skill.
+
+---
+
+## Span-filter narrowing
+
+If anomalies concentrate in one workflow, task, or span name, narrowing `agent_span_filters`
+scopes the metric to just that slice — or excludes a noisy slice by monitoring the rest.
+
+**Write shape rules (strict — the API rejects violations):**
+
+- At most **one** span filter entry.
+- Each sub-field is a nested object: `{"workflow": {"value": "TTSA"}}` — never a bare string.
+- Field names are camelCase in the wire shape (`spanName`), snake_case in the tool parameter
+  (`agent_span_filters`).
+- **NEVER include an `agent` entry inside `agent_span_filters`.** The agent is identified by the
+  top-level `agent` parameter, not a span filter. An `agent` sub-field is rejected.
+
+**Trade-off:** a narrower filter no longer sees anomalies outside the slice. Always state what
+the monitor stops watching.
+
+---
+
+## Aggregation
+
+`is_agent_trace_aggregation=True` computes the metric once per trace (e.g. total tokens per
+conversation) instead of per span. Trace aggregation and span-level filters are mutually
+exclusive — **do not** combine `is_agent_trace_aggregation=True` with `agent_span_filters`.
+
+Recommend switching to trace aggregation when per-span values are inherently spiky but the
+per-trace total is stable (and vice versa). Schedule intervals must be `fixed`/`manual`, at
+least 60 minutes, and a multiple of 60.
+
+---
+
+## Applying changes
+
+Use `create_or_update_agent_metric_monitor` to update the monitor in place. The general
+preview-then-confirm rules from the metric monitor reference apply (always pass
+`monitor_uuid=<uuid>`, always dry-run first, stale-uuid handling).
+
+### Common mistakes
+
+- **CRITICAL: the `agent` parameter takes the Agent reference, verbatim.** Copy the report's
+  `- Agent reference:` value exactly (e.g. `analytics:prod_agents.rothbot`) — **never** the bare
+  agent name and **never** the trace table's MCON. If the report shows no Agent reference, stop:
+  the agent was likely deleted, renamed, or moved, and the monitor can't be updated until that's
+  resolved.
+- **NEVER** put an `agent` entry inside `agent_span_filters` (see above).
+- **PUT semantics** — same as all monitor types: omitted fields revert to defaults. Re-pass
+  everything you want to keep, and note two easy-to-miss fields:
+  - `is_draft` — omitting it both un-drafts AND un-pauses a paused monitor.
+  - `tags` — omitting them silently drops the monitor's tags (including the agent tags the
+    platform uses for routing).
+- Sensitivity and `aggregate_by` values are lowercase (`"low"`, `"day"`).
+- **Diff the preview against the original** before `dry_run=False`, exactly as for metric
+  monitors.


### PR DESCRIPTION
## Changes

- New `skills/tune-monitor/references/agent-metric-monitor.md` — type-specific tuning guidance for agent metric monitors, following the existing reference skeleton (Config fields / Threshold adjustment / Span-filter narrowing / Aggregation / Applying changes + Common mistakes).
- `SKILL.md`: frontmatter description, reference list, MCP tools table (+`create_or_update_agent_metric_monitor`), Phase 1.5 dispatch row, the five-type stop instruction, and the Phase 4 `Type:` line now include agent metric monitors.
- Version bump 1.22.3 → 1.23.0 across all six plugins (bump-version.sh, which also re-synced the shared hook libs — no-op, already in sync).

## Context

Part of AI-780 (tuning agent — agent-monitor infra + `agent_metric` support). The mcp-server now renders agent-metric monitor reports and exposes `AGENT_METRIC` on `get_monitors`/`get_monitor_report`, and `create_or_update_agent_metric_monitor` applies changes. This PR mirrors that capability into the customer-facing tune-monitor skill.

Key traps the reference encodes (from the tuning-graph rules):
- The `agent` parameter takes the report's **Agent reference verbatim** — never the bare agent name or the trace-table MCON.
- **Never** an `agent` entry inside `agent_span_filters`; ≤1 span filter; nested `{"value": ...}` shape.
- `is_agent_trace_aggregation=True` is mutually exclusive with span-level filters.
- PUT semantics: re-pass `is_draft` (omitting un-drafts AND un-pauses) and `tags` (omitting drops the platform's agent tags).

## Verification

- `lint-skill.py tune-monitor` — only pre-existing findings (`name` canonical-form ERROR and `version`-field WARN exist on main; this PR doesn't touch those fields).
- Manual walkthrough against a real agent-metric monitor is part of the AI-780 live-validation legs (gates the merge chain; needs VPN + SSO).

**Merge/release note:** merge after the ai-agent/mcp-server PR deploys — the skill instructs calls to `create_or_update_agent_metric_monitor` and `get_monitor_report` on `AGENT_METRIC`, which need the server-side support live. Ships to customers on the next `v1.23.0` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)