### PR TITLE
fix(skills): correct stale MCP tool names and argument shapes

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Claude Code will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Codex will be do
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/copilot/CHANGELOG.md
+++ b/plugins/copilot/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Copilot CLI will
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.1",
+    "version": "1.24.2",
     "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cortex-code/.cortex-plugin/plugin.json
+++ b/plugins/cortex-code/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-agent-toolkit",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Monte Carlo Agent Toolkit — data observability for AI coding agents. Surfaces blast radius, active alerts, and monitor coverage gaps before you edit dbt SQL. Includes skills for incident response, proactive monitoring, storage cost analysis, and push ingestion. Hooks enforce data-safety checks automatically as you work.",
   "author": {
     "name": "Monte Carlo",

--- a/plugins/cortex-code/CHANGELOG.md
+++ b/plugins/cortex-code/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Snowflake Cortex
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mc-agent-toolkit",
-    "version": "1.24.1",
+    "version": "1.24.2",
     "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
     "author": {
         "name": "Monte Carlo",

--- a/plugins/cursor/CHANGELOG.md
+++ b/plugins/cursor/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for Cursor will be d
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Monte Carlo Agent Toolkit plugin for OpenCode will be
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-09-08
+
+### Fixed
+
+- performance-diagnosis: replace the hallucinated `get_top_slow_queries` tool with the real `get_query_perf_profile` and its actual parameters (`start_time` required, `query_type` read/write)
+- asset-health, prevent: call `get_asset_lineage` with the published `mcons` list parameter and uppercase `direction` values; the singular/lowercase forms fail schema validation
+- monitoring-advisor: document metric and custom-SQL monitor alert-condition fields in their real camelCase form (`thresholdValue`, `baselineAggFunction`, ...); the snake_case names previously shown are rejected with `extra_forbidden` validation errors
+
 ## [1.24.1] - 2026-08-10
 
 ### Changed

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@montecarlo/mc-agent-toolkit",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Monte Carlo Agent Toolkit — data observability skills and enforcement hooks for AI coding agents.",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/analyze-root-cause/references/freshness-investigation.md
+++ b/skills/analyze-root-cause/references/freshness-investigation.md
@@ -6,7 +6,7 @@ Use this when a table hasn't updated on its expected schedule.
 
 ### 1. Confirm the freshness delay
 
-Call `get_table_freshness` with the table's `full_table_id` and `resource_id`. Check:
+Call `get_table_freshness` with the table's `full_table_id` and `resource_id`. Also call `get_table` with the same `full_table_id` — its response includes the table's `mcon`, which the lineage and query tools below need. Check:
 - When was the last successful update?
 - What's the normal update cadence? (hourly, daily, etc.)
 - How long has the delay been?

--- a/skills/asset-health/references/workflows.md
+++ b/skills/asset-health/references/workflows.md
@@ -50,7 +50,7 @@ get_alerts(created_after="<7 days ago>", created_before="<now>", table_mcons=["<
 get_monitors(mcons=["<mcon>"])
 → monitor configs — check status field for paused vs active
 
-get_asset_lineage(mcon="<mcon>", direction="upstream")
+get_asset_lineage(mcons=["<mcon>"], direction="UPSTREAM", hops=1)
 → 1-hop upstream parent assets
 ```
 
@@ -111,7 +111,7 @@ When the user requests deeper upstream investigation for a specific parent:
 ### Phase 1 — Get upstream of the specified parent
 
 ```
-get_asset_lineage(mcon="<parent_mcon>", direction="upstream")
+get_asset_lineage(mcons=["<parent_mcon>"], direction="UPSTREAM", hops=1)
 → 1-hop upstream of the parent (grandparents of the original asset)
 ```
 

--- a/skills/monitoring-advisor/references/data-custom-sql-monitor.md
+++ b/skills/monitoring-advisor/references/data-custom-sql-monitor.md
@@ -41,7 +41,7 @@ If you find yourself contorting another monitor type to fit the user's intent, s
 | `description` | string | Human-readable description of what the monitor checks. |
 | `warehouse` | string | Warehouse name or UUID where the SQL query will be executed. |
 | `sql` | string | SQL query that returns a **single numeric value** (one row, one column). |
-| `alert_conditions` | array | List of threshold conditions (see Alert Conditions below). |
+| `alert_condition` | object | When the monitor should fire (see Alert Conditions below). Singular — the tool takes exactly one condition object, not an array. |
 
 ## Optional Parameters
 
@@ -66,37 +66,34 @@ If you find yourself contorting another monitor type to fit the user's intent, s
 
 ## Alert Conditions
 
-Each alert condition compares the query result against a threshold.
+Field names inside `alert_condition` are camelCase (`thresholdValue`, `thresholdSensitivity`, `baselineAggFunction`, ...) — NOT snake_case. Snake_case keys like `threshold_value` are rejected with an `extra_forbidden` validation error.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `operator` | string | Yes | One of: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`, `NOOP`. Note: the inequality operator is `NEQ` (not `NE`). |
-| `threshold_value` | number | Yes | Numeric threshold to compare the query result against. |
+| `operator` | string | Yes | One of: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`, `AUTO`, `AUTO_HIGH`, `AUTO_LOW`, `NOOP`. Note: the inequality operator is `NEQ` (not `NE`). |
+| `thresholdValue` | number | For explicit operators | Numeric threshold to compare the query result against. Pair with `GT`, `GTE`, `LT`, `LTE`, `EQ`, `NEQ`. |
+| `type` | string | No | Comparison semantics — see Threshold types below. Default: `threshold`. |
 
 ### Threshold types
 
-Custom SQL monitors support two threshold types — `absolute` (default) and `change`. Each requires a different set of fields:
-
-| `type` | Behavior | Required fields (in addition to `operator`) |
+| `type` | Behavior | Fields (in addition to `operator`) |
 |---|---|---|
-| `absolute` (default) | Compare the query result directly against a fixed value. | `threshold_value` |
-| `change` | Compare the query result against a recent baseline (e.g. 2-day rolling MAX). | `threshold_value`, `baseline_agg_function`, `baseline_interval_minutes`, `is_threshold_relative` |
+| `threshold` (default) | Compare the query result directly against a fixed value. | `thresholdValue` |
+| `dynamic_threshold` | ML anomaly detection on the query result. | `operator` = `AUTO` / `AUTO_HIGH` / `AUTO_LOW`; optional `thresholdSensitivity` (`low` / `medium` / `high`, default `medium`) |
+| `change` | Compare the query result against a recent baseline (e.g. 2-day rolling MAX). | `thresholdValue`, `baselineAggFunction`, `baselineIntervalMinutes`, `isThresholdRelative` |
+| `noop` | Collect data without alerting. | `operator` = `NOOP`, no threshold |
 
-**`change`-type required fields:**
+**`change`-type fields:**
 
-- `baseline_agg_function` — how to aggregate baseline samples. One of: `AVG`, `MIN`, `MAX`. Backend rejects anything else: `Must be one of: AVG, MIN, MAX.`
-- `baseline_interval_minutes` — lookback window for the baseline, in minutes. Must be between `0` and `129600` (90 days).
-- `is_threshold_relative` — `true` if `threshold_value` is a percentage (relative to baseline), `false` if it is an absolute delta. Required — the backend rejects with `is_threshold_relative is a required field. Set to True if threshold value is % else False`.
+- `baselineAggFunction` — how to aggregate baseline samples. One of: `AVG`, `MIN`, `MAX`. Backend rejects anything else: `Must be one of: AVG, MIN, MAX.`
+- `baselineIntervalMinutes` — lookback window for the baseline, in minutes (e.g. `1440` = last 24h). Required with `type="change"`; the backend accepts up to `129600` (90 days).
+- `isThresholdRelative` — `true` if `thresholdValue` is a percentage (relative to baseline), `false` if it is an absolute delta. Defaults to `false`.
 
-Omitting any of these on a `change`-type condition produces stacked `required` / `Aggregate function is required` / `Lookback Interval in minutes should be between 0 and 129600` errors. Use snake_case for all field names here — mixing camelCase (`baselineAggFunction`) causes `Unknown field` rejections.
+Omitting these on a `change`-type condition produces stacked `required` / `Aggregate function is required` / `Lookback Interval in minutes should be between 0 and 129600` backend errors.
 
-### Operator subsets by threshold type
+### Operator and type pairing
 
-Not every operator is accepted for every threshold type. The `absolute` threshold type only supports: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`. Using e.g. `NOOP` with an Absolute Threshold is rejected as `Absolute Threshold only supports these operators: {EQ, NEQ, LT, LTE, GT, GTE, OUTSIDE_RANGE, INSIDE_RANGE}`.
-
-### No AUTO Support
-
-Custom SQL monitors do **NOT** support `AUTO` / `AUTO_HIGH` / `AUTO_LOW` (anomaly detection). You must specify an explicit operator and threshold for every alert condition. This is a common mistake -- if the user asks for anomaly detection, steer them toward a metric monitor instead, which does support `AUTO`.
+Not every operator is accepted for every threshold type. The default `threshold` type only supports: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `OUTSIDE_RANGE`, `INSIDE_RANGE`. Pair `INSIDE_RANGE` / `OUTSIDE_RANGE` with `lowerThreshold` + `upperThreshold` instead of `thresholdValue`.
 
 If the user is unsure what threshold to set, help them reason about it: "What value would indicate a problem? If the query returns X, should that fire an alert?"
 
@@ -157,12 +154,10 @@ Alert when orders reference customers that don't exist.
   "description": "Detect orders referencing non-existent customers",
   "warehouse": "production_snowflake",
   "sql": "SELECT COUNT(*) FROM analytics.core.orders o LEFT JOIN analytics.core.customers c ON o.customer_id = c.id WHERE c.id IS NULL",
-  "alert_conditions": [
-    {
-      "operator": "GT",
-      "threshold_value": 0
-    }
-  ]
+  "alert_condition": {
+    "operator": "GT",
+    "thresholdValue": 0
+  }
 }
 ```
 
@@ -176,12 +171,10 @@ Alert when total revenue for the past 24 hours drops below a minimum.
   "description": "Alert when daily revenue falls below $10,000",
   "warehouse": "production_snowflake",
   "sql": "SELECT COALESCE(SUM(amount), 0) FROM analytics.billing.transactions WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP())",
-  "alert_conditions": [
-    {
-      "operator": "LT",
-      "threshold_value": 10000
-    }
-  ]
+  "alert_condition": {
+    "operator": "LT",
+    "thresholdValue": 10000
+  }
 }
 ```
 
@@ -195,18 +188,16 @@ Alert when the duplicate rate on a key field exceeds 1%.
   "description": "Alert when order_id duplicate rate exceeds 1%",
   "warehouse": "production_snowflake",
   "sql": "SELECT COALESCE(1.0 - (COUNT(DISTINCT order_id) * 1.0 / NULLIF(COUNT(*), 0)), 0) FROM analytics.core.orders WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP())",
-  "alert_conditions": [
-    {
-      "operator": "GT",
-      "threshold_value": 0.01
-    }
-  ]
+  "alert_condition": {
+    "operator": "GT",
+    "thresholdValue": 0.01
+  }
 }
 ```
 
-### Multiple threshold conditions (range check)
+### Range check (OUTSIDE_RANGE)
 
-Alert when a value falls outside an acceptable range. Multiple conditions act as independent checks -- each one that evaluates to true fires its own alert.
+Alert when a value falls outside an acceptable range. A two-sided range is a single condition with `lowerThreshold` + `upperThreshold`, not two separate conditions.
 
 ```json
 {
@@ -214,16 +205,11 @@ Alert when a value falls outside an acceptable range. Multiple conditions act as
   "description": "Alert when average order amount is outside the $20-$500 range",
   "warehouse": "production_snowflake",
   "sql": "SELECT COALESCE(AVG(amount), 0) FROM analytics.core.orders WHERE created_at >= DATEADD(day, -1, CURRENT_TIMESTAMP()) AND status = 'completed'",
-  "alert_conditions": [
-    {
-      "operator": "LT",
-      "threshold_value": 20
-    },
-    {
-      "operator": "GT",
-      "threshold_value": 500
-    }
-  ]
+  "alert_condition": {
+    "operator": "OUTSIDE_RANGE",
+    "lowerThreshold": 20,
+    "upperThreshold": 500
+  }
 }
 ```
 
@@ -237,11 +223,9 @@ Alert when the latest row in a downstream table is more than 2 hours behind the 
   "description": "Alert when downstream table lags source by more than 2 hours",
   "warehouse": "production_bigquery",
   "sql": "SELECT COALESCE(TIMESTAMP_DIFF(s.max_ts, t.max_ts, MINUTE), 9999) FROM (SELECT MAX(event_timestamp) AS max_ts FROM project.raw.events) s CROSS JOIN (SELECT MAX(processed_at) AS max_ts FROM project.analytics.events_processed) t",
-  "alert_conditions": [
-    {
-      "operator": "GT",
-      "threshold_value": 120
-    }
-  ]
+  "alert_condition": {
+    "operator": "GT",
+    "thresholdValue": 120
+  }
 }
 ```

--- a/skills/monitoring-advisor/references/data-metric-monitor.md
+++ b/skills/monitoring-advisor/references/data-metric-monitor.md
@@ -144,13 +144,15 @@ If the metric you want isn't in the compatibility matrix above, it doesn't exist
 
 ## Alert Conditions
 
+Alert-condition field names are camelCase (`thresholdValue`, not `threshold_value` or `threshold`) — snake_case keys are rejected with an `extra_forbidden` validation error.
+
 Each alert condition has:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `metric` | string | Yes | The metric to monitor (see Metrics Reference below). |
 | `operator` | string | Yes | `"AUTO"` (anomaly detection), `"GT"`, `"LT"`, `"EQ"`, `"GTE"`, `"LTE"`, `"NEQ"`. Note: the inequality operator is `NEQ`, not `NE`. |
-| `threshold` | number | For explicit operators | The threshold value. Required when using `GT`, `LT`, `EQ`, `GTE`, `LTE`, or `NEQ`. Not used with `AUTO`. |
+| `thresholdValue` | number | For explicit operators | The threshold value. Required when using `GT`, `LT`, `EQ`, `GTE`, `LTE`, or `NEQ`. Not used with `AUTO`. |
 | `fields` | array of string | Depends | Column names to apply the metric to. Required for field-level metrics. Not needed for table-level metrics. |
 
 ---
@@ -167,7 +169,7 @@ Each alert condition has:
 
 - Use when there is a known business rule or data contract (e.g., "null rate on `email` should never exceed 5%", "order amount must always be greater than 0").
 - Provides deterministic alerting -- no training period needed, alerts fire immediately when the condition is met.
-- Requires a `threshold` value in the alert condition.
+- Requires a `thresholdValue` in the alert condition.
 
 ### Operator restrictions by metric
 
@@ -264,7 +266,7 @@ Each alert condition has:
     {
       "metric": "NULL_COUNT",
       "operator": "GT",
-      "threshold": 50,
+      "thresholdValue": 50,
       "fields": ["email", "user_id"]
     }
   ]
@@ -329,7 +331,7 @@ Each alert condition has:
     {
       "metric": "NULL_RATE",
       "operator": "GT",
-      "threshold": 0.01,
+      "thresholdValue": 0.01,
       "fields": ["transaction_id"]
     }
   ]

--- a/skills/performance-diagnosis/README.md
+++ b/skills/performance-diagnosis/README.md
@@ -17,7 +17,7 @@ Connect to Monte Carlo's MCP server (`integrations.getmontecarlo.com/mcp`). The 
 | Tool | Tier | Purpose |
 |------|------|---------|
 | `get_jobs_performance` | Discovery | Find slow/failing jobs |
-| `get_top_slow_queries` | Discovery | Find most expensive queries |
+| `get_query_perf_profile` | Discovery | Find most expensive queries |
 | `get_tables_for_job` | Bridge | Convert job MCONs to table MCONs |
 | `get_tasks_performance` | Diagnosis | Find bottleneck tasks within a job |
 | `get_change_timeline` | Diagnosis | Unified "what changed?" timeline |
@@ -42,7 +42,7 @@ Tier 1: Discovery          Tier 2: Diagnosis
 
 get_jobs_performance ──┐
                        ├──► get_tables_for_job ──► get_tasks_performance
-get_top_slow_queries ──┘                           get_change_timeline
+get_query_perf_profile ──┘                           get_change_timeline
                                                    get_query_rca
                                                    get_query_latency_distribution
                                                    get_asset_lineage

--- a/skills/performance-diagnosis/SKILL.md
+++ b/skills/performance-diagnosis/SKILL.md
@@ -53,7 +53,7 @@ The following MCP tools must be available (connect to Monte Carlo's MCP server):
 
 **Discovery tools (Tier 1):**
 - `get_jobs_performance` -- find slow/failing jobs across Airflow, dbt, Databricks
-- `get_top_slow_queries` -- find slowest query groups by total runtime
+- `get_query_perf_profile` -- find slowest query groups by total runtime
 
 **Bridge tool:**
 - `get_tables_for_job` -- convert job MCONs to table MCONs
@@ -87,8 +87,8 @@ If you don't have specific MCONs to investigate, start with discovery:
    - Results include: job name, average duration, trend (7-day), run count, failure rate
    - Look for: high `avgDuration`, negative `runDurationTrend7d`, high failure rates
 
-2. **Find expensive queries**: Call `get_top_slow_queries` with optional `warehouse_id` and `query_type` ("read" for SELECTs, "write" for INSERT/CREATE/MERGE).
-   - Results include: query hash, total runtime, average runtime, run count
+2. **Find expensive queries**: Call `get_query_perf_profile` with `start_time` (ISO 8601, required) and optional `end_time`, `warehouse_id`, and `query_type` ("read" for SELECTs, "write" for INSERT/CREATE/MERGE).
+   - Results include: query group hash, sum_runtime (total), avg_runtime, max_runtime, query_count
    - Look for: queries with high total runtime or high individual execution time
 
 Present the top findings to the user before drilling deeper. A typical investigation needs only 3-7 tool calls.

--- a/skills/performance-diagnosis/references/investigation-tiers.md
+++ b/skills/performance-diagnosis/references/investigation-tiers.md
@@ -21,19 +21,22 @@ Find slow or failing jobs across all connected platforms.
 - Jobs with high `failureRate` (>10%)
 - Jobs with high `avgDuration` relative to peers
 
-### `get_top_slow_queries`
+### `get_query_perf_profile`
 
 Find the slowest query groups by total runtime.
 
 **When to use:** Finding which queries consume the most compute.
 
 **Key parameters:**
+- `start_time` (required): ISO 8601 start of the window to profile
+- `end_time` (optional): ISO 8601 end of the window
 - `warehouse_id` (optional): Scope to a specific warehouse
 - `query_type` (optional): "read" for SELECT queries, "write" for INSERT/CREATE/MERGE
+- `sort_field` (optional): defaults to `sum_runtime` (total execution time); also `avg_runtime`, `max_runtime`, `query_count`
 
 **What to look for:**
-- Queries with high total runtime (total = avg runtime x run count)
-- Queries with high individual execution time (p95 >> p50 means outliers)
+- Query groups with high `sum_runtime` (total compute consumed)
+- Query groups with high `max_runtime` relative to `avg_runtime` (outlier executions)
 
 ## Bridge -- Job to Tables
 

--- a/skills/prevent/references/workflows.md
+++ b/skills/prevent/references/workflows.md
@@ -41,7 +41,7 @@ artifact.
    Workflow 2's blast-radius synthesis, make one additional direct call:
 
    ```
-   get_asset_lineage(mcon="<mcon resolved by asset-health>", direction="DOWNSTREAM")
+   get_asset_lineage(mcons=["<mcon resolved by asset-health>"], direction="DOWNSTREAM")
    ```
 
    Use the MCON asset-health already resolved — do **not** re-call `search()`.


### PR DESCRIPTION
## Summary

Prod telemetry shows external MCP clients guided by these skills calling Monte Carlo MCP tools with wrong names and argument shapes. This fixes the skill docs to match the real tool schemas (verified against `mcp-server/mcp_server/mcp_tools/`).

- **performance-diagnosis**: replaced the hallucinated `get_top_slow_queries` tool (does not exist) with the real `get_query_perf_profile` — documented its required `start_time`, optional `end_time`/`warehouse_id`/`sort_field`, and `query_type` values `"read"`/`"write"`.
- **asset-health, prevent**: `get_asset_lineage(mcon="...", direction="upstream")` → `get_asset_lineage(mcons=["..."], direction="UPSTREAM", hops=1)`. The published parameter is the plural `mcons` list and `direction` is `Literal["UPSTREAM", "DOWNSTREAM"]` — the lowercase form fails validation. Added `hops=1` where the doc describes a 1-hop lookup (the tool's default is the full transitive graph).
- **analyze-root-cause**: freshness-investigation flow used `table_mcon` in later steps with no source; added a bridge line — the table's MCON comes from `get_table`.
- **monitoring-advisor** (metric + custom-SQL monitor refs): alert-condition fields were documented in snake_case (`threshold`, `threshold_value`, `baseline_agg_function`, ...). Both tools' `_AlertConditionInput` models are camelCase with `extra="forbid"`, so those keys are rejected with `extra_forbidden` errors — exactly what telemetry shows. All field tables and JSON examples now use `thresholdValue`, `thresholdSensitivity`, `baselineAggFunction`, `baselineIntervalMinutes`, `isThresholdRelative`, `lowerThreshold`/`upperThreshold`.

Scope notes beyond the literal threshold-field ask, same class of error in the same files:
- data-custom-sql-monitor.md documented an `alert_conditions` **array**; the tool takes a singular `alert_condition` object.
- Its threshold-type list (`absolute`, `change`) didn't match the tool's real `type` values (`threshold`, `dynamic_threshold`, `change`, `noop`), and it claimed AUTO/anomaly detection is unsupported — the tool supports it via `type="dynamic_threshold"` + `thresholdSensitivity`.
- The two-condition range-check example was rewritten as a single `OUTSIDE_RANGE` condition (the tool accepts exactly one condition per call).

Version bumped to 1.24.2 with changelog entries in all six plugins (per CONTRIBUTING).

## Test plan

- [x] Verified every changed tool name/parameter against the real tool schemas in `mcp-server/mcp_server/mcp_tools/` (`get_query_perf_profile.py`, `get_asset_lineage.py`, `get_table.py`, `get_queries_for_table.py`, `create_or_update_metric_monitor.py`, `create_or_update_sql_monitor.py`)
- [x] `lint-skill.py` clean on all touched skills (one pre-existing ERROR on `prevent` frontmatter length, untouched by this change)
- [x] Repo CI (`validate.yml`) covers hook symlinks/lib-sync only — unaffected (markdown + version files only)
- [na] Unit tests — docs-only change, no code in this repo exercises skill markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)