### PR TITLE
fix(prevent): verify the impact-assessment gate against sub-agent transcripts

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/claude-code/hooks/prevent/lib/protocol.py
+++ b/plugins/claude-code/hooks/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/claude-code/hooks/prevent/lib/protocol.py
+++ b/plugins/claude-code/hooks/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/claude-code/hooks/prevent/pre_edit_hook.py
+++ b/plugins/claude-code/hooks/prevent/pre_edit_hook.py
@@ -17,6 +17,7 @@ def main():
         session_id=raw.get("session_id", "unknown"),
         file_path=raw.get("tool_input", {}).get("file_path", ""),
         transcript_path=raw.get("transcript_path", ""),
+        agent_id=raw.get("agent_id"),
     )
     result = evaluate_pre_edit(inp)
     if result.action == "deny":

--- a/plugins/claude-code/tests/prevent/test_pre_edit_hook.py
+++ b/plugins/claude-code/tests/prevent/test_pre_edit_hook.py
@@ -7,8 +7,8 @@ from io import StringIO
 from lib.protocol import HookOutput
 
 
-def _make_stdin(file_path):
-    return json.dumps({
+def _make_stdin(file_path, agent_id=None):
+    payload = {
         "session_id": "test_session",
         "transcript_path": "/tmp/test_transcript.jsonl",
         "cwd": "/project",
@@ -16,7 +16,10 @@ def _make_stdin(file_path):
         "tool_name": "Edit",
         "tool_input": {"file_path": file_path},
         "tool_use_id": "toolu_test123",
-    })
+    }
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    return json.dumps(payload)
 
 
 class TestPreEditHookCCAdapter:
@@ -52,3 +55,24 @@ class TestPreEditHookCCAdapter:
         """Adapter should extract file_path from tool_input."""
         raw = json.loads(_make_stdin("/project/models/orders.sql"))
         assert raw["tool_input"]["file_path"] == "/project/models/orders.sql"
+
+    def test_agent_id_passed_through(self):
+        """agent_id identifies the sub-agent whose transcript holds its markers."""
+        with patch("pre_edit_hook.evaluate_pre_edit",
+                   return_value=HookOutput(action="noop")) as mock_eval, \
+             patch("sys.stdin", StringIO(_make_stdin("/project/models/orders.sql",
+                                                     agent_id="a1b2c3"))):
+            from pre_edit_hook import main
+            main()
+
+        assert mock_eval.call_args.args[0].agent_id == "a1b2c3"
+
+    def test_agent_id_absent_in_main_loop(self):
+        """Main-loop tool calls carry no agent_id."""
+        with patch("pre_edit_hook.evaluate_pre_edit",
+                   return_value=HookOutput(action="noop")) as mock_eval, \
+             patch("sys.stdin", StringIO(_make_stdin("/project/models/orders.sql"))):
+            from pre_edit_hook import main
+            main()
+
+        assert mock_eval.call_args.args[0].agent_id is None

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/codex/hooks/prevent/lib/protocol.py
+++ b/plugins/codex/hooks/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/codex/hooks/prevent/lib/protocol.py
+++ b/plugins/codex/hooks/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/copilot/hooks/prevent/lib/protocol.py
+++ b/plugins/copilot/hooks/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/copilot/hooks/prevent/lib/protocol.py
+++ b/plugins/copilot/hooks/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/cortex-code/hooks/prevent/lib/protocol.py
+++ b/plugins/cortex-code/hooks/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/cortex-code/hooks/prevent/lib/protocol.py
+++ b/plugins/cortex-code/hooks/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/cursor/hooks/prevent/lib/protocol.py
+++ b/plugins/cursor/hooks/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/cursor/hooks/prevent/lib/protocol.py
+++ b/plugins/cursor/hooks/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-06
+
+### Fixed
+
+- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- prevent: sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit
+- prevent (Claude Code only): sub-agent edits to dbt models are no longer blocked indefinitely — the change-impact gate now also scans the session's sub-agent transcripts, where a sub-agent's `MC_IMPACT_CHECK_COMPLETE` marker is written. Only model-authored text counts, so the gate still requires a real assessment before the edit. Other editors are unaffected: Cortex Code reads a different transcript format, Copilot does no transcript scanning, and OpenCode reads messages through the SDK
 
 ## [1.24.0] - 2026-08-02
 

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/shared/prevent/lib/protocol.py
+++ b/plugins/shared/prevent/lib/protocol.py
@@ -4,6 +4,7 @@ All business logic for the prevent hooks lives here.
 Platform adapters (Claude Code, Cursor) call these functions
 and translate the result to their platform's JSON format.
 """
+import glob
 import json
 import os
 import re
@@ -33,7 +34,7 @@ class HookInput:
 
     __slots__ = ("session_id", "file_path", "command", "transcript_path",
                  "cwd", "tool_name", "stop_hook_active", "validate_command",
-                 "transcript_format")
+                 "transcript_format", "agent_id")
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class HookInput:
         stop_hook_active: bool = False,
         validate_command: str = "/mc-validate",
         transcript_format: str = "raw",
+        agent_id: str | None = None,
     ):
         self.session_id = session_id
         self.file_path = file_path
@@ -55,6 +57,10 @@ class HookInput:
         self.tool_name = tool_name
         self.stop_hook_active = stop_hook_active
         self.validate_command = validate_command
+        # Set when the tool call comes from a sub-agent rather than the main
+        # loop. Sub-agent turns are written to their own transcript, so the
+        # marker scan needs the id to find the right file.
+        self.agent_id = agent_id
         # Transcript layout this adapter produced: "raw" (line-scannable text,
         # the default for Claude Code/Cursor/Copilot/Codex) or "messages_jsonl"
         # (Cortex `.history.jsonl`, where only assistant text blocks are scanned).
@@ -108,6 +114,12 @@ def _match_markers_in_lines(lines, table_name: str) -> dict:
     return found
 
 
+def _merge_markers(*results: dict) -> dict:
+    """Union of marker results — a marker found in any scanned source counts."""
+    return {key: any(r[key] for r in results)
+            for key in ("impact_check", "monitor_gap")}
+
+
 def scan_transcript_for_markers(transcript_path: str, table_name: str) -> dict:
     """Scan a plain-text / JSONL transcript line-by-line for prevent markers.
 
@@ -140,16 +152,16 @@ def _iter_assistant_text(content) -> list[str]:
     return texts
 
 
-def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
-    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers.
+def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dict:
+    """Match markers against assistant-authored text in a JSONL transcript.
 
-    Only assistant-authored text blocks are scanned. Cortex persists hook output
-    — including this gate's own deny reason — back into the transcript as a
-    tool_result delivered under role "user". Scanning only assistant text ensures
-    nothing but the model's own emitted marker can unlock the gate.
+    `extract_texts` maps one parsed entry to the assistant text it holds, and
+    returns nothing for anything the model didn't author (the prompt it was
+    given, tool results). Restricting the match to assistant text ensures
+    nothing but the model's own emitted marker can unlock the gate — harnesses
+    persist hook output, including this gate's own deny reason, back into the
+    transcript.
 
-    Each line is an Anthropic Messages-style object:
-        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
     Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
     (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
     miss a genuine marker. Worst case the scan finds no marker and the gate stays
@@ -159,18 +171,18 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
     try:
-        with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             for raw in f:
                 raw = raw.strip()
                 if not raw:
                     continue
                 try:
-                    msg = json.loads(raw)
+                    entry = json.loads(raw)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(entry, dict):
                     continue
-                for text in _iter_assistant_text(msg.get("content")):
+                for text in extract_texts(entry):
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
@@ -180,16 +192,102 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return found
 
 
+def _cortex_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Cortex `.history.jsonl` entry.
+
+    Each line is an Anthropic Messages-style object:
+        {"role": "assistant", "content": [{"type": "text", "text": "..."}, ...]}
+    Cortex persists hook output as a tool_result delivered under role "user",
+    which this skips.
+    """
+    if entry.get("role") != "assistant":
+        return []
+    return _iter_assistant_text(entry.get("content"))
+
+
+def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
+    """Scan a Cortex `<id>.history.jsonl` transcript for prevent markers."""
+    return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
+
+
+# Sub-agent (sidechain) turns are written to their own transcript files and never
+# into the main one:
+#   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
+# Hook input still reports the main session's id and transcript_path, so a marker
+# a sub-agent emitted is invisible to a scan of the main transcript alone.
+_SIDECHAIN_DIR = "subagents"
+_JSONL_SUFFIX = ".jsonl"
+
+
+def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
+    """Sub-agent transcript files belonging to a main transcript.
+
+    Prefers the acting sub-agent's own file when `agent_id` is known; nested
+    sub-agents sit a directory deeper, so the id is matched anywhere below
+    `subagents/`. Falls back to every sidechain of the session when no id was
+    reported or it doesn't resolve — a marker there is still scoped to this
+    session and this table, the same scope the main-transcript scan accepts.
+    Returns nothing for harnesses that don't write sidechains, leaving their
+    behavior unchanged.
+    """
+    if not transcript_path.endswith(_JSONL_SUFFIX):
+        return []
+    session_dir = transcript_path[: -len(_JSONL_SUFFIX)]
+    sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
+    if not os.path.isdir(sidechain_dir):
+        return []
+    if agent_id:
+        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
+                        recursive=True)
+        if own:
+            return own
+    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
+                            recursive=True))
+
+
+def _claude_code_assistant_texts(entry: dict) -> list[str]:
+    """Assistant text of one Claude Code transcript entry.
+
+    Entries wrap an Anthropic Messages-style object under "message" and carry the
+    author in a top-level "type":
+        {"type": "assistant", "message": {"content": [{"type": "text", ...}]}}
+    """
+    if entry.get("type") != "assistant":
+        return []
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    return _iter_assistant_text(message.get("content"))
+
+
+def scan_sidechain_transcripts_for_markers(
+    transcript_path: str, table_name: str, agent_id: str | None = None,
+) -> dict:
+    """Scan a session's sub-agent transcripts for prevent markers."""
+    found = {"impact_check": False, "monitor_gap": False}
+    for path in _sidechain_transcripts(transcript_path, agent_id):
+        found = _merge_markers(
+            found,
+            _scan_jsonl_assistant_text(path, table_name, _claude_code_assistant_texts),
+        )
+        if found["impact_check"] and found["monitor_gap"]:
+            break
+    return found
+
+
 def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     """Dispatch to the right transcript scanner for the harness's format.
 
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan. An unrecognized format (e.g. a future adapter's typo) deliberately
-    returns no markers so the gate stays denied — failing CLOSED rather than
-    silently scanning with the wrong reader (which would drop the assistant-text
-    protection) or raising (which fails OPEN, since the adapter's safe_run exits 0).
+    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
+    reach the main transcript, so without them an assessment run inside a
+    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    adapter's typo) deliberately returns no markers so the gate stays denied —
+    failing CLOSED rather than silently scanning with the wrong reader (which
+    would drop the assistant-text protection) or raising (which fails OPEN, since
+    the adapter's safe_run exits 0).
     """
     no_markers = {"impact_check": False, "monitor_gap": False}
     path = inp.transcript_path or ""
@@ -198,7 +296,10 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
-        return scan_transcript_for_markers(path, table_name)
+        return _merge_markers(
+            scan_transcript_for_markers(path, table_name),
+            scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
+        )
     return no_markers  # unknown format → fail closed
 
 

--- a/plugins/shared/prevent/lib/protocol.py
+++ b/plugins/shared/prevent/lib/protocol.py
@@ -93,12 +93,15 @@ def _compile_marker_patterns(table_name: str):
 
     Matches the table name with an optional MCON-style prefix (e.g.
     "analytics:prod.client_hub") so markers work even if the model emits a fully
-    qualified name instead of just "client_hub".
+    qualified name instead of just "client_hub". The name must END the marker
+    value: qualification is allowed before it, never after, so a marker for
+    "prod.client_hub.events" does not satisfy the gate for "client_hub".
     """
     esc = re.escape(table_name)
+    end = r"(?=\s|$)"
     return (
-        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}\b"),
-        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}\b"),
+        re.compile(rf"MC_IMPACT_CHECK_COMPLETE:\s+(?:\S+\.)?{esc}{end}"),
+        re.compile(rf"MC_MONITOR_GAP:\s+(?:\S+\.)?{esc}{end}"),
     )
 
 
@@ -162,11 +165,14 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
     persist hook output, including this gate's own deny reason, back into the
     transcript.
 
-    Malformed (non-JSON) lines are skipped, and undecodable bytes are replaced
-    (errors="replace") so a stray non-UTF-8 byte doesn't abort the whole scan and
-    miss a genuine marker. Worst case the scan finds no marker and the gate stays
-    denied (fail closed) rather than raising into the adapter's safe_run (which
-    would exit 0 and let the edit through).
+    Undecodable bytes are replaced (errors="replace") so a stray non-UTF-8 byte
+    doesn't abort the scan and miss a genuine marker. Every failure is contained
+    at the narrowest scope that can still make progress: a line that won't parse
+    or extract is skipped and the rest of the file is still read; a file that
+    won't open yields no markers. Both exception guards are deliberately broad —
+    the gate must fail CLOSED, and anything escaping into the adapter's safe_run
+    exits 0 and lets the edit through. Deeply nested JSON (RecursionError) and
+    oversized lines (MemoryError) both take this route.
     """
     found = {"impact_check": False, "monitor_gap": False}
     ic_pattern, mg_pattern = _compile_marker_patterns(table_name)
@@ -178,16 +184,17 @@ def _scan_jsonl_assistant_text(path: str, table_name: str, extract_texts) -> dic
                     continue
                 try:
                     entry = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
+                    if not isinstance(entry, dict):
+                        continue
+                    texts = extract_texts(entry)
+                except Exception:
                     continue
-                if not isinstance(entry, dict):
-                    continue
-                for text in extract_texts(entry):
+                for text in texts:
                     if ic_pattern.search(text):
                         found["impact_check"] = True
                     if mg_pattern.search(text):
                         found["monitor_gap"] = True
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         pass
     return found
 
@@ -210,25 +217,37 @@ def scan_history_jsonl_for_markers(history_path: str, table_name: str) -> dict:
     return _scan_jsonl_assistant_text(history_path, table_name, _cortex_assistant_texts)
 
 
-# Sub-agent (sidechain) turns are written to their own transcript files and never
-# into the main one:
+# Sub-agent (sidechain) turns are written to their own transcript files, keyed by
+# the acting agent's id, under the session's own directory:
 #   <transcript_dir>/<session_id>/subagents/[<parent_agent_id>/]agent-<agent_id>.jsonl
-# Hook input still reports the main session's id and transcript_path, so a marker
-# a sub-agent emitted is invisible to a scan of the main transcript alone.
+# Hook input reports the main session's id and transcript_path in both cases.
 _SIDECHAIN_DIR = "subagents"
 _JSONL_SUFFIX = ".jsonl"
+
+
+def _under_dir(path: str, directory: str) -> bool:
+    """True when `path` resolves to somewhere inside `directory`.
+
+    Symlinks under the transcript directory would otherwise let a scan read
+    another session's markers, so every candidate is checked after resolution.
+    """
+    try:
+        root = os.path.realpath(directory)
+        return os.path.commonpath([root, os.path.realpath(path)]) == root
+    except (OSError, ValueError):
+        return False
 
 
 def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[str]:
     """Sub-agent transcript files belonging to a main transcript.
 
-    Prefers the acting sub-agent's own file when `agent_id` is known; nested
-    sub-agents sit a directory deeper, so the id is matched anywhere below
-    `subagents/`. Falls back to every sidechain of the session when no id was
-    reported or it doesn't resolve — a marker there is still scoped to this
-    session and this table, the same scope the main-transcript scan accepts.
-    Returns nothing for harnesses that don't write sidechains, leaving their
-    behavior unchanged.
+    Prefers the acting sub-agent's own file; nested sub-agents sit a directory
+    deeper, so the id is matched anywhere below `subagents/`. `agent_id` is
+    escaped before it reaches the pattern — it comes from the harness payload,
+    and a raw glob metacharacter there would select files the caller never named.
+    Falls back to every sidechain of the session when the id doesn't resolve.
+    Every candidate must resolve inside the session's own directory.
+    Returns nothing for harnesses that don't write sidechains.
     """
     if not transcript_path.endswith(_JSONL_SUFFIX):
         return []
@@ -236,13 +255,23 @@ def _sidechain_transcripts(transcript_path: str, agent_id: str | None) -> list[s
     sidechain_dir = os.path.join(session_dir, _SIDECHAIN_DIR)
     if not os.path.isdir(sidechain_dir):
         return []
+
+    def contained(paths):
+        return [p for p in paths if os.path.isfile(p) and _under_dir(p, sidechain_dir)]
+
     if agent_id:
-        own = glob.glob(os.path.join(sidechain_dir, "**", f"agent-{agent_id}{_JSONL_SUFFIX}"),
-                        recursive=True)
+        own_name = f"agent-{glob.escape(str(agent_id))}{_JSONL_SUFFIX}"
+        flat = os.path.join(sidechain_dir, own_name)
+        if os.path.isfile(flat) and _under_dir(flat, sidechain_dir):
+            return [flat]
+        own = contained(glob.glob(os.path.join(sidechain_dir, "**", own_name), recursive=True))
         if own:
             return own
-    return sorted(glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"),
-                            recursive=True))
+    # Newest first: the acting sub-agent wrote most recently, so the marker is
+    # usually in the first file and the scan stops before reading the rest.
+    sweep = contained(
+        glob.glob(os.path.join(sidechain_dir, "**", f"*{_JSONL_SUFFIX}"), recursive=True))
+    return sorted(sweep, key=lambda p: (-os.path.getmtime(p), p))
 
 
 def _claude_code_assistant_texts(entry: dict) -> list[str]:
@@ -281,9 +310,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     Adapters that store messages in an Anthropic Messages-style `.history.jsonl`
     (Cortex) set inp.transcript_format == "messages_jsonl" and point
     transcript_path at that sibling file. "raw" (the default) uses the raw-line
-    scan, plus the session's sub-agent transcripts — a sub-agent's turns never
-    reach the main transcript, so without them an assessment run inside a
-    sub-agent can never satisfy the gate. An unrecognized format (e.g. a future
+    scan over the main transcript. A sub-agent's turns are written to their own
+    file, so when the caller is a sub-agent (inp.agent_id is set) its sidechains
+    are scanned too. A main-loop edit reports no agent_id and its own transcript
+    is the whole surface: the evidence must sit in the context window of the
+    agent doing the editing. An unrecognized format (e.g. a future
     adapter's typo) deliberately returns no markers so the gate stays denied —
     failing CLOSED rather than silently scanning with the wrong reader (which
     would drop the assistant-text protection) or raising (which fails OPEN, since
@@ -296,8 +327,11 @@ def _scan_markers(inp: "HookInput", table_name: str) -> dict:
     if inp.transcript_format == "messages_jsonl":
         return scan_history_jsonl_for_markers(path, table_name)
     if inp.transcript_format == "raw":
+        main = scan_transcript_for_markers(path, table_name)
+        if not inp.agent_id:
+            return main
         return _merge_markers(
-            scan_transcript_for_markers(path, table_name),
+            main,
             scan_sidechain_transcripts_for_markers(path, table_name, inp.agent_id),
         )
     return no_markers  # unknown format → fail closed

--- a/plugins/shared/prevent/lib/tests/test_protocol.py
+++ b/plugins/shared/prevent/lib/tests/test_protocol.py
@@ -48,6 +48,27 @@ class TestScanTranscriptForMarkers:
         result = scan_transcript_for_markers(str(transcript), "client_hub_master")
         assert result["impact_check"] is False
 
+    def test_qualified_prefix_still_matches(self, tmp_path):
+        """A fully qualified name resolves to its final segment."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('<!-- MC_IMPACT_CHECK_COMPLETE: analytics:prod.orders -->\n')
+        result = scan_transcript_for_markers(str(transcript), "orders")
+        assert result["impact_check"] is True
+
+    def test_other_table_qualified_by_target_no_match(self, tmp_path):
+        """orders must end the marker value, not merely appear inside it."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('<!-- MC_IMPACT_CHECK_COMPLETE: prod.orders.customers -->\n')
+        result = scan_transcript_for_markers(str(transcript), "orders")
+        assert result["impact_check"] is False
+
+    def test_hyphenated_sibling_no_match(self, tmp_path):
+        """orders-staging is a different table from orders."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('<!-- MC_IMPACT_CHECK_COMPLETE: orders-staging -->\n')
+        result = scan_transcript_for_markers(str(transcript), "orders")
+        assert result["impact_check"] is False
+
 
 def _cc_entry(entry_type, content, extra=None):
     """One Claude Code transcript line: author in "type", message nested."""
@@ -322,10 +343,7 @@ class TestEvaluatePreEditSubAgent:
     """A sub-agent must be able to satisfy the gate it was blocked by.
 
     Hook input reports the main session's id and transcript_path even when the
-    edit comes from a sub-agent, whose turns are written to a separate file. With
-    only the main transcript scanned, "injected" could never reach "verified":
-    the edit was denied inside the grace period and the full instruction
-    re-injected after it, with no way out.
+    edit comes from a sub-agent, whose turns are written to a separate file.
     """
 
     def _model(self, tmp_path):
@@ -410,6 +428,49 @@ class TestEvaluatePreEditSubAgent:
 
         inp = HookInput(session_id="s1", file_path=str(sql_file), transcript_path=str(main))
         assert evaluate_pre_edit(inp).action == "noop"
+
+    def test_main_loop_edit_not_unlocked_by_sidechain_marker(self, tmp_path):
+        """A sub-agent's marker satisfies the gate only for that sub-agent.
+
+        The main loop reports no agent_id and its own transcript is the whole
+        surface — an assessment run in a sub-agent's context window is not
+        evidence the editing agent saw the blast radius.
+        """
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file), transcript_path=str(main))
+        assert evaluate_pre_edit(inp).action == "deny"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "injected"
+
+    def test_deeply_nested_json_in_sidechain_still_denies(self, tmp_path):
+        """An unparseable sidechain line leaves the gate denied, never open."""
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text("[" * 20000 + "]" * 20000 + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        assert evaluate_pre_edit(inp).action == "deny"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "injected"
+
+    def test_nested_json_line_does_not_hide_a_later_marker(self, tmp_path):
+        """One unparseable line skips that line, not the rest of the file."""
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            "[" * 20000 + "]" * 20000 + "\n"
+            + _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        assert evaluate_pre_edit(inp).action == "noop"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "verified"
 
 
 class TestEvaluatePostEdit:

--- a/plugins/shared/prevent/lib/tests/test_protocol.py
+++ b/plugins/shared/prevent/lib/tests/test_protocol.py
@@ -13,6 +13,7 @@ from lib.protocol import (
     evaluate_validate_command,
     scan_transcript_for_markers,
     scan_history_jsonl_for_markers,
+    scan_sidechain_transcripts_for_markers,
 )
 
 
@@ -46,6 +47,124 @@ class TestScanTranscriptForMarkers:
         transcript.write_text('<!-- MC_IMPACT_CHECK_COMPLETE: client_hub -->\n')
         result = scan_transcript_for_markers(str(transcript), "client_hub_master")
         assert result["impact_check"] is False
+
+
+def _cc_entry(entry_type, content, extra=None):
+    """One Claude Code transcript line: author in "type", message nested."""
+    entry = {"type": entry_type, "message": {"role": entry_type, "content": content}}
+    entry.update(extra or {})
+    return json.dumps(entry)
+
+
+def _cc_assistant_text(text):
+    return _cc_entry("assistant", [{"type": "text", "text": text}], {"isSidechain": True})
+
+
+def _cc_tool_result(text):
+    """A tool result — delivered under "user", where hook output is persisted."""
+    return _cc_entry("user", [{"type": "tool_result", "content": text}],
+                     {"isSidechain": True})
+
+
+def _cc_session(tmp_path, session_id="sess1", main_lines=""):
+    """Build a Claude Code project dir: main transcript + its subagents/ dir.
+
+      <project>/<session_id>.jsonl
+      <project>/<session_id>/subagents/agent-<agent_id>.jsonl
+    """
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    main = project / f"{session_id}.jsonl"
+    main.write_text(main_lines)
+    sidechains = project / session_id / "subagents"
+    sidechains.mkdir(parents=True, exist_ok=True)
+    return main, sidechains
+
+
+class TestScanSidechainTranscripts:
+    """Sub-agent turns never reach the main transcript — their files count too."""
+
+    def test_marker_found_for_acting_agent(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: orders -->") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result["impact_check"] is True
+
+    def test_marker_found_without_agent_id(self, tmp_path):
+        """Harnesses that report no agent id still get the session-wide sweep."""
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: orders -->") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders")
+        assert result["impact_check"] is True
+
+    def test_unknown_agent_id_falls_back_to_sweep(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: orders -->") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "nosuchagent")
+        assert result["impact_check"] is True
+
+    def test_nested_agent_found_by_id(self, tmp_path):
+        """A sub-agent spawned by a sub-agent sits a directory deeper."""
+        main, sidechains = _cc_session(tmp_path)
+        nested = sidechains / "a1"
+        nested.mkdir()
+        (nested / "agent-a2.jsonl").write_text(
+            _cc_assistant_text(
+                "<!-- MC_MONITOR_GAP: orders --> <!-- MC_IMPACT_CHECK_COMPLETE: orders -->"
+            ) + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a2")
+        assert result["impact_check"] is True
+        assert result["monitor_gap"] is True
+
+    def test_marker_in_tool_result_does_not_count(self, tmp_path):
+        """Only the model's own text may unlock the gate — not what was fed to it."""
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_tool_result("[Hook] ... MC_IMPACT_CHECK_COMPLETE: orders ...") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result["impact_check"] is False
+
+    def test_no_marker_stays_false(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("Reading the model file now.") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result == {"impact_check": False, "monitor_gap": False}
+
+    def test_other_table_marker_does_not_match(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: customers -->") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result["impact_check"] is False
+
+    def test_no_sidechain_dir_returns_nothing(self, tmp_path):
+        """Harnesses without sub-agent transcripts are unaffected."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(_cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: orders -->") + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(transcript), "orders", "a1")
+        assert result == {"impact_check": False, "monitor_gap": False}
+
+    def test_malformed_line_skipped_valid_line_still_found(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            "this is not json\n"
+            + _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: orders -->") + "\n"
+            + "{also not valid\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result["impact_check"] is True
+
+    def test_entries_missing_message_skipped(self, tmp_path):
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            json.dumps({"type": "assistant"}) + "\n"
+            + json.dumps({"type": "assistant", "message": None}) + "\n"
+            + json.dumps(["not", "a", "dict"]) + "\n")
+        result = scan_sidechain_transcripts_for_markers(str(main), "orders", "a1")
+        assert result == {"impact_check": False, "monitor_gap": False}
 
 
 class TestDenyReasonSelfBypass:
@@ -103,6 +222,20 @@ class TestDenyReasonSelfBypass:
         at = tmp_path / "at.history.jsonl"
         at.write_text(_assistant_text(reason) + "\n")
         assert scan_history_jsonl_for_markers(str(at), "macro:helper")["impact_check"] is False
+
+    def test_model_deny_reason_does_not_self_unlock_sidechain(self, tmp_path):
+        """The same invariant for sub-agent transcripts: the deny reason lands there
+        as a tool result, and must not unlock the gate it was emitted by."""
+        reason = self._deny_reason(tmp_path, "models", "orders.sql",
+                                   "SELECT * FROM {{ ref('raw') }}")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(_cc_tool_result(reason) + "\n")
+        assert scan_sidechain_transcripts_for_markers(
+            str(main), "orders", "a1")["impact_check"] is False
+        # And even if the wording were echoed back as assistant text, it must not match.
+        (sidechains / "agent-a1.jsonl").write_text(_cc_assistant_text(reason) + "\n")
+        assert scan_sidechain_transcripts_for_markers(
+            str(main), "orders", "a1")["impact_check"] is False
 
 
 class TestEvaluatePreEdit:
@@ -183,6 +316,100 @@ class TestEvaluatePreEdit:
         assert result.action == "deny"
         assert "macro" in result.reason.lower()
         assert "helper" in result.reason
+
+
+class TestEvaluatePreEditSubAgent:
+    """A sub-agent must be able to satisfy the gate it was blocked by.
+
+    Hook input reports the main session's id and transcript_path even when the
+    edit comes from a sub-agent, whose turns are written to a separate file. With
+    only the main transcript scanned, "injected" could never reach "verified":
+    the edit was denied inside the grace period and the full instruction
+    re-injected after it, with no way out.
+    """
+
+    def _model(self, tmp_path):
+        model_dir = tmp_path / "models"
+        model_dir.mkdir()
+        sql_file = model_dir / "mixpanel_mcp_events.sql"
+        sql_file.write_text("SELECT * FROM {{ ref('raw') }}")
+        return sql_file
+
+    def test_injected_with_marker_in_sidechain_verifies(self, tmp_path):
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        result = evaluate_pre_edit(inp)
+        assert result.action == "noop"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "verified"
+
+    def test_state_none_with_marker_in_sidechain_verifies(self, tmp_path):
+        sql_file = self._model(tmp_path)
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        result = evaluate_pre_edit(inp)
+        assert result.action == "noop"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "verified"
+
+    def test_monitor_gap_in_sidechain_recorded(self, tmp_path):
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text(
+                "<!-- MC_MONITOR_GAP: mixpanel_mcp_events -->\n"
+                "<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->"
+            ) + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        assert evaluate_pre_edit(inp).action == "noop"
+        assert cache.has_monitor_gap("s1", "mixpanel_mcp_events") is True
+
+    def test_no_assessment_in_sidechain_still_denies(self, tmp_path):
+        """The gate still holds: a sub-agent that skipped the assessment is blocked."""
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("Editing the model now.") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        result = evaluate_pre_edit(inp)
+        assert result.action == "deny"
+        assert cache.get_impact_check_state("s1", "mixpanel_mcp_events") == "injected"
+
+    def test_marker_for_other_table_in_sidechain_still_denies(self, tmp_path):
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, sidechains = _cc_session(tmp_path)
+        (sidechains / "agent-a1.jsonl").write_text(
+            _cc_assistant_text("<!-- MC_IMPACT_CHECK_COMPLETE: some_other_model -->") + "\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file),
+                        transcript_path=str(main), agent_id="a1")
+        assert evaluate_pre_edit(inp).action == "deny"
+
+    def test_marker_in_main_transcript_still_works(self, tmp_path):
+        """Main-loop edits keep verifying off the main transcript."""
+        sql_file = self._model(tmp_path)
+        cache.mark_impact_check_injected("s1", "mixpanel_mcp_events")
+        main, _ = _cc_session(
+            tmp_path,
+            main_lines="<!-- MC_IMPACT_CHECK_COMPLETE: mixpanel_mcp_events -->\n")
+
+        inp = HookInput(session_id="s1", file_path=str(sql_file), transcript_path=str(main))
+        assert evaluate_pre_edit(inp).action == "noop"
 
 
 class TestEvaluatePostEdit:


### PR DESCRIPTION
## What was broken

The Prevent plugin gates edits to dbt model files behind a change impact assessment. The gate keeps per-table state: it marks a table `injected` when it blocks an edit, and `verified` once the agent emits `MC_IMPACT_CHECK_COMPLETE: <table>`. Verification worked by scanning the session transcript for that marker.

Claude Code writes a sub-agent's turns to its own transcript file — `<transcript_dir>/<session_id>/subagents/agent-<agent_id>.jsonl` — and never into the main transcript. Hook input still reports the main session's id and `transcript_path`. So when the work is done by a sub-agent, the marker it emits lands in a file the hook never opens.

`injected` could therefore never become `verified`:

- inside the 120s grace window the edit is denied with "has not completed yet"
- after the window the full assessment instruction is re-injected
- repeat

A sub-agent asked to edit any dbt model was hard-blocked with no way through. Real hit: a sub-agent could not edit `analytics/models/internal_bi/mixpanel_mcp_events.sql` in the `dbt` repo at all, and the change had to be applied from the parent session instead. Shipped behavior, reported on 1.11.0.

Second-order effect worth naming: in the sub-agent case the gate was not verifying anything. It was failing closed on a transcript it could not see.

## What changed

`_scan_markers` (`plugins/shared/prevent/lib/protocol.py`) now unions two scans for the `raw` transcript format:

1. the main transcript, as before
2. the session's sub-agent transcripts

Sub-agent files are resolved from the acting `agent_id`, which Claude Code puts in every hook payload for a sub-agent tool call. `agent_id` is new on `HookInput` and is passed by the Claude Code pre-edit adapter. Nested sub-agents sit a directory deeper, so the id is matched anywhere below `subagents/`. When no id is reported, or it does not resolve, the scan sweeps every sidechain of the session — still scoped to this session and this table, the same scope the main-transcript scan already accepted.

The sidechain reader matches **only model-authored text**. A sub-agent's transcript also holds the prompt it was given and its tool results, and hook output is persisted there — including this gate's own deny reason. This reuses the assistant-text discipline the Cortex reader already had; the shared JSONL scanning logic is now factored into `_scan_jsonl_assistant_text`, with a small per-harness extractor for the two entry shapes.

Harnesses that write no sub-agent transcripts (Cursor, Codex, Copilot) resolve to an empty file list and behave exactly as before.

### The safety property is preserved

The gate still requires that an assessment happened, in this session, for this table, before the edit. Nothing passes unconditionally, nothing is skipped for sub-agents, and the grace window is unchanged. What changed is only *where* the hook looks for the marker it already required. Tests assert the negative side explicitly: a sub-agent that skipped the assessment is still denied, a marker for a different table does not unlock, a marker in a tool result does not unlock, and the deny reason cannot unlock the gate that emitted it.

## How it was verified

Confirmed empirically from inside a real sub-agent on Claude Code 2.1.222, against live transcripts:

- text emitted by the sub-agent appears in `subagents/agent-<id>.jsonl` and **not** in the parent transcript (the parent has zero `"isSidechain":true` entries)
- the assistant text line is flushed to disk before the tool call in the same turn executes, so the marker is on disk when the pre-edit hook runs
- a real marker emitted in a sub-agent turn: main-transcript scan → not found (old behavior, blocked forever); sidechain scan → found, both by `agent_id` and by the sweep
- full `evaluate_pre_edit` run on that live transcript: `injected` → `verified`, edit allowed. Control with no marker anywhere: still denied, state stays `injected`

Cost on the largest real session directory available (29 files, 14.2 MB): 69 ms worst case for the full sweep, 3 ms when targeted by `agent_id`. It only runs before verification — the state file short-circuits afterwards.

Test-first: the three unblock tests were confirmed red (`deny` instead of `noop`) with only the `_scan_markers` wiring reverted, and the "still denies" tests pass with or without the fix.

## Tests

`plugins/shared/prevent/lib/tests/test_protocol.py`

- `TestScanSidechainTranscripts` — 10 cases on the reader: found by `agent_id`, found without one, unknown id falls back to the sweep, nested agent, tool-result text ignored, no marker, wrong table, no sidechain dir, malformed lines skipped, entries missing `message` skipped
- `TestEvaluatePreEditSubAgent` — 6 end-to-end gate cases, including the reported scenario (`injected` + marker in sidechain → `noop`, state `verified`) and the guards that must keep denying
- `TestDenyReasonSelfBypass::test_model_deny_reason_does_not_self_unlock_sidechain` — the self-bypass invariant extended to the new path

`plugins/claude-code/tests/prevent/test_pre_edit_hook.py` — `agent_id` pass-through, and absent for main-loop calls

```
plugins/shared/prevent   113 passed
claude-code               12 passed
cursor                    10 passed
codex                     21 passed
cortex-code               12 passed
copilot                   12 passed
skills/prevent sandbox    52 passed
```

Shared lib synced into all five editor plugins via `./scripts/bump-version.sh --sync-only`; the CI no-symlinks-under-hooks check passes locally.

## Out of scope

OpenCode ports the hook logic to TypeScript and reads messages through the SDK by session id rather than scanning files (`plugins/opencode/src/prevent/index.ts`). It may have the same class of problem for child sessions, but that is a different API and was not investigated or changed here.

## Checklist

- [x] Version bumped — `1.24.0` → `1.24.1`, patch (plugin/hook bug fix), all 6 plugin configs and changelogs updated by `bump-version.sh`
- [x] Shared hook lib edited in `plugins/shared/` and synced with `--sync-only`
- [x] No symlinks under `plugins/<editor>/hooks/`
- [x] Tests added and passing
- [na] New skill registration (signal definitions, workflow orchestrator, `/mc` catalog) — no new skill
- [na] Skill content / frontmatter changes — hooks only, no `SKILL.md` change


- [x] Ran `/santi-review` — 9 reviewers (8 Claude + OpenAI Codex); fixed 7 findings in `bb1a89d`
