### PR TITLE
feat(tune-monitor): mirror the already-applied-lever guidance (AI-872)

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-08-10
+
+### Changed
+
+- tune-monitor: check every recommended lever against the configuration read in
+  Phase 2c before naming it — a setting the monitor is already on is a report
+  that the user's change did not take, not a recommendation (AI-872)
+
 ## [1.24.0] - 2026-08-02
 
 ### Added

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/tune-monitor/SKILL.md
+++ b/skills/tune-monitor/SKILL.md
@@ -142,6 +142,12 @@ reference loaded in Phase 1.5. At minimum, extract:
 - Schedule interval
 - Audiences / notification channels
 - Whether the monitor uses ML thresholds or explicit thresholds
+- The value of every setting you might propose changing — sensitivity, thresholds, the time bucket
+  it aggregates on, its filter, and the segments it already excludes
+
+That last item is what Phase 3 checks each recommendation against, so extract it even where nothing
+about the report suggests the setting is the problem. Write the values down in your analysis; a
+setting you never read is one you cannot tell you are about to re-propose.
 
 ### 2d. Troubleshooting analysis (if available)
 Look at any troubleshooting TL;DRs in the report. Note:
@@ -157,6 +163,20 @@ Based on the analysis, produce a prioritized list of recommendations. For each r
 - State the **problem** it solves
 - Give the **specific config change** (use exact field names from the MC config schema)
 - Explain the **trade-off** (what signal might be lost)
+
+**Check every change against the value you read in 2c.** Reading the configuration is the floor,
+not the point — a lever the monitor is already set to is not a recommendation, it is a report that
+the user's change did not take, and it costs them a second attempt at something already done.
+Before naming a lever, find it in what you extracted and confirm the monitor is not already there.
+If it is, say so under **What NOT to change** and spend the slot on a lever that would actually
+move. This binds the heading as tightly as the body: a recommendation titled *"switch to weekly
+buckets"* on a monitor already bucketing weekly reads as advice to re-apply it, whatever the
+paragraph underneath goes on to say.
+
+The same applies to a change someone made recently. The report covers a window; the configuration
+is only as of now. If `last_update_time` is more recent than the alerts you are reasoning from,
+those alerts fired under an older configuration — say so, and check each lever against the current
+values rather than against what the alert pattern implies the monitor used to be set to.
 
 ### General recommendations (all monitor types)
 


### PR DESCRIPTION
Mirrors the AI-872 tuning guidance into the toolkit copy of `tune-monitor`. Companion to monte-carlo-data/ai-agent#2175 — **merge this after that PR's mcp-server deploy**, since the Phase 2c wording leans on tool descriptions that ship with it.

## Why

On 2026-08-06 in `#andes-alerts-prod`, the Monte Carlo AI Slack bot recommended three tuning levers on a monitor whose owners had already applied all three about eight hours earlier. A lever the monitor is already set to is not a recommendation — it is a report that the user's change did not take, and it costs them a second attempt at something already done.

This skill was already closer than the chat surface: Phase 1 fetches `get_monitors` with `include_fields=["config"]` alongside the report, so the configuration is in context. The gap is that nothing in Phase 3 says to *check a recommendation against it*. Reading the config is the floor, not the point.

## What changed

`skills/tune-monitor/SKILL.md`, two body edits (frontmatter untouched):

- **Phase 2c** now asks for the value of every setting that could be proposed — sensitivity, thresholds, the time bucket, the filter, the excluded segments — not just the four orienting fields, and names Phase 3 as what those values are for. A setting never read is one you cannot tell you are re-proposing.
- **Phase 3** opens with the check, and binds the *heading* as tightly as the body: a recommendation titled *"switch to weekly buckets"* on a monitor already bucketing weekly reads as advice to re-apply it, whatever the paragraph underneath goes on to say. Levers the monitor is already on move to **What NOT to change**, freeing the slot for one that would actually move. The staleness direction is covered too — the report covers a window, the configuration is only as of now, so a `last_update_time` newer than the alerts means those alerts fired under an older configuration.

Version bumped 1.24.0 → 1.24.1 via `scripts/bump-version.sh patch` (6 plugin configs + 6 changelogs).

## Verification

- `lint-skill.py tune-monitor` reports two findings, **both byte-identical on `origin/main`** and untouched here: the frontmatter `name: tune-monitor` predates the `monte-carlo-<directory>` convention, and the inert `version:` field. Renaming the skill changes its invocation name — a separate decision, deliberately not made in this PR.
- Diff confined to the skill body plus the mechanical version bump; `git status` shows exactly the 13 expected files.

## Drift obligation

`ai-agent/ai_agent/monitor_tuning/CLAUDE.md` requires this skill to track the in-repo `tune-monitor` SKILL.md and the `get_monitors` / `get_monitor_report` tool descriptions. This PR discharges that for AI-872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
